### PR TITLE
Use asynchronous Element#getMap for speed.

### DIFF
--- a/client-side/static/script.js
+++ b/client-side/static/script.js
@@ -1,5 +1,5 @@
-import drawTable from './draw_table.js'
-import setUpPolygonDrawing from './polygon_draw.js'
+import drawTable from './draw_table.js';
+import setUpPolygonDrawing from './polygon_draw.js';
 
 // Adds an EarthEngine layer (from EEObject.getMap()) to the given Google Map
 // and returns the "overlay" that was added, in case the caller wants to add


### PR DESCRIPTION
This was the major result of profiling. Also left a few TODOs around other operations that took more than a millisecond.

In ~unrelated change, stop using "namespace" variable, since modules avoid namespace pollution by design (I think).