### PR TITLE
Add delete button to polygon info windows

### DIFF
--- a/client-side/static/run.js
+++ b/client-side/static/run.js
@@ -70,8 +70,8 @@ function createAndDisplayJoinedData(
       processedData, (features) => highlightFeatures(features, map),
       (table, tableData) => {
         loadingElementFinished(tableContainerId);
-        // every time we get a new table and data, reselect elements in the
-        // table based on {@code currentFeatures} in highlight_features.js.
+        // every time we get a new table and data, reselect elements in the table
+        // based on {@code currentFeatures} in highlight_features.js.
         selectHighlightedFeatures(table, tableData);
         // TODO: handle ctrl+click situations
         mapSelectListener = map.addListener('click', (event) => {
@@ -79,8 +79,8 @@ function createAndDisplayJoinedData(
               event.latLng.lng(), event.latLng.lat(), map, snapAndDamageAsset,
               table, tableData);
         });
-        // map.data covers clicks to map areas underneath map.data so we need
-        // two listeners
+        // map.data covers clicks to map areas underneath map.data so we need two
+        // listeners
         featureSelectListener = map.data.addListener('click', (event) => {
           clickFeature(
               event.latLng.lng(), event.latLng.lat(), map, snapAndDamageAsset,

--- a/cypress/integration/integration_tests/polygon_draw_test.js
+++ b/cypress/integration/integration_tests/polygon_draw_test.js
@@ -115,5 +115,6 @@ function drawPointAndPrepareForNext(x, y) {
   // cy.get('.map').trigger('mousemove', {clientX: clientX, clientY: clientY});
   cy.get('.map').click(x, y);
   // Ensure that element from click is present.
-  cy.get('div[style*="left: ' + (x - 325) + 'px; top: ' + (y - 245) + 'px;"');
+  cy.get('div[style*="left: ' + (x - 325) + 'px; top: ' + (y - 245) + 'px;"',
+      {timeout: 2000});
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const LOADING_TIMEOUT = 40000;
+const LOADING_TIMEOUT = 20000;
 
 /**
  * Awaits loading. If no divId is provided, then a full page load is awaited.
@@ -6,21 +6,19 @@ const LOADING_TIMEOUT = 40000;
  * @param {Object} cy The Cypress object.
  * @param {string[]} divIds The ids of specific divs to await loading on.
  */
-Cypress.Commands.add('awaitLoad', (divIds) => {
+Cypress.Commands.add("awaitLoad", (divIds) => {
   let loaderDivs = ['#mapContainer-loader', '#tableContainer-loader'];
   if (divIds) loaderDivs = divIds.map((divId) => '#' + divId + '-loader');
 
   // Ensure overlays are added.
   loaderDivs.forEach((loaderDivId) => {
     cy.get(loaderDivId, {timeout: LOADING_TIMEOUT})
-        .should('have.css', 'opacity')
-        .and('eq', '1');
+        .should('have.css', 'opacity').and('eq', '1');
   });
 
   // Ensure overlays are cleared.
   loaderDivs.forEach((loaderDivId) => {
     cy.get(loaderDivId, {timeout: LOADING_TIMEOUT})
-        .should('have.css', 'opacity')
-        .and('eq', '0');
+        .should('have.css', 'opacity').and('eq', '0');
   });
 });


### PR DESCRIPTION
The info window HTML needs to be cleaned up, but at least this is functional.

Deletion is not propagated to the polygon backend, so while you can delete saved polygons, they're still there on reload. That will be added in a follow-up PR.