### PR TITLE
Fix integration_tests/polygon_draw_test on Electron

### DIFF
--- a/cypress/integration/integration_tests/polygon_draw_test.js
+++ b/cypress/integration/integration_tests/polygon_draw_test.js
@@ -171,7 +171,7 @@ describe('Integration tests for drawing polygons', () => {
     cy.get('#mapContainer').contains(notes).should('not.be.visible');
   });
 
-  it.only('Hides polygon, re-shows, tries to hide during edit', () => {
+  it('Hides polygon, re-shows, tries to hide during edit', () => {
     cy.visit(host);
 
     drawPolygonAndClickOnIt();


### PR DESCRIPTION
I also saw a flaky failure about "Timed out retrying: cy.click() could not be issued because this element is currently animating" on the user features checkbox, but putting my head in the sand about it for now, because it only happened once.