### PR TITLE
Set current disaster back to Harvey

### DIFF
--- a/client-side/static/resources.js
+++ b/client-side/static/resources.js
@@ -9,7 +9,7 @@ function getResources() {
 }
 
 /** The current disaster. */
-const disaster = 'michael';
+const disaster = 'harvey';
 
 /** Disaster asset names and other constants. */
 const disasters = new Map();


### PR DESCRIPTION
https://github.com/givedirectly/Google-Partnership/pull/154 set it to michael accidentally.

I should have caught this in review, but didn't realize this variable was used for both import and serving.