### PR TITLE
Enable click feature test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
   # realizes they're the same and distributes the work between them properly.
   jobs:
     - DUMMY_VARIABLE_FOR_MULTIPLE_MACHINES=1
-    # - DUMMY_VARIABLE_FOR_MULTIPLE_MACHINES=2
+    - DUMMY_VARIABLE_FOR_MULTIPLE_MACHINES=2
 before_install:
   # Coming from
   # `travis encrypt-file mapping-crisis-firebase-adminsdk-pw40g-e2e1f3a2b2.json`
@@ -40,6 +40,4 @@ before_install:
 before_script:
   - yarn run ws --directory docs --port 8080 &
 script:
-  # TODO(janakr): enable remaining test.
-  - yarn run cypress run --browser chromium --parallel --record --config video=false --spec
-    'cypress/integration/integration_tests/click_feature_test.js'
+  - yarn run cypress run --browser chromium --parallel --record --config video=false

--- a/cypress/integration/integration_tests/click_feature_test.js
+++ b/cypress/integration/integration_tests/click_feature_test.js
@@ -81,6 +81,7 @@ describe('Integration test for clicking feature', () => {
 /** Convenience function for clicking on the block group we use for testing. */
 function clickAndVerifyBlockGroup() {
   zoom(4);
+  // TODO(janakr): can we reduce this wait time or search for a page element?
   cy.wait(2000);
   cy.get('.map').click(730, 400);
   cy.get('.map').should('contain', 'SCORE: 53');


### PR DESCRIPTION
Add a wait after zoom, since it seems like Travis's window system isn't able to handle the frenetic zoom quite as well. This puts all our tests on Travis!

Closes #21 