### PR TITLE
Fix resource name

### DIFF
--- a/docs/earth_engine_asset.js
+++ b/docs/earth_engine_asset.js
@@ -1,5 +1,3 @@
-import {cdcSviKey} from './import/import_data_keys.js';
-
 export {assets, EarthEngineAsset};
 
 /**


### PR DESCRIPTION
I copied this asset from the one in ruthtalbot@'s repo and made a typo in the copy, but also used the original SVI key from the CDC and I think there was some preprocessing that changed it to SVI. This should all be factored out when I parameterize the asset layers. 