### PR TITLE
Reduce Travis builds to a single machine and wait longer for drawing toolbar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,11 @@ env:
   # Having multiple lines of env settings makes Travis start two jobs, one for
   # each line. Since the $TRAVIS_BUILD_ID is the same for both jobs, Cypress
   # realizes they're the same and distributes the work between them properly.
-  jobs:
-    - DUMMY_VARIABLE_FOR_MULTIPLE_MACHINES=1
-    - DUMMY_VARIABLE_FOR_MULTIPLE_MACHINES=2
+# Commented out because right now we're running enough builds that there's often
+# queueing. If this changes, uncomment and add --parallel to Cypress arguments.
+#  jobs:
+#    - DUMMY_VARIABLE_FOR_MULTIPLE_MACHINES=1
+#    - DUMMY_VARIABLE_FOR_MULTIPLE_MACHINES=2
 before_install:
   # Coming from
   # `travis encrypt-file mapping-crisis-firebase-adminsdk-pw40g-e2e1f3a2b2.json`
@@ -40,4 +42,4 @@ before_install:
 before_script:
   - yarn run ws --directory docs --port 8080 &
 script:
-  - yarn run cypress run --browser chromium --parallel --record --config video=false
+  - yarn run cypress run --browser chromium --record --config video=false

--- a/cypress/integration/integration_tests/polygon_draw_test.js
+++ b/cypress/integration/integration_tests/polygon_draw_test.js
@@ -262,7 +262,7 @@ describe('Integration tests for drawing polygons', () => {
   it('Degenerate polygon with one vertex not allowed', () => {
     cy.visit(host);
 
-    cy.get('[title="Draw a shape"]').click();
+    startDrawing();
     drawPointAndPrepareForNext(400, 400);
     let alertShown = false;
     cy.on('window:alert', () => alertShown = true);
@@ -302,8 +302,7 @@ describe('Integration tests for drawing polygons', () => {
  * @param {number} offset Shift polygon down this many pixels
  */
 function drawPolygonAndClickOnIt(offset = 0) {
-  const polygonButton = cy.get('[title="Draw a shape"]');
-  polygonButton.click();
+  startDrawing();
   // Wait for polygon selection overlay to appear.
   // Fragile, but ensures that "clicking" layer is present.
   // Explanation of string: 'div' means we're searching for elements that are
@@ -399,4 +398,12 @@ function drawPointAndPrepareForNext(x, y) {
 function saveAndAwait() {
   pressPopupButton('save');
   cy.awaitLoad(['writeWaiter']);
+}
+
+/**
+ * Clicks on the "Draw a shape" button on map. Waits longer than usual for it to
+ * be found because it requires Firebase authentication to finish.
+ */
+function startDrawing() {
+  cy.get('[title="Draw a shape"]', {timeout: 10000}).click();
 }


### PR DESCRIPTION
Pushing triggers enough builds that we often have builds queued. At that point, parallelization isn't very useful because the overhead of starting up an additional machine is very high, and we only have two machines available.

Also wait longer for the "Draw a shape" button to appear, since it is now dependent on Firebase, and the polygon_draw_test doesn't wait for the whole page to load.