### PR TITLE
Mask ImageCollection to avoid jagged black edges

### DIFF
--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -255,6 +255,13 @@ function addLayer(layerName, index, map) {
   }
 }
 
+/**
+ * Given a layer name, turns it into an ImageCollection. Masks images with
+ * themselves to avoid displaying black pixels (which are usually just points
+ * that weren't captured by the imagery).
+ * @param {string} layerName Name of ImageCollection
+ * @return {ee.ImageCollection}
+ */
 function processImageCollection(layerName) {
   return ee.ImageCollection(layerName).map((image) => image.selfMask());
 }

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -240,7 +240,7 @@ function addLayer(layerName, index, map) {
       addImageLayer(map, ee.Image(layerName), layerName, index);
       break;
     case LayerType.IMAGE_COLLECTION:
-      addImageLayer(map, ee.ImageCollection(layerName), layerName, index);
+      addImageLayer(map, processImageCollection(layerName), layerName, index);
       break;
     case LayerType.FEATURE:
     case LayerType.FEATURE_COLLECTION:
@@ -253,6 +253,10 @@ function addLayer(layerName, index, map) {
       createError('parsing layer type during add')(
           '[' + index + ']: ' + layerName + ' not recognized layer type');
   }
+}
+
+function processImageCollection(layerName) {
+  return ee.ImageCollection(layerName).map((image) => image.selfMask());
 }
 
 /**


### PR DESCRIPTION
Now: 
![masked_after](https://user-images.githubusercontent.com/10134896/68507577-4360d680-023a-11ea-868c-59123d43b5cb.png). Before: 
![masked_before](https://user-images.githubusercontent.com/10134896/68507583-48258a80-023a-11ea-9b08-9f5413d84e05.png). Doesn't seem to appreciably change the load time.

This doesn't really fix #174, but it makes ImageCollection a lot more palatable, if we can handle the lag.

