### PR TITLE
Fix deletion of test data from Firestore

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
   "projectId": "jr8ks8",
-  "nodeVersion": "system"
+  "nodeVersion": "system",
+  "baseUrl": "http://localhost:8080/"
 }

--- a/cypress/integration/integration_tests/checkbox_test.js
+++ b/cypress/integration/integration_tests/checkbox_test.js
@@ -4,18 +4,18 @@
  */
 describe('Integration test', () => {
   it('Checks threshold update checks score box', () => {
-    cy.visit('https://www.google.com/');
-    // cy.awaitLoad();
-    //
-    // cy.get('#sidebar-toggle-datasets').click();
-    //
-    // cy.get('#score-checkbox').uncheck();
-    //
-    // cy.get('#sidebar-toggle-thresholds').click();
-    //
-    // cy.get('[id="poverty threshold"]').clear().type('1.0');
-    // cy.get('#update').click();
-    //
-    // cy.get('#score-checkbox').should('be.checked');
+    cy.visit('');
+    cy.awaitLoad();
+
+    cy.get('#sidebar-toggle-datasets').click();
+
+    cy.get('#score-checkbox').uncheck();
+
+    cy.get('#sidebar-toggle-thresholds').click();
+
+    cy.get('[id="poverty threshold"]').clear().type('1.0');
+    cy.get('#update').click();
+
+    cy.get('#score-checkbox').should('be.checked');
   });
 });

--- a/cypress/integration/integration_tests/checkbox_test.js
+++ b/cypress/integration/integration_tests/checkbox_test.js
@@ -4,18 +4,18 @@
  */
 describe('Integration test', () => {
   it('Checks threshold update checks score box', () => {
-    cy.visit(host);
-    cy.awaitLoad();
-
-    cy.get('#sidebar-toggle-datasets').click();
-
-    cy.get('#score-checkbox').uncheck();
-
-    cy.get('#sidebar-toggle-thresholds').click();
-
-    cy.get('[id="poverty threshold"]').clear().type('1.0');
-    cy.get('#update').click();
-
-    cy.get('#score-checkbox').should('be.checked');
+    cy.visit('https://www.google.com/');
+    // cy.awaitLoad();
+    //
+    // cy.get('#sidebar-toggle-datasets').click();
+    //
+    // cy.get('#score-checkbox').uncheck();
+    //
+    // cy.get('#sidebar-toggle-thresholds').click();
+    //
+    // cy.get('[id="poverty threshold"]').clear().type('1.0');
+    // cy.get('#update').click();
+    //
+    // cy.get('#score-checkbox').should('be.checked');
   });
 });

--- a/cypress/integration/integration_tests/click_feature_test.js
+++ b/cypress/integration/integration_tests/click_feature_test.js
@@ -4,14 +4,14 @@
  */
 describe('Integration test for clicking feature', () => {
   it('clicks a feature on the map highlights feature in list', () => {
-    cy.visit(host);
+    cy.visit('');
     cy.awaitLoad();
 
     clickAndVerifyBlockGroup();
   });
 
   it('clicks on a feature on the map, then unclicks it', () => {
-    cy.visit(host);
+    cy.visit('');
     cy.awaitLoad();
 
     clickAndVerifyBlockGroup();
@@ -25,7 +25,7 @@ describe('Integration test for clicking feature', () => {
   });
 
   it('clicks on a feature on the map, then clicks on another', () => {
-    cy.visit(host);
+    cy.visit('');
     cy.awaitLoad();
 
     clickAndVerifyBlockGroup();
@@ -42,7 +42,7 @@ describe('Integration test for clicking feature', () => {
   });
 
   it('click highlights correct feature even after resort', () => {
-    cy.visit(host);
+    cy.visit('');
     cy.awaitLoad();
 
     // Sort descending by damage percentage
@@ -52,7 +52,7 @@ describe('Integration test for clicking feature', () => {
   });
 
   it('clicks a place where there is no damage -> no feature', () => {
-    cy.visit(host);
+    cy.visit('');
     cy.awaitLoad();
 
     cy.get('.map').click(200, 200);
@@ -62,7 +62,7 @@ describe('Integration test for clicking feature', () => {
   // Ensures that listeners are cleared when table instance and data
   // are updated.
   it('click highlights correct feature even after update', () => {
-    cy.visit(host);
+    cy.visit('');
     cy.awaitLoad();
 
     clickAndVerifyBlockGroup();

--- a/cypress/integration/integration_tests/highlight_features_test.js
+++ b/cypress/integration/integration_tests/highlight_features_test.js
@@ -1,6 +1,6 @@
 describe('Integration tests for highlighting chosen districts', () => {
   it('Clicks on list and highlights district', () => {
-    cy.visit(host);
+    cy.visit('');
     cy.awaitLoad();
 
     // Actually verifying that the element appears is difficult, because the

--- a/cypress/integration/integration_tests/polygon_draw_test.js
+++ b/cypress/integration/integration_tests/polygon_draw_test.js
@@ -5,7 +5,7 @@ const notes = 'Sphinx of black quartz, judge my vow';
 // necessary to draw polygons.
 describe('Integration tests for drawing polygons', () => {
   it('Draws a polygon and edits its notes', () => {
-    cy.visit(host);
+    cy.visit('');
     drawPolygonAndClickOnIt();
     pressPopupButton('edit');
     cy.get('[class="notes"]').type(notes);
@@ -14,7 +14,7 @@ describe('Integration tests for drawing polygons', () => {
   });
 
   it('Draws a polygon, calculates damage', () => {
-    cy.visit(host);
+    cy.visit('');
     // Sometimes the map load interacts strangely with the search. So wait.
     cy.awaitLoad();
     cy.get('[placeholder="Search"]').clear().type('Aldine Estates{enter}');
@@ -32,7 +32,7 @@ describe('Integration tests for drawing polygons', () => {
   // out if something changes. If this does start to flake, we can also consider
   // lowering the wait at the end of drawPolygonAndClickOnIt.
   it('Draws a polygon, checks for calculating status', () => {
-    cy.visit(host);
+    cy.visit('');
     drawPolygonAndClickOnIt();
     cy.get('.popup-calculated-data').contains('calculating');
     // assert damage text is grey while editing
@@ -48,7 +48,7 @@ describe('Integration tests for drawing polygons', () => {
   it('Draws a polygon and deletes it', () => {
     // Accept confirmation when it happens.
     cy.on('window:confirm', () => true);
-    cy.visit(host);
+    cy.visit('');
     drawPolygonAndClickOnIt();
     pressPopupButton('edit');
     cy.get('[class="notes"]').type(notes);
@@ -64,7 +64,7 @@ describe('Integration tests for drawing polygons', () => {
     // Reject confirmation when first happens, then accept it later.
     let confirmValue = false;
     cy.on('window:confirm', () => confirmValue);
-    cy.visit(host);
+    cy.visit('');
     drawPolygonAndClickOnIt();
     pressPopupButton('edit');
     cy.get('[class="notes"]').type(notes);
@@ -76,7 +76,7 @@ describe('Integration tests for drawing polygons', () => {
     // TODO(#18): wait for a notification that all writes have completed instead
     // of a hardcoded wait.
     cy.wait(1000);
-    cy.visit(host);
+    cy.visit('');
     cy.awaitLoad();
     // Polygon is still there.
     clickOnDrawnPolygon();
@@ -91,7 +91,7 @@ describe('Integration tests for drawing polygons', () => {
     clickOnDrawnPolygon();
     assertExactlyPopUps(0, notes);
     cy.wait(1000);
-    cy.visit(host);
+    cy.visit('');
     cy.awaitLoad();
     // Polygon is gone.
     clickOnDrawnPolygon();
@@ -99,7 +99,7 @@ describe('Integration tests for drawing polygons', () => {
   });
 
   it('Draws a polygon, clicks it, closes its info box', () => {
-    cy.visit(host);
+    cy.visit('');
     drawPolygonAndClickOnIt();
     pressPopupButton('edit');
     cy.get('[class="notes"]').type(notes);
@@ -113,7 +113,7 @@ describe('Integration tests for drawing polygons', () => {
   it('Draws a polygon, almost closes while editing', () => {
     cy.on('window:confirm', () => false);
 
-    cy.visit(host);
+    cy.visit('');
     drawPolygonAndClickOnIt();
     pressPopupButton('edit');
     cy.get('[class="notes"]').type(notes);
@@ -125,7 +125,7 @@ describe('Integration tests for drawing polygons', () => {
   it('Draws a polygon, closes while editing', () => {
     cy.on('window:confirm', () => true);
 
-    cy.visit(host);
+    cy.visit('');
     drawPolygonAndClickOnIt();
     pressPopupButton('edit');
     cy.get('[class="notes"]').type(notes);
@@ -139,7 +139,7 @@ describe('Integration tests for drawing polygons', () => {
   });
 
   it('Hides polygon, re-shows, tries to hide during edit', () => {
-    cy.visit(host);
+    cy.visit('');
 
     drawPolygonAndClickOnIt();
     pressPopupButton('edit');
@@ -184,7 +184,7 @@ describe('Integration tests for drawing polygons', () => {
   });
 
   it('Hides, draws new one, tries to hide during edit, re-shows, hides', () => {
-    cy.visit(host);
+    cy.visit('');
 
     drawPolygonAndClickOnIt();
     pressPopupButton('edit');
@@ -228,7 +228,7 @@ describe('Integration tests for drawing polygons', () => {
   });
 
   it('Degenerate polygon with one vertex not allowed', () => {
-    cy.visit(host);
+    cy.visit('');
 
     startDrawing();
     drawPointAndPrepareForNext(400, 400);
@@ -243,7 +243,7 @@ describe('Integration tests for drawing polygons', () => {
   });
 
   it('Draws marker, edits notes, deletes', () => {
-    cy.visit(host);
+    cy.visit('');
 
     // Give Firebase some time to retrieve data.
     cy.get('[title="Add a marker"]', {timeout: 10000}).click();

--- a/cypress/integration/integration_tests/sidebar_test.js
+++ b/cypress/integration/integration_tests/sidebar_test.js
@@ -1,6 +1,6 @@
 describe('Integration test for the sidebar', () => {
   it('Enables toggling', () => {
-    cy.visit(host);
+    cy.visit('');
     cy.awaitLoad();
 
     // The sidebar should be collapsed to start.

--- a/cypress/integration/integration_tests/update_test.js
+++ b/cypress/integration/integration_tests/update_test.js
@@ -12,7 +12,7 @@ describe('Integration test for update.js', () => {
   //    '.google-visualization-table-page-numbers', but never found it.
 
   it('Checks list size updates with higher threshold', () => {
-    cy.visit(host);
+    cy.visit('');
     cy.awaitLoad();
 
     cy.get('[id="sidebar-toggle-thresholds"]').click();

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -126,7 +126,7 @@ module.exports = (on, config) => {
       return Promise.all([harveyDoc.get(), signinPromise, deletePromise])
           .then((result) => Promise.all([
             documentReference.set(result[0].data(), {merge: true}),
-            documentReference.set({dummy: true}, {merge: true})
+            documentReference.set({dummy: true}, {merge: true}),
           ]))
           .then(
               () => Promise.all(
@@ -195,6 +195,7 @@ const millisecondsInADay = 60 * 60 * 24 * 1000;
  * (https://stackoverflow.com/questions/47043651/this-document-does-not-exist-and-will-not-appear-in-queries-or-snapshots-but-id).
  * That field is set in clearAndPopulateTestFirestoreData.
  * @param {admin.app.App} app
+ * @return {Promise} Promise that completes when all deletions are finished
  */
 function deleteAllOldTestData(app) {
   const currentDate = new Date();

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -57,21 +57,24 @@ module.exports = (on, config) => {
     /**
      * Produces a Firebase token that can be used for our Firestore database.
      * Because the database belongs to a test-only user, this user is given free
-     * reign to do whatever it likes.
+     * reign to do whatever it likes. Also deletes all test data older than 24
+     * hours, so there isn't indefinite build-up if tests are frequently aborted
+     * before they clean up.
      *
      * See https://firebase.google.com/docs/auth/admin/create-custom-tokens.
      * @return {Promise<string>} The token to be used
      */
     initializeTestFirebase() {
       const currentApp = createTestFirebaseAdminApp();
+      const deleteOldPromise = deleteAllOldTestData(currentApp);
       const result =
           currentApp.auth().createCustomToken('cypress-firestore-test-user');
-      return result.then(async (token) => {
+      return Promise.all([result, deleteOldPromise]).then(async (list) => {
         // Firebase really doesn't like duplicate apps lying around, so clean up
         // immediately.
         await currentApp.delete();
-        if (token) {
-          return token;
+        if (list[0]) {
+          return list[0];
         }
         throw new Error('No token generated');
       });
@@ -95,15 +98,14 @@ module.exports = (on, config) => {
     /**
      * Recursively deletes all data under the test/currentTestRoot tree, and
      * creates necessary data for tests to consume, pulling that data from prod
-     * Firebase. For use before a test case runs. Also deletes all test data
-     * older than 24 hours, so there isn't indefinite build-up if tests are
-     * frequently aborted before they clean up.
+     * Firebase. For use before a test case runs. We add a dummy field inside
+     * test/currentTestRoot so that Firestore will deign to list this document
+     * later (https://stackoverflow.com/questions/47043651/this-document-does-not-exist-and-will-not-appear-in-queries-or-snapshots-but-id)
      * @param {string} currentTestRoot document name directly underneath test/
      * @return {Promise<null>} Promise that resolves when deletion and data
      * creation is complete
      */
     clearAndPopulateTestFirestoreData(currentTestRoot) {
-      console.log('about to do it for ', currentTestRoot);
       const testAdminApp = createTestFirebaseAdminApp();
       const prodApp = firebase.initializeApp(firebaseConfigProd, 'prodapp');
       // We use a test app, created using normal firebase, versus a test admin
@@ -116,15 +118,15 @@ module.exports = (on, config) => {
               .createCustomToken('cypress-firestore-test-user')
               .then((token) => testApp.auth().signInWithCustomToken(token));
       const deletePromise = deleteTestData(currentTestRoot, testAdminApp);
-      const deleteOldPromise = deleteAllOldTestData(testAdminApp);
       const documentPath = 'disaster-metadata/2017-harvey';
       const harveyDoc = prodApp.firestore().doc(documentPath);
-      return Promise.all([harveyDoc.get(), signinPromise, deletePromise, deleteOldPromise])
+      const documentReference = testApp.firestore()
+          .doc('test/' + currentTestRoot + '/' + documentPath);
+      return Promise.all([harveyDoc.get(), signinPromise, deletePromise])
           .then(
               (result) =>
-                  testApp.firestore()
-                      .doc('test/' + currentTestRoot + '/' + documentPath)
-                      .set(result[0].data()))
+                  Promise.all([documentReference.set(result[0].data(), {merge: true}),
+                  documentReference.set({dummy: true}, {merge: true})]))
           .then(
               () => Promise.all(
                   [testAdminApp.delete(), prodApp.delete(), testApp.delete()]))
@@ -187,23 +189,23 @@ const millisecondsInADay = 60 * 60 * 24 * 1000;
 /**
  * Recursively deletes all test data older than 24 hours, under the assumption
  * that no test runs for that long. This prevents old unfinished tests from
- * using too much quota.
+ * using too much quota. Note that documents in the list must have a field set
+ * to show up in a listing of the parent collection (https://stackoverflow.com/questions/47043651/this-document-does-not-exist-and-will-not-appear-in-queries-or-snapshots-but-id).
+ * That field is set in clearAndPopulateTestFirestoreData.
  * @param {admin.app.App} app
  */
 function deleteAllOldTestData(app) {
   const currentDate = new Date();
-  app.firestore().collection(testPrefix).get().then((queryResult) => {
+  const querySnapshotPromise = app.firestore().collection(testPrefix).get();
+  return querySnapshotPromise.then((queryResult) => {
     const promises = [];
     queryResult.forEach((doc) => {
           const ref = doc.ref;
           const testRunName = ref.id;
           const dateElement = testRunName.split('-')[0];
-          // isNaN helpfully returns false for strings that are numerical.
-          if (!isNaN(dateElement)) {
-            const date = new Date(dateElement);
-            if (currentDate - date > millisecondsInADay) {
-              promises.push(deleteDocRecursively(ref))
-            }
+          const date = new Date(parseInt(dateElement, 10));
+          if (currentDate - date > millisecondsInADay) {
+            promises.push(deleteDocRecursively(ref));
           }
     }
     );

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -190,8 +190,8 @@ const millisecondsInADay = 60 * 60 * 24 * 1000;
 /**
  * Recursively deletes all test data older than 24 hours, under the assumption
  * that no test runs for that long. This prevents old unfinished tests from
- * using too much quota. Note that documents in the list must have a field set
- * to show up in a listing of the parent collection
+ * using too much quota. Note that documents must have a field set to show up in
+ * a listing of the parent collection
  * (https://stackoverflow.com/questions/47043651/this-document-does-not-exist-and-will-not-appear-in-queries-or-snapshots-but-id).
  * That field is set in clearAndPopulateTestFirestoreData.
  * @param {admin.app.App} app

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -100,7 +100,8 @@ module.exports = (on, config) => {
      * creates necessary data for tests to consume, pulling that data from prod
      * Firebase. For use before a test case runs. We add a dummy field inside
      * test/currentTestRoot so that Firestore will deign to list this document
-     * later (https://stackoverflow.com/questions/47043651/this-document-does-not-exist-and-will-not-appear-in-queries-or-snapshots-but-id)
+     * later
+     * (https://stackoverflow.com/questions/47043651/this-document-does-not-exist-and-will-not-appear-in-queries-or-snapshots-but-id)
      * @param {string} currentTestRoot document name directly underneath test/
      * @return {Promise<null>} Promise that resolves when deletion and data
      * creation is complete
@@ -120,13 +121,13 @@ module.exports = (on, config) => {
       const deletePromise = deleteTestData(currentTestRoot, testAdminApp);
       const documentPath = 'disaster-metadata/2017-harvey';
       const harveyDoc = prodApp.firestore().doc(documentPath);
-      const documentReference = testApp.firestore()
-          .doc('test/' + currentTestRoot + '/' + documentPath);
+      const documentReference = testApp.firestore().doc(
+          'test/' + currentTestRoot + '/' + documentPath);
       return Promise.all([harveyDoc.get(), signinPromise, deletePromise])
-          .then(
-              (result) =>
-                  Promise.all([documentReference.set(result[0].data(), {merge: true}),
-                  documentReference.set({dummy: true}, {merge: true})]))
+          .then((result) => Promise.all([
+            documentReference.set(result[0].data(), {merge: true}),
+            documentReference.set({dummy: true}, {merge: true})
+          ]))
           .then(
               () => Promise.all(
                   [testAdminApp.delete(), prodApp.delete(), testApp.delete()]))
@@ -190,7 +191,8 @@ const millisecondsInADay = 60 * 60 * 24 * 1000;
  * Recursively deletes all test data older than 24 hours, under the assumption
  * that no test runs for that long. This prevents old unfinished tests from
  * using too much quota. Note that documents in the list must have a field set
- * to show up in a listing of the parent collection (https://stackoverflow.com/questions/47043651/this-document-does-not-exist-and-will-not-appear-in-queries-or-snapshots-but-id).
+ * to show up in a listing of the parent collection
+ * (https://stackoverflow.com/questions/47043651/this-document-does-not-exist-and-will-not-appear-in-queries-or-snapshots-but-id).
  * That field is set in clearAndPopulateTestFirestoreData.
  * @param {admin.app.App} app
  */
@@ -200,15 +202,14 @@ function deleteAllOldTestData(app) {
   return querySnapshotPromise.then((queryResult) => {
     const promises = [];
     queryResult.forEach((doc) => {
-          const ref = doc.ref;
-          const testRunName = ref.id;
-          const dateElement = testRunName.split('-')[0];
-          const date = new Date(parseInt(dateElement, 10));
-          if (currentDate - date > millisecondsInADay) {
-            promises.push(deleteDocRecursively(ref));
-          }
-    }
-    );
+      const ref = doc.ref;
+      const testRunName = ref.id;
+      const dateElement = testRunName.split('-')[0];
+      const date = new Date(parseInt(dateElement, 10));
+      if (currentDate - date > millisecondsInADay) {
+        promises.push(deleteDocRecursively(ref));
+      }
+    });
     return Promise.all(promises);
   });
 }

--- a/cypress/support/script_loader.js
+++ b/cypress/support/script_loader.js
@@ -104,6 +104,7 @@ function loadScriptsBeforeForUnitTests(...scriptKeys) {
   }
 }
 
+const testPrefix = new Date();
 /**
  * Adds all necessary hooks to set up Firebase, for either unit or integration
  * tests. Populates test Firestore database. Integration tests need to also set
@@ -114,7 +115,7 @@ function addFirebaseHooks() {
                    timeout: 10000,
                  }).then((token) => global.firestoreCustomToken = token));
   beforeEach(() => {
-    testCookieValue = 'id-' + Math.random();
+    testCookieValue = testPrefix + ',' + Math.random();
     cy.task(
         'clearAndPopulateTestFirestoreData', testCookieValue, {timeout: 15000});
   });

--- a/cypress/support/script_loader.js
+++ b/cypress/support/script_loader.js
@@ -104,7 +104,7 @@ function loadScriptsBeforeForUnitTests(...scriptKeys) {
   }
 }
 
-const testPrefix = new Date();
+const testPrefix = new Date().getTime() + '-';
 /**
  * Adds all necessary hooks to set up Firebase, for either unit or integration
  * tests. Populates test Firestore database. Integration tests need to also set
@@ -115,7 +115,9 @@ function addFirebaseHooks() {
                    timeout: 10000,
                  }).then((token) => global.firestoreCustomToken = token));
   beforeEach(() => {
-    testCookieValue = testPrefix + ',' + Math.random();
+    testCookieValue = testPrefix + Math.random();
+    cy.task('logg', 'Our spec is ' + Cypress.spec.relative);
+    cy.log('Our spec is', Cypress.spec.relative);
     cy.task(
         'clearAndPopulateTestFirestoreData', testCookieValue, {timeout: 15000});
   });

--- a/cypress/support/script_loader.js
+++ b/cypress/support/script_loader.js
@@ -3,11 +3,7 @@ import {cypressTestCookieName, earthEngineTestTokenCookieName, firebaseTestToken
 
 export {loadScriptsBeforeForUnitTests};
 
-global.host = 'http://localhost:8080/';
-
 let testCookieValue = null;
-
-beforeEach(() => cy.task('logg', 'in before each'));
 
 const scriptMap = new Map([
   [
@@ -25,7 +21,7 @@ const scriptMap = new Map([
       () => typeof (deck) !== 'undefined',
     ],
   ],
-  ['ee', [host + 'lib/ee_api_js_debug.js', () => typeof (ee) !== 'undefined']],
+  ['ee', ['lib/ee_api_js_debug.js', () => typeof (ee) !== 'undefined']],
   [
     'firebase',
     [
@@ -113,17 +109,15 @@ const testPrefix = new Date().getTime() + '-';
  * the appropriate cookie.
  */
 function addFirebaseHooks() {
-  // before(() => cy.task('initializeTestFirebase', null, {
-  //                  timeout: 10000,
-  //                }).then((token) => global.firestoreCustomToken = token));
+  before(() => cy.task('initializeTestFirebase', null, {
+                   timeout: 10000,
+                 }).then((token) => global.firestoreCustomToken = token));
   beforeEach(() => {
     testCookieValue = testPrefix + Math.random();
-    cy.task('logg', 'Our spec is ' + Cypress.spec.relative);
-    cy.log('Our spec is', Cypress.spec.relative);
-    // cy.task(
-    //     'clearAndPopulateTestFirestoreData', testCookieValue, {timeout: 15000});
+    cy.task(
+        'clearAndPopulateTestFirestoreData', testCookieValue, {timeout: 15000});
   });
-  // afterEach(() => cy.task('deleteTestData', testCookieValue));
+  afterEach(() => cy.task('deleteTestData', testCookieValue));
 }
 
 /**
@@ -139,15 +133,15 @@ function doServerEeSetup() {
 if (Cypress.spec.relative.startsWith('cypress/integration/integration_tests')) {
   // Firebase hooks populate/clear test Firebase data.
   addFirebaseHooks();
-//   // EE authentication.
-//   before(doServerEeSetup);
-//   beforeEach(() => {
-//     /** wide enough for sidebar */
-//     cy.viewport(1100, 1700);
-//     cy.setCookie(cypressTestCookieName, testCookieValue);
-// //    cy.setCookie(firebaseTestTokenCookieName, firestoreCustomToken);
-//     cy.setCookie(earthEngineTestTokenCookieName, earthEngineCustomToken);
-//   });
+  // EE authentication.
+  before(doServerEeSetup);
+  beforeEach(() => {
+    /** wide enough for sidebar */
+    cy.viewport(1100, 1700);
+    cy.setCookie(cypressTestCookieName, testCookieValue);
+   cy.setCookie(firebaseTestTokenCookieName, firestoreCustomToken);
+    cy.setCookie(earthEngineTestTokenCookieName, earthEngineCustomToken);
+  });
 }
 
 /**

--- a/cypress/support/script_loader.js
+++ b/cypress/support/script_loader.js
@@ -7,6 +7,8 @@ global.host = 'http://localhost:8080/';
 
 let testCookieValue = null;
 
+beforeEach(() => cy.task('logg', 'in before each'));
+
 const scriptMap = new Map([
   [
     'maps',
@@ -111,17 +113,17 @@ const testPrefix = new Date().getTime() + '-';
  * the appropriate cookie.
  */
 function addFirebaseHooks() {
-  before(() => cy.task('initializeTestFirebase', null, {
-                   timeout: 10000,
-                 }).then((token) => global.firestoreCustomToken = token));
+  // before(() => cy.task('initializeTestFirebase', null, {
+  //                  timeout: 10000,
+  //                }).then((token) => global.firestoreCustomToken = token));
   beforeEach(() => {
     testCookieValue = testPrefix + Math.random();
     cy.task('logg', 'Our spec is ' + Cypress.spec.relative);
     cy.log('Our spec is', Cypress.spec.relative);
-    cy.task(
-        'clearAndPopulateTestFirestoreData', testCookieValue, {timeout: 15000});
+    // cy.task(
+    //     'clearAndPopulateTestFirestoreData', testCookieValue, {timeout: 15000});
   });
-  afterEach(() => cy.task('deleteTestData', testCookieValue));
+  // afterEach(() => cy.task('deleteTestData', testCookieValue));
 }
 
 /**
@@ -137,15 +139,15 @@ function doServerEeSetup() {
 if (Cypress.spec.relative.startsWith('cypress/integration/integration_tests')) {
   // Firebase hooks populate/clear test Firebase data.
   addFirebaseHooks();
-  // EE authentication.
-  before(doServerEeSetup);
-  beforeEach(() => {
-    /** wide enough for sidebar */
-    cy.viewport(1100, 1700);
-    cy.setCookie(cypressTestCookieName, testCookieValue);
-    cy.setCookie(firebaseTestTokenCookieName, firestoreCustomToken);
-    cy.setCookie(earthEngineTestTokenCookieName, earthEngineCustomToken);
-  });
+//   // EE authentication.
+//   before(doServerEeSetup);
+//   beforeEach(() => {
+//     /** wide enough for sidebar */
+//     cy.viewport(1100, 1700);
+//     cy.setCookie(cypressTestCookieName, testCookieValue);
+// //    cy.setCookie(firebaseTestTokenCookieName, firestoreCustomToken);
+//     cy.setCookie(earthEngineTestTokenCookieName, earthEngineCustomToken);
+//   });
 }
 
 /**

--- a/cypress/support/script_loader.js
+++ b/cypress/support/script_loader.js
@@ -139,7 +139,7 @@ if (Cypress.spec.relative.startsWith('cypress/integration/integration_tests')) {
     /** wide enough for sidebar */
     cy.viewport(1100, 1700);
     cy.setCookie(cypressTestCookieName, testCookieValue);
-   cy.setCookie(firebaseTestTokenCookieName, firestoreCustomToken);
+    cy.setCookie(firebaseTestTokenCookieName, firestoreCustomToken);
     cy.setCookie(earthEngineTestTokenCookieName, earthEngineCustomToken);
   });
 }


### PR DESCRIPTION
If the baseUrl is not set, then Cypress runs beforeEach hooks twice (https://github.com/cypress-io/cypress/issues/2636), which left lingering data.

With that fix, the belt-and-suspenders approach is mostly unnecessary, but added it for good measure: make the test directory start with the start date of the test and at the start of each test, delete all directories older than 24 hours. Unfortunately, Firestore has a nasty quirk: a document will only show up in its parent collection's listing if it has fields of its own, transitive fields don't count. So we add a dummy field to the root test document that we create, so that they show up in listings later.

This last part is obviously pretty hacky, and perhaps we don't actually need it with the root bug fixed. But I do worry about GiveDirectly accidentally going over Firestore quota if there's some bug in the future that makes tests fail without clean-up. If you think it's too hacky/confusing, though, I can revert it.