### PR TITLE
Deflake test by making it a unit test

### DIFF
--- a/cypress/integration/integration_tests/polygon_draw_test.js
+++ b/cypress/integration/integration_tests/polygon_draw_test.js
@@ -34,6 +34,8 @@ describe('Integration tests for drawing polygons', () => {
   it('Draws a polygon, checks for calculating status', () => {
     cy.visit(host);
     drawPolygonAndClickOnIt();
+    // TODO(janakr): remove when test is no longer flaky.
+    cy.get('.popup-calculated-data').then(($elt) => cy.task('logg', $elt.text()));
     cy.get('.popup-calculated-data').contains('calculating');
     // assert damage text is grey while editing
     cy.get('.popup-calculated-data')

--- a/cypress/integration/integration_tests/polygon_draw_test.js
+++ b/cypress/integration/integration_tests/polygon_draw_test.js
@@ -26,27 +26,6 @@ describe('Integration tests for drawing polygons', () => {
         .and('eq', 'rgb(0, 0, 0)');
   });
 
-  // This test relies on the earth engine damage count calculation happening
-  // slower than the cypress gets for the grey 'calculating'. Running a bunch
-  // of times manually this seems fairly safe, but there's a chance it flakes
-  // out if something changes. If this does start to flake, we can also consider
-  // lowering the wait at the end of drawPolygonAndClickOnIt.
-  it('Draws a polygon, checks for calculating status', () => {
-    cy.visit(host);
-    drawPolygonAndClickOnIt();
-    // TODO(janakr): remove when test is no longer flaky.
-    cy.get('.popup-calculated-data').then(($elt) => cy.task('logg', $elt.text()));
-    cy.get('.popup-calculated-data').contains('calculating');
-    // assert damage text is grey while editing
-    cy.get('.popup-calculated-data')
-        .should('have.css', 'color')
-        .and('eq', 'rgb(128, 128, 128)');
-    cy.awaitLoad(['writeWaiter']);
-    cy.get('.popup-calculated-data')
-        .should('have.css', 'color')
-        .and('eq', 'rgb(0, 0, 0)');
-  });
-
   it('Draws a polygon and deletes it', () => {
     // Accept confirmation when it happens.
     cy.on('window:confirm', () => true);

--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -183,7 +183,7 @@ describe('Unit test for ShapeData', () => {
     const map = new google.maps.Map(div, {center: {lat: 0, lng: 0}, zoom: 1});
     const polygon = new google.maps.Polygon({
       map: map,
-      paths: [{lat: 0, lng: 0}, {lat: 1, lng: 1}, {lat: 0, lng: 1}]
+      paths: [{lat: 0, lng: 0}, {lat: 1, lng: 1}, {lat: 0, lng: 1}],
     });
     setUpPopup();
     const popup = createPopup(polygon, map, 'notes');

--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -179,7 +179,7 @@ describe('Unit test for ShapeData', () => {
 
   it('Shows calculating before update finishes', () => {
     const div = document.createElement('div');
-    document.getElementsByTagName('body')[0].appendChild(div);
+    document.body.appendChild(div);
     const map = new google.maps.Map(div, {center: {lat: 0, lng: 0}, zoom: 1});
     const polygon = new google.maps.Polygon({
       map: map,
@@ -196,6 +196,8 @@ describe('Unit test for ShapeData', () => {
         });
     let calculatingDiv;
     // Popup initialization happens async, apparently, and takes a bit of time.
+    // Update is also happening. 50 ms is in the sweet spot of >popup init but
+    // <update.
     cy.wait(50).then(() => {
       calculatingDiv =
           document.getElementsByClassName('popup-calculated-data')[0];

--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -1,8 +1,8 @@
 import {getFirestoreRoot} from '../../../docs/firestore_document';
 import * as loading from '../../../docs/loading';
-import SettablePromise from '../../../docs/settable_promise';
-import {processUserRegions, StoredShapeData, setUpPolygonDrawing} from '../../../docs/polygon_draw';
+import {processUserRegions, setUpPolygonDrawing, StoredShapeData} from '../../../docs/polygon_draw';
 import * as resourceGetter from '../../../docs/resources';
+import SettablePromise from '../../../docs/settable_promise';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
 const polyCoords = [
@@ -189,25 +189,24 @@ describe('Unit test for ShapeData', () => {
     event.overlay = polygon;
     firebaseCollection.add = () => Promise.resolve({id: 'id'});
     const updatePromise = new SettablePromise();
-    cy.wrap(setUpPolygonDrawing(map, Promise.resolve())).then((drawingManager) => {
-      google.maps.event.trigger(drawingManager, 'overlaycomplete', event);
-      updatePromise.setPromise(event.resultPromise);
-    });
+    cy.wrap(setUpPolygonDrawing(map, Promise.resolve()))
+        .then((drawingManager) => {
+          google.maps.event.trigger(drawingManager, 'overlaycomplete', event);
+          updatePromise.setPromise(event.resultPromise);
+        });
     let calculatingDiv;
     // Popup initialization happens async, apparently, and takes a bit of time.
-    cy.wait(50)
-        .then(() => {
-          calculatingDiv =
-              document.getElementsByClassName('popup-calculated-data')[0];
-          expect(calculatingDiv).to.contain('calculating');
-          expect(getComputedStyle(calculatingDiv).color)
-              .to.eql('rgb(128, 128, 128)');
-        });
+    cy.wait(50).then(() => {
+      calculatingDiv =
+          document.getElementsByClassName('popup-calculated-data')[0];
+      expect(calculatingDiv).to.contain('calculating');
+      expect(getComputedStyle(calculatingDiv).color)
+          .to.eql('rgb(128, 128, 128)');
+    });
     cy.wrap(updatePromise.getPromise())
         .then(
             () => expect(getComputedStyle(calculatingDiv).color)
                       .to.eql('rgb(0, 0, 0)'));
-
   });
 
   it('Skips update if nothing changed', () => {

--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -1,9 +1,9 @@
 import {getFirestoreRoot} from '../../../docs/firestore_document';
 import * as loading from '../../../docs/loading';
 import {processUserRegions, StoredShapeData} from '../../../docs/polygon_draw';
+import {createPopup, setUpPopup} from '../../../docs/popup';
 import * as resourceGetter from '../../../docs/resources';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
-import {createPopup, setUpPopup} from "../../../docs/popup";
 
 const polyCoords = [
   {lng: 1, lat: 1},
@@ -181,22 +181,32 @@ describe('Unit test for ShapeData', () => {
     const div = document.createElement('div');
     document.getElementsByTagName('body')[0].appendChild(div);
     const map = new google.maps.Map(div, {center: {lat: 0, lng: 0}, zoom: 1});
-    const polygon = new google.maps.Polygon({map: map, paths: [{lat: 0, lng: 0}, {lat: 1, lng: 1}, {lat: 0, lng: 1}]});
+    const polygon = new google.maps.Polygon({
+      map: map,
+      paths: [{lat: 0, lng: 0}, {lat: 1, lng: 1}, {lat: 0, lng: 1}]
+    });
     setUpPopup();
     const popup = createPopup(polygon, map, 'notes');
     const storedShapeData = new StoredShapeData(null, null, null, popup);
     firebaseCollection.add = () => Promise.resolve({id: 'id'});
     let calculatingDiv;
-    cy.wait(50).then(() => {
-      calculatingDiv = document.getElementsByClassName('popup-calculated-data')[0];
-      expect(calculatingDiv).to.contain('calculating');
-      expect(getComputedStyle(calculatingDiv).color).to.eql('rgb(128, 128, 128)');
-      const resultPromise = storedShapeData.update();
-      // Promise is definitely not done: we're still in the same thread.
-      expect(calculatingDiv).to.contain('calculating');
-      expect(getComputedStyle(calculatingDiv).color).to.eql('rgb(128, 128, 128)');
-      return resultPromise;
-    }).then(() => expect(getComputedStyle(calculatingDiv).color).to.eql('rgb(0, 0, 0)'));
+    cy.wait(50)
+        .then(() => {
+          calculatingDiv =
+              document.getElementsByClassName('popup-calculated-data')[0];
+          expect(calculatingDiv).to.contain('calculating');
+          expect(getComputedStyle(calculatingDiv).color)
+              .to.eql('rgb(128, 128, 128)');
+          const resultPromise = storedShapeData.update();
+          // Promise is definitely not done: we're still in the same thread.
+          expect(calculatingDiv).to.contain('calculating');
+          expect(getComputedStyle(calculatingDiv).color)
+              .to.eql('rgb(128, 128, 128)');
+          return resultPromise;
+        })
+        .then(
+            () => expect(getComputedStyle(calculatingDiv).color)
+                      .to.eql('rgb(0, 0, 0)'));
   });
 
   it('Skips update if nothing changed', () => {

--- a/docs/create_map.js
+++ b/docs/create_map.js
@@ -1,6 +1,6 @@
 import mapStyles from './map_styles.js';
 import {geoPointToLatLng} from './map_util.js';
-import setUpPolygonDrawing from './polygon_draw.js';
+import {setUpPolygonDrawing} from './polygon_draw.js';
 
 export {createMap as default};
 

--- a/docs/polygon_draw.js
+++ b/docs/polygon_draw.js
@@ -7,12 +7,12 @@ import {createPopup, isMarker, setUpPopup} from './popup.js';
 import {getResources} from './resources.js';
 import {userRegionData} from './user_region_data.js';
 
-// StoredShapeData and setUpPolygonDrawing are only for testing.
+// StoredShapeData is only for testing.
 export {
   displayCalculatedData,
   processUserRegions,
   setUpPolygonDrawing,
-  StoredShapeData
+  StoredShapeData,
 };
 
 /**

--- a/docs/polygon_draw.js
+++ b/docs/polygon_draw.js
@@ -7,12 +7,12 @@ import {createPopup, isMarker, setUpPopup} from './popup.js';
 import {getResources} from './resources.js';
 import {userRegionData} from './user_region_data.js';
 
-// ShapeData is only for testing.
+// StoredShapeData and setUpPolygonDrawing are only for testing.
 export {
   displayCalculatedData,
   processUserRegions,
-  setUpPolygonDrawing as default,
-  StoredShapeData,
+  setUpPolygonDrawing,
+  StoredShapeData
 };
 
 /**
@@ -310,11 +310,12 @@ const appearance = {
  * @param {google.maps.Map} map
  * @param {Promise<any>} firebasePromise Promise that will complete when
  *     Firebase authentication is finished
+ * @return {Promise} Promise that contains DrawingManager when complete
  */
 function setUpPolygonDrawing(map, firebasePromise) {
   setUpPopup();
 
-  firebasePromise.then(() => {
+  return firebasePromise.then(() => {
     const drawingManager = new google.maps.drawing.DrawingManager({
       drawingControl: true,
       drawingControlOptions: {drawingModes: ['marker', 'polygon']},
@@ -334,10 +335,12 @@ function setUpPolygonDrawing(map, firebasePromise) {
       const popup = createPopup(feature, map, '');
       const data = new StoredShapeData(null, null, null, popup);
       userRegionData.set(feature, data);
-      data.update();
+      // Set the promise here for use in tests.
+      event.resultPromise = data.update();
     });
 
     drawingManager.setMap(map);
+    return drawingManager;
   });
 }
 


### PR DESCRIPTION
Most of these tests don't need to be integration tests. Starting with this one, since it's pretty flaky.

Setting an attribute on the event in overlaycomplete is a bit hacky. I can deduce when the promise is finished other ways as well, but since that promise is exactly what we want, I think it's nice to use it. Other alternatives would be to wait on the firebase add to complete (we can track that, since we're stubbing out the add), or to watch for the loading waiter changes (right now we completely stub those out).

The interaction between Cypress and Promises isn't my favorite, but not too terrible.