### PR TITLE
Special-case score rather than relying on it not being in firebaseLayers

### DIFF
--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -207,7 +207,8 @@ function addLayerFromFeatures(layerMapValue, layerName) {
     // TODO(janakr): deck.gl docs claim that the "color" property should
     // automatically color the features, but it doesn't appear to work:
     // https://deck.gl/#/documentation/deckgl-api-reference/layers/geojson-layer?section=getelevation-function-number-optional-transition-enabled
-    getFillColor: layerName === scoreLayerName ? getColorOfFeature : getStyleFunction(layerName),
+    getFillColor: layerName === scoreLayerName ? getColorOfFeature :
+                                                 getStyleFunction(layerName),
     visible: layerMapValue.displayed,
   });
   redrawLayers();

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -207,8 +207,7 @@ function addLayerFromFeatures(layerMapValue, layerName) {
     // TODO(janakr): deck.gl docs claim that the "color" property should
     // automatically color the features, but it doesn't appear to work:
     // https://deck.gl/#/documentation/deckgl-api-reference/layers/geojson-layer?section=getelevation-function-number-optional-transition-enabled
-    getFillColor: firebaseLayers[layerName] ? getStyleFunction(layerName) :
-                                              getColorOfFeature,
+    getFillColor: layerName === scoreLayerName ? getColorOfFeature : getStyleFunction(layerName),
     visible: layerMapValue.displayed,
   });
   redrawLayers();


### PR DESCRIPTION
In the case that the Firebase fetch is slow, firebaseLayers may not be initialized, but that shouldn't block the score from being displayed. I don't know if this is responsible for our flaky loading-forever issues on Travis, but it seems possible.