### PR TITLE
Stop using asset names as keys for layer metadata

### DIFF
--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -5,7 +5,9 @@ import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
 const mockData = {};
 
-const colorProperties = {'single-color': 'yellow'};
+const colorProperties = {
+  'single-color': 'yellow',
+};
 const mockFirebaseLayers = [
   {
     'ee-name': 'asset0',

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -34,7 +34,7 @@ const mockFirebaseLayers = [
 
 const colorProperties = {
   'single-color': 'blue',
-  'opacity': 100
+  'opacity': 100,
 };
 
 describe('Unit test for toggleLayerOn', () => {

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -1,5 +1,5 @@
 import {LayerType} from '../../../docs/firebase_layers.js';
-import {deckGlArray, DisplayedLayerData, layerArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
+import {DeckParams, deckGlArray, DisplayedLayerData, layerArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
 import * as loading from '../../../docs/loading';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
@@ -32,6 +32,8 @@ const mockFirebaseLayers = [
   },
 ];
 
+const colorProperties = {'single-color': 'blue', 'opacity': 100};
+
 describe('Unit test for toggleLayerOn', () => {
   loadScriptsBeforeForUnitTests('ee', 'deck', 'maps');
   before(() => {
@@ -40,11 +42,11 @@ describe('Unit test for toggleLayerOn', () => {
     loading.loadingElementFinished = () => {};
   });
   beforeEach(() => {
-    layerArray[0] = new DisplayedLayerData(null, true);
+    layerArray[0] = new DisplayedLayerData(new DeckParams('asset0', colorProperties), true);
     layerArray[0].data = mockData;
-    layerArray[1] = new DisplayedLayerData(null, false);
+    layerArray[1] = new DisplayedLayerData(new DeckParams('asset1', colorProperties), false);
     layerArray[1].data = mockData;
-    layerArray[2] = new DisplayedLayerData(null, false);
+    layerArray[2] = new DisplayedLayerData(new DeckParams('asset2', colorProperties), false);
     // Initialize deck object in production.
     setMapToDrawLayersOn(null);
     deckGlArray[0] = new deck.GeoJsonLayer({});

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -1,6 +1,6 @@
 import {initializeFirebaseLayers, LayerType} from '../../../docs/firebase_layers.js';
+import {deckGlArray, LayerMapValue, mapOverlayArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
 import * as loading from '../../../docs/loading';
-import {deckGlArray, mapOverlayArray, LayerMapValue, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
 const mockData = {};
@@ -16,7 +16,7 @@ const mockFirebaseLayers = [
   },
   {
     'asset-type': LayerType.FEATURE_COLLECTION,
-      'ee-name': 'asset1',
+    'ee-name': 'asset1',
     'display-name': 'asset1',
     'display-on-load': false,
     'color-function': {'single-color': 'yellow'},
@@ -24,8 +24,8 @@ const mockFirebaseLayers = [
   },
   {
     'asset-type': LayerType.FEATURE_COLLECTION,
-      'ee-name': 'asset2',
-      'display-name': 'asset2',
+    'ee-name': 'asset2',
+    'display-name': 'asset2',
     'display-on-load': false,
     'color-function': {'single-color': 'yellow'},
     'index': 2,

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -14,7 +14,7 @@ const mockFirebaseLayers = [
     'asset-type': LayerType.FEATURE_COLLECTION,
     'display-name': 'asset0',
     'display-on-load': true,
-    'color-function': {'single-color': 'yellow'},
+    'color-function': colorProperties,
     'index': 0,
   },
   {
@@ -22,7 +22,7 @@ const mockFirebaseLayers = [
     'asset-type': LayerType.FEATURE_COLLECTION,
     'display-name': 'asset1',
     'display-on-load': false,
-    'color-function': {'single-color': 'yellow'},
+    'color-function': colorProperties,
     'index': 1,
   },
   {
@@ -30,7 +30,7 @@ const mockFirebaseLayers = [
     'asset-type': LayerType.FEATURE_COLLECTION,
     'display-name': 'asset2',
     'display-on-load': false,
-    'color-function': newVar,
+    'color-function': colorProperties,
     'index': 2,
   },
 ];

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -1,5 +1,5 @@
 import {initializeFirebaseLayers, LayerType} from '../../../docs/firebase_layers.js';
-import {deckGlArray, LayerMapValue, mapOverlayArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
+import {deckGlArray, DisplayedLayerData, mapOverlayArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
 import * as loading from '../../../docs/loading';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
@@ -40,11 +40,11 @@ describe('Unit test for toggleLayerOn', () => {
     loading.loadingElementFinished = () => {};
   });
   beforeEach(() => {
-    mapOverlayArray[0] = new LayerMapValue('asset0', true);
+    mapOverlayArray[0] = new DisplayedLayerData('asset0', true);
     mapOverlayArray[0].data = mockData;
-    mapOverlayArray[1] = new LayerMapValue('asset1', false);
+    mapOverlayArray[1] = new DisplayedLayerData('asset1', false);
     mapOverlayArray[1].data = mockData;
-    mapOverlayArray[2] = new LayerMapValue('asset2', false);
+    mapOverlayArray[2] = new DisplayedLayerData('asset2', false);
     initializeFirebaseLayers(mockFirebaseLayers);
     // Initialize deck object in production.
     setMapToDrawLayersOn(null);

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -40,12 +40,11 @@ describe('Unit test for toggleLayerOn', () => {
     loading.loadingElementFinished = () => {};
   });
   beforeEach(() => {
-    layerArray[0] = new DisplayedLayerData('asset0', true);
+    layerArray[0] = new DisplayedLayerData(null, true);
     layerArray[0].data = mockData;
-    layerArray[1] = new DisplayedLayerData('asset1', false);
+    layerArray[1] = new DisplayedLayerData(null, false);
     layerArray[1].data = mockData;
-    layerArray[2] = new DisplayedLayerData('asset2', false);
-    initializeFirebaseLayers(mockFirebaseLayers);
+    layerArray[2] = new DisplayedLayerData(null, false);
     // Initialize deck object in production.
     setMapToDrawLayersOn(null);
     deckGlArray[0] = new deck.GeoJsonLayer({});

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -1,5 +1,5 @@
 import {initializeFirebaseLayers, LayerType} from '../../../docs/firebase_layers.js';
-import {deckGlArray, DisplayedLayerData, mapOverlayArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
+import {deckGlArray, DisplayedLayerData, layerArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
 import * as loading from '../../../docs/loading';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
@@ -40,11 +40,11 @@ describe('Unit test for toggleLayerOn', () => {
     loading.loadingElementFinished = () => {};
   });
   beforeEach(() => {
-    mapOverlayArray[0] = new DisplayedLayerData('asset0', true);
-    mapOverlayArray[0].data = mockData;
-    mapOverlayArray[1] = new DisplayedLayerData('asset1', false);
-    mapOverlayArray[1].data = mockData;
-    mapOverlayArray[2] = new DisplayedLayerData('asset2', false);
+    layerArray[0] = new DisplayedLayerData('asset0', true);
+    layerArray[0].data = mockData;
+    layerArray[1] = new DisplayedLayerData('asset1', false);
+    layerArray[1].data = mockData;
+    layerArray[2] = new DisplayedLayerData('asset2', false);
     initializeFirebaseLayers(mockFirebaseLayers);
     // Initialize deck object in production.
     setMapToDrawLayersOn(null);
@@ -53,11 +53,11 @@ describe('Unit test for toggleLayerOn', () => {
   });
 
   it('displays a hidden but loaded layer', () => {
-    expect(mapOverlayArray[1].displayed).to.equals(false);
-    expect(mapOverlayArray[1].data).to.not.be.null;
+    expect(layerArray[1].displayed).to.equals(false);
+    expect(layerArray[1].data).to.not.be.null;
 
     toggleLayerOn(mockFirebaseLayers[1]);
-    expect(mapOverlayArray[1].displayed).to.equals(true);
+    expect(layerArray[1].displayed).to.equals(true);
     const layerProps = deckGlArray[1].props;
     expect(layerProps).to.have.property('id', 'asset1');
     expect(layerProps).to.have.property('visible', true);
@@ -65,8 +65,8 @@ describe('Unit test for toggleLayerOn', () => {
   });
 
   it('loads a hidden layer and displays', () => {
-    expect(mapOverlayArray[2].displayed).to.equals(false);
-    expect(mapOverlayArray[2].data).to.be.undefined;
+    expect(layerArray[2].displayed).to.equals(false);
+    expect(layerArray[2].data).to.be.undefined;
 
     const emptyList = [];
     let callback = null;
@@ -77,8 +77,8 @@ describe('Unit test for toggleLayerOn', () => {
     // TODO(janakr): Here and below, consider returning a Promise from
     //  toggleLayerOn that can be waited on instead of this event-loop push.
     cy.wait(0).then(() => {
-      expect(mapOverlayArray[2].displayed).to.equals(true);
-      expect(mapOverlayArray[2].data).to.not.be.null;
+      expect(layerArray[2].displayed).to.equals(true);
+      expect(layerArray[2].data).to.not.be.null;
       const layerProps = deckGlArray[2].props;
       expect(layerProps).to.have.property('id', 'asset2');
       expect(layerProps).to.have.property('visible', true);
@@ -87,8 +87,8 @@ describe('Unit test for toggleLayerOn', () => {
   });
 
   it('check hidden layer, then uncheck before list evaluation', () => {
-    expect(mapOverlayArray[2].displayed).to.equals(false);
-    expect(mapOverlayArray[2].data).to.be.undefined;
+    expect(layerArray[2].displayed).to.equals(false);
+    expect(layerArray[2].data).to.be.undefined;
 
     const emptyList = [];
     let callback = null;
@@ -99,8 +99,8 @@ describe('Unit test for toggleLayerOn', () => {
 
     // Evaluate after the promise finishes by using an instant wait.
     cy.wait(0).then(() => {
-      expect(mapOverlayArray[2].displayed).to.equals(false);
-      expect(mapOverlayArray[2].data).to.not.be.null;
+      expect(layerArray[2].displayed).to.equals(false);
+      expect(layerArray[2].data).to.not.be.null;
       const layerProps = deckGlArray[2].props;
       expect(layerProps).to.have.property('id', 'asset2');
       expect(layerProps).to.have.property('visible', false);
@@ -111,12 +111,12 @@ describe('Unit test for toggleLayerOn', () => {
 
 describe('Unit test for toggleLayerOff', () => {
   it('hides a displayed layer', () => {
-    expect(mapOverlayArray[0].displayed).to.equals(true);
-    expect(mapOverlayArray[0].data).to.not.be.null;
+    expect(layerArray[0].displayed).to.equals(true);
+    expect(layerArray[0].data).to.not.be.null;
 
     toggleLayerOff(0);
-    expect(mapOverlayArray[0].displayed).to.equals(false);
-    expect(mapOverlayArray[0].data).to.not.be.null;
+    expect(layerArray[0].displayed).to.equals(false);
+    expect(layerArray[0].data).to.not.be.null;
     const layerProps = deckGlArray[0].props;
     expect(layerProps).to.have.property('id', 'asset0');
     expect(layerProps).to.have.property('visible', false);

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -1,5 +1,5 @@
 import {LayerType} from '../../../docs/firebase_layers.js';
-import {deckGlArray, DeckParams, LayerDisplayData, layerArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
+import {deckGlArray, DeckParams, layerArray, LayerDisplayData, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
 import * as loading from '../../../docs/loading';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
@@ -46,11 +46,11 @@ describe('Unit test for toggleLayerOn', () => {
     layerArray[0] =
         new LayerDisplayData(new DeckParams('asset0', colorProperties), true);
     layerArray[0].data = mockData;
-    layerArray[1] = new LayerDisplayData(
-        new DeckParams('asset1', colorProperties), false);
+    layerArray[1] =
+        new LayerDisplayData(new DeckParams('asset1', colorProperties), false);
     layerArray[1].data = mockData;
-    layerArray[2] = new LayerDisplayData(
-        new DeckParams('asset2', colorProperties), false);
+    layerArray[2] =
+        new LayerDisplayData(new DeckParams('asset2', colorProperties), false);
     // Initialize deck object in production.
     setMapToDrawLayersOn(null);
     deckGlArray[0] = new deck.GeoJsonLayer({});

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -1,5 +1,5 @@
 import {initializeFirebaseLayers, LayerType} from '../../../docs/firebase_layers.js';
-import {layerArray, layerMap, LayerMapValue, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
+import {deckGlArray, mapOverlayArray, LayerMapValue, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
 const mockData = {};
@@ -28,31 +28,31 @@ const mockFirebaseLayers = {
 describe('Unit test for toggleLayerOn', () => {
   loadScriptsBeforeForUnitTests('ee', 'deck', 'maps');
   beforeEach(() => {
-    layerMap.set('asset0', new LayerMapValue(mockData, 0, true));
-    layerMap.set('asset1', new LayerMapValue(mockData, 1, false));
-    layerMap.set('asset2', new LayerMapValue(null, 2, false));
+    mapOverlayArray.set('asset0', new LayerMapValue(0, true));
+    mapOverlayArray.set('asset1', new LayerMapValue(1, false));
+    mapOverlayArray.set('asset2', new LayerMapValue(2, false));
     initializeFirebaseLayers(mockFirebaseLayers);
     // Initialize deck object in production.
     setMapToDrawLayersOn(null);
-    layerArray[0] = new deck.GeoJsonLayer({});
-    layerArray[1] = new deck.GeoJsonLayer({});
+    deckGlArray[0] = new deck.GeoJsonLayer({});
+    deckGlArray[1] = new deck.GeoJsonLayer({});
   });
 
   it('displays a hidden but loaded layer', () => {
-    expect(layerMap.get('asset1').displayed).to.equals(false);
-    expect(layerMap.get('asset1').data).to.not.be.null;
+    expect(mapOverlayArray.get('asset1').displayed).to.equals(false);
+    expect(mapOverlayArray.get('asset1').data).to.not.be.null;
 
     toggleLayerOn('asset1');
-    expect(layerMap.get('asset1').displayed).to.equals(true);
-    const layerProps = layerArray[1].props;
+    expect(mapOverlayArray.get('asset1').displayed).to.equals(true);
+    const layerProps = deckGlArray[1].props;
     expect(layerProps).to.have.property('id', 'asset1');
     expect(layerProps).to.have.property('visible', true);
     expect(layerProps).to.have.property('data', mockData);
   });
 
   it('loads a hidden layer and displays', () => {
-    expect(layerMap.get('asset2').displayed).to.equals(false);
-    expect(layerMap.get('asset2').data).to.be.null;
+    expect(mapOverlayArray.get('asset2').displayed).to.equals(false);
+    expect(mapOverlayArray.get('asset2').data).to.be.null;
 
     const emptyList = [];
     let callback = null;
@@ -63,9 +63,9 @@ describe('Unit test for toggleLayerOn', () => {
     // TODO(janakr): Here and below, consider returning a Promise from
     //  toggleLayerOn that can be waited on instead of this event-loop push.
     cy.wait(0).then(() => {
-      expect(layerMap.get('asset2').displayed).to.equals(true);
-      expect(layerMap.get('asset2').data).to.not.be.null;
-      const layerProps = layerArray[2].props;
+      expect(mapOverlayArray.get('asset2').displayed).to.equals(true);
+      expect(mapOverlayArray.get('asset2').data).to.not.be.null;
+      const layerProps = deckGlArray[2].props;
       expect(layerProps).to.have.property('id', 'asset2');
       expect(layerProps).to.have.property('visible', true);
       expect(layerProps).to.have.property('data', emptyList);
@@ -73,8 +73,8 @@ describe('Unit test for toggleLayerOn', () => {
   });
 
   it('check hidden layer, then uncheck before list evaluation', () => {
-    expect(layerMap.get('asset2').displayed).to.equals(false);
-    expect(layerMap.get('asset2').data).to.be.null;
+    expect(mapOverlayArray.get('asset2').displayed).to.equals(false);
+    expect(mapOverlayArray.get('asset2').data).to.be.null;
 
     const emptyList = [];
     let callback = null;
@@ -85,9 +85,9 @@ describe('Unit test for toggleLayerOn', () => {
 
     // Evaluate after the promise finishes by using an instant wait.
     cy.wait(0).then(() => {
-      expect(layerMap.get('asset2').displayed).to.equals(false);
-      expect(layerMap.get('asset2').data).to.not.be.null;
-      const layerProps = layerArray[2].props;
+      expect(mapOverlayArray.get('asset2').displayed).to.equals(false);
+      expect(mapOverlayArray.get('asset2').data).to.not.be.null;
+      const layerProps = deckGlArray[2].props;
       expect(layerProps).to.have.property('id', 'asset2');
       expect(layerProps).to.have.property('visible', false);
       expect(layerProps).to.have.property('data', emptyList);
@@ -97,13 +97,13 @@ describe('Unit test for toggleLayerOn', () => {
 
 describe('Unit test for toggleLayerOff', () => {
   it('hides a displayed layer', () => {
-    expect(layerMap.get('asset0').displayed).to.equals(true);
-    expect(layerMap.get('asset0').data).to.not.be.null;
+    expect(mapOverlayArray.get('asset0').displayed).to.equals(true);
+    expect(mapOverlayArray.get('asset0').data).to.not.be.null;
 
     toggleLayerOff('asset0');
-    expect(layerMap.get('asset0').displayed).to.equals(false);
-    expect(layerMap.get('asset0').data).to.not.be.null;
-    const layerProps = layerArray[0].props;
+    expect(mapOverlayArray.get('asset0').displayed).to.equals(false);
+    expect(mapOverlayArray.get('asset0').data).to.not.be.null;
+    const layerProps = deckGlArray[0].props;
     expect(layerProps).to.have.property('id', 'asset0');
     expect(layerProps).to.have.property('visible', false);
     expect(layerProps).to.have.property('data', mockData);

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -1,5 +1,5 @@
 import {LayerType} from '../../../docs/firebase_layers.js';
-import {deckGlArray, DeckParams, DisplayedLayerData, layerArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
+import {deckGlArray, DeckParams, LayerDisplayData, layerArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
 import * as loading from '../../../docs/loading';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
@@ -44,12 +44,12 @@ describe('Unit test for toggleLayerOn', () => {
   });
   beforeEach(() => {
     layerArray[0] =
-        new DisplayedLayerData(new DeckParams('asset0', colorProperties), true);
+        new LayerDisplayData(new DeckParams('asset0', colorProperties), true);
     layerArray[0].data = mockData;
-    layerArray[1] = new DisplayedLayerData(
+    layerArray[1] = new LayerDisplayData(
         new DeckParams('asset1', colorProperties), false);
     layerArray[1].data = mockData;
-    layerArray[2] = new DisplayedLayerData(
+    layerArray[2] = new LayerDisplayData(
         new DeckParams('asset2', colorProperties), false);
     // Initialize deck object in production.
     setMapToDrawLayersOn(null);

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -1,4 +1,4 @@
-import {initializeFirebaseLayers, LayerType} from '../../../docs/firebase_layers.js';
+import {LayerType} from '../../../docs/firebase_layers.js';
 import {deckGlArray, DisplayedLayerData, layerArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
 import * as loading from '../../../docs/loading';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -5,6 +5,7 @@ import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
 const mockData = {};
 
+const colorProperties = {'single-color': 'yellow'};
 const mockFirebaseLayers = [
   {
     'ee-name': 'asset0',
@@ -15,27 +16,22 @@ const mockFirebaseLayers = [
     'index': 0,
   },
   {
-    'asset-type': LayerType.FEATURE_COLLECTION,
     'ee-name': 'asset1',
+    'asset-type': LayerType.FEATURE_COLLECTION,
     'display-name': 'asset1',
     'display-on-load': false,
     'color-function': {'single-color': 'yellow'},
     'index': 1,
   },
   {
-    'asset-type': LayerType.FEATURE_COLLECTION,
     'ee-name': 'asset2',
+    'asset-type': LayerType.FEATURE_COLLECTION,
     'display-name': 'asset2',
     'display-on-load': false,
-    'color-function': {'single-color': 'yellow'},
+    'color-function': newVar,
     'index': 2,
   },
 ];
-
-const colorProperties = {
-  'single-color': 'blue',
-  'opacity': 100,
-};
 
 describe('Unit test for toggleLayerOn', () => {
   loadScriptsBeforeForUnitTests('ee', 'deck', 'maps');

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -1,5 +1,5 @@
 import {LayerType} from '../../../docs/firebase_layers.js';
-import {DeckParams, deckGlArray, DisplayedLayerData, layerArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
+import {deckGlArray, DeckParams, DisplayedLayerData, layerArray, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
 import * as loading from '../../../docs/loading';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
@@ -32,7 +32,10 @@ const mockFirebaseLayers = [
   },
 ];
 
-const colorProperties = {'single-color': 'blue', 'opacity': 100};
+const colorProperties = {
+  'single-color': 'blue',
+  'opacity': 100
+};
 
 describe('Unit test for toggleLayerOn', () => {
   loadScriptsBeforeForUnitTests('ee', 'deck', 'maps');
@@ -42,11 +45,14 @@ describe('Unit test for toggleLayerOn', () => {
     loading.loadingElementFinished = () => {};
   });
   beforeEach(() => {
-    layerArray[0] = new DisplayedLayerData(new DeckParams('asset0', colorProperties), true);
+    layerArray[0] =
+        new DisplayedLayerData(new DeckParams('asset0', colorProperties), true);
     layerArray[0].data = mockData;
-    layerArray[1] = new DisplayedLayerData(new DeckParams('asset1', colorProperties), false);
+    layerArray[1] = new DisplayedLayerData(
+        new DeckParams('asset1', colorProperties), false);
     layerArray[1].data = mockData;
-    layerArray[2] = new DisplayedLayerData(new DeckParams('asset2', colorProperties), false);
+    layerArray[2] = new DisplayedLayerData(
+        new DeckParams('asset2', colorProperties), false);
     // Initialize deck object in production.
     setMapToDrawLayersOn(null);
     deckGlArray[0] = new deck.GeoJsonLayer({});

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -4,33 +4,39 @@ import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
 const mockData = {};
 
-const mockFirebaseLayers = {
-  'asset0': {
+const mockFirebaseLayers = [
+  {
+    'ee-name': 'asset0',
     'asset-type': LayerType.FEATURE_COLLECTION,
     'display-name': 'asset0',
     'display-on-load': true,
     'color-function': {'single-color': 'yellow'},
+    'index': 0,
   },
-  'asset1': {
+  {
     'asset-type': LayerType.FEATURE_COLLECTION,
+      'ee-name': 'asset1',
     'display-name': 'asset1',
     'display-on-load': false,
     'color-function': {'single-color': 'yellow'},
+    'index': 1,
   },
-  'asset2': {
+  {
     'asset-type': LayerType.FEATURE_COLLECTION,
-    'display-name': 'asset2',
+      'ee-name': 'asset2',
+      'display-name': 'asset2',
     'display-on-load': false,
     'color-function': {'single-color': 'yellow'},
+    'index': 2,
   },
-};
+];
 
 describe('Unit test for toggleLayerOn', () => {
   loadScriptsBeforeForUnitTests('ee', 'deck', 'maps');
   beforeEach(() => {
-    mapOverlayArray.set('asset0', new LayerMapValue(0, true));
-    mapOverlayArray.set('asset1', new LayerMapValue(1, false));
-    mapOverlayArray.set('asset2', new LayerMapValue(2, false));
+    mapOverlayArray[0] = new LayerMapValue('asset0', true);
+    mapOverlayArray[1] = new LayerMapValue('asset1', false);
+    mapOverlayArray[2] = new LayerMapValue('asset2', false);
     initializeFirebaseLayers(mockFirebaseLayers);
     // Initialize deck object in production.
     setMapToDrawLayersOn(null);
@@ -38,12 +44,12 @@ describe('Unit test for toggleLayerOn', () => {
     deckGlArray[1] = new deck.GeoJsonLayer({});
   });
 
-  it('displays a hidden but loaded layer', () => {
-    expect(mapOverlayArray.get('asset1').displayed).to.equals(false);
-    expect(mapOverlayArray.get('asset1').data).to.not.be.null;
+  it.only('displays a hidden but loaded layer', () => {
+    expect(mapOverlayArray[1].displayed).to.equals(false);
+    expect(mapOverlayArray[1].data).to.not.be.null;
 
-    toggleLayerOn('asset1');
-    expect(mapOverlayArray.get('asset1').displayed).to.equals(true);
+    toggleLayerOn(mockFirebaseLayers[1]);
+    expect(mapOverlayArray[1].displayed).to.equals(true);
     const layerProps = deckGlArray[1].props;
     expect(layerProps).to.have.property('id', 'asset1');
     expect(layerProps).to.have.property('visible', true);
@@ -51,20 +57,20 @@ describe('Unit test for toggleLayerOn', () => {
   });
 
   it('loads a hidden layer and displays', () => {
-    expect(mapOverlayArray.get('asset2').displayed).to.equals(false);
-    expect(mapOverlayArray.get('asset2').data).to.be.null;
+    expect(mapOverlayArray[2].displayed).to.equals(false);
+    expect(mapOverlayArray[2].data).to.be.null;
 
     const emptyList = [];
     let callback = null;
     stubForEmptyList((callb) => callback = callb);
-    toggleLayerOn('asset2');
+    toggleLayerOn(mapOverlayArray[2]);
     callback(emptyList);
     // Evaluate after the promise finishes by using an instant wait.
     // TODO(janakr): Here and below, consider returning a Promise from
     //  toggleLayerOn that can be waited on instead of this event-loop push.
     cy.wait(0).then(() => {
-      expect(mapOverlayArray.get('asset2').displayed).to.equals(true);
-      expect(mapOverlayArray.get('asset2').data).to.not.be.null;
+      expect(mapOverlayArray[2].displayed).to.equals(true);
+      expect(mapOverlayArray[2].data).to.not.be.null;
       const layerProps = deckGlArray[2].props;
       expect(layerProps).to.have.property('id', 'asset2');
       expect(layerProps).to.have.property('visible', true);
@@ -73,20 +79,20 @@ describe('Unit test for toggleLayerOn', () => {
   });
 
   it('check hidden layer, then uncheck before list evaluation', () => {
-    expect(mapOverlayArray.get('asset2').displayed).to.equals(false);
-    expect(mapOverlayArray.get('asset2').data).to.be.null;
+    expect(mapOverlayArray[2].displayed).to.equals(false);
+    expect(mapOverlayArray[2].data).to.be.null;
 
     const emptyList = [];
     let callback = null;
     stubForEmptyList((callb) => callback = callb);
-    toggleLayerOn('asset2');
-    toggleLayerOff('asset2');
+    toggleLayerOn(mapOverlayArray[2]);
+    toggleLayerOff(mapOverlayArray[2]);
     callback(emptyList);
 
     // Evaluate after the promise finishes by using an instant wait.
     cy.wait(0).then(() => {
-      expect(mapOverlayArray.get('asset2').displayed).to.equals(false);
-      expect(mapOverlayArray.get('asset2').data).to.not.be.null;
+      expect(mapOverlayArray[2].displayed).to.equals(false);
+      expect(mapOverlayArray[2].data).to.not.be.null;
       const layerProps = deckGlArray[2].props;
       expect(layerProps).to.have.property('id', 'asset2');
       expect(layerProps).to.have.property('visible', false);
@@ -97,12 +103,12 @@ describe('Unit test for toggleLayerOn', () => {
 
 describe('Unit test for toggleLayerOff', () => {
   it('hides a displayed layer', () => {
-    expect(mapOverlayArray.get('asset0').displayed).to.equals(true);
-    expect(mapOverlayArray.get('asset0').data).to.not.be.null;
+    expect(mapOverlayArray[0].displayed).to.equals(true);
+    expect(mapOverlayArray[0].data).to.not.be.null;
 
-    toggleLayerOff('asset0');
-    expect(mapOverlayArray.get('asset0').displayed).to.equals(false);
-    expect(mapOverlayArray.get('asset0').data).to.not.be.null;
+    toggleLayerOff(mapOverlayArray[0]);
+    expect(mapOverlayArray[0].displayed).to.equals(false);
+    expect(mapOverlayArray[0].data).to.not.be.null;
     const layerProps = deckGlArray[0].props;
     expect(layerProps).to.have.property('id', 'asset0');
     expect(layerProps).to.have.property('visible', false);
@@ -119,7 +125,7 @@ describe('Unit test for toggleLayerOff', () => {
  */
 function stubForEmptyList(callbackReceiver) {
   const emptyCollection = ee.FeatureCollection([]);
-  cy.stub(ee, 'FeatureCollection').withArgs('asset2').returns(emptyCollection);
+  cy.stub(ee, 'FeatureCollection').withArgs(mapOverlayArray[2]).returns(emptyCollection);
   const emptyEeList = ee.List([]);
   cy.stub(emptyCollection, 'toList').returns(emptyEeList);
   cy.stub(emptyEeList, 'evaluate').callsFake(callbackReceiver);

--- a/cypress/integration/unit_tests/style_functions_test.js
+++ b/cypress/integration/unit_tests/style_functions_test.js
@@ -5,12 +5,11 @@ describe('Unit test for generating style functions', () => {
     const fxn = createStyleFunction({
       'continuous': false,
       'field': 'flavor',
-
       'opacity': 100,
       'colors': {
         'cherry': 'red',
         'banana': 'yellow',
-      }
+      },
     });
     const cherry = fxn({'properties': {'flavor': 'cherry'}});
     const expectedCherry = colorMap.get('red');

--- a/cypress/integration/unit_tests/style_functions_test.js
+++ b/cypress/integration/unit_tests/style_functions_test.js
@@ -10,7 +10,8 @@ describe('Unit test for generating style functions', () => {
       'colors': {
         'cherry': 'red',
         'banana': 'yellow',
-      }});
+      }
+    });
     const cherry = fxn({'properties': {'flavor': 'cherry'}});
     const expectedCherry = colorMap.get('red');
     expect(cherry).to.eql(expectedCherry);
@@ -21,12 +22,12 @@ describe('Unit test for generating style functions', () => {
 
   it('calculates a continuous function', () => {
     const fxn = createStyleFunction({
-        'continuous': true,
-        'field': 'oranges',
-        'base-color': 'orange',
-        'opacity': 83,
-        'min': 14,
-        'max': 10005,
+      'continuous': true,
+      'field': 'oranges',
+      'base-color': 'orange',
+      'opacity': 83,
+      'min': 14,
+      'max': 10005,
     });
     const orangeish = fxn({'properties': {'oranges': 734}});
     // orange = [255, 140, 0]
@@ -39,8 +40,8 @@ describe('Unit test for generating style functions', () => {
 
   it('calculates a single-color function', () => {
     const fxn = createStyleFunction({
-        'single-color': 'blue',
-        'opacity': 83,
+      'single-color': 'blue',
+      'opacity': 83,
     });
     const trueBlue = fxn({});
     const blue = colorMap.get('blue');

--- a/cypress/integration/unit_tests/style_functions_test.js
+++ b/cypress/integration/unit_tests/style_functions_test.js
@@ -1,28 +1,16 @@
-import {firebaseLayers} from '../../../docs/firebase_layers';
-import {colorMap, getStyleFunction, initializeFirebaseLayers} from '../../../docs/firebase_layers.js';
+import {colorMap, createStyleFunction} from '../../../docs/firebase_layers.js';
 
 describe('Unit test for generating style functions', () => {
-  before(() => initializeFirebaseLayers({}));
-
-  afterEach(
-      () => Object.keys(firebaseLayers)
-                .forEach((asset) => firebaseLayers[asset] = undefined));
-
   it('calculates a discrete function', () => {
-    firebaseLayers['asset0'] = {
-      'color-function': {
-        'continuous': false,
-        'field': 'flavor',
+    const fxn = createStyleFunction({
+      'continuous': false,
+      'field': 'flavor',
 
-        'opacity': 100,
-        'colors': {
-          'cherry': 'red',
-          'banana': 'yellow',
-        },
-      },
-    };
-
-    const fxn = getStyleFunction('asset0');
+      'opacity': 100,
+      'colors': {
+        'cherry': 'red',
+        'banana': 'yellow',
+      }});
     const cherry = fxn({'properties': {'flavor': 'cherry'}});
     const expectedCherry = colorMap.get('red');
     expect(cherry).to.eql(expectedCherry);
@@ -32,18 +20,14 @@ describe('Unit test for generating style functions', () => {
   });
 
   it('calculates a continuous function', () => {
-    firebaseLayers['asset1'] = {
-      'color-function': {
+    const fxn = createStyleFunction({
         'continuous': true,
         'field': 'oranges',
         'base-color': 'orange',
         'opacity': 83,
         'min': 14,
         'max': 10005,
-      },
-    };
-
-    const fxn = getStyleFunction('asset1');
+    });
     const orangeish = fxn({'properties': {'oranges': 734}});
     // orange = [255, 140, 0]
     // white = [255, 255, 255]
@@ -54,14 +38,10 @@ describe('Unit test for generating style functions', () => {
   });
 
   it('calculates a single-color function', () => {
-    firebaseLayers['asset2'] = {
-      'color-function': {
+    const fxn = createStyleFunction({
         'single-color': 'blue',
         'opacity': 83,
-      },
-    };
-
-    const fxn = getStyleFunction('asset2');
+    });
     const trueBlue = fxn({});
     const blue = colorMap.get('blue');
     expect(trueBlue).to.eql(blue);

--- a/docs/create_map.js
+++ b/docs/create_map.js
@@ -92,33 +92,6 @@ function createMap(firebasePromise) {
     });
     map.fitBounds(bounds);
   });
-  for (let i = 0; i < TILE_URLS.length; i++) {
-    const tileUrl = TILE_URLS[i];
-    const tileOverlay = new google.maps.ImageMapType({
-      getTileUrl: (coord, zoom) => tileUrl.replace('{Z}', zoom)
-          .replace('{X}', coord.x)
-          .replace('{Y}', coord.y),
-      tileSize: new google.maps.Size(256, 256),
-    });
-    map.overlayMapTypes.insertAt(i, tileOverlay);
-  }
+
   return map;
 }
-
-const TILE_URLS = [
-  'https://stormscdn.ngs.noaa.gov/20170827-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170828a-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170828b-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170829a-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170829b-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170830-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170831a-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170831b-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170901a-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170901b-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170901c-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170902a-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170902b-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170902c-rgb/{Z}/{X}/{Y}',
-  'https://stormscdn.ngs.noaa.gov/20170903-rgb/{Z}/{X}/{Y}',
-];

--- a/docs/create_map.js
+++ b/docs/create_map.js
@@ -92,6 +92,5 @@ function createMap(firebasePromise) {
     });
     map.fitBounds(bounds);
   });
-
   return map;
 }

--- a/docs/create_map.js
+++ b/docs/create_map.js
@@ -92,5 +92,33 @@ function createMap(firebasePromise) {
     });
     map.fitBounds(bounds);
   });
+  for (let i = 0; i < TILE_URLS.length; i++) {
+    const tileUrl = TILE_URLS[i];
+    const tileOverlay = new google.maps.ImageMapType({
+      getTileUrl: (coord, zoom) => tileUrl.replace('{Z}', zoom)
+          .replace('{X}', coord.x)
+          .replace('{Y}', coord.y),
+      tileSize: new google.maps.Size(256, 256),
+    });
+    map.overlayMapTypes.insertAt(i, tileOverlay);
+  }
   return map;
 }
+
+const TILE_URLS = [
+  'https://stormscdn.ngs.noaa.gov/20170827-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170828a-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170828b-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170829a-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170829b-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170830-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170831a-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170831b-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170901a-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170901b-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170901c-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170902a-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170902b-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170902c-rgb/{Z}/{X}/{Y}',
+  'https://stormscdn.ngs.noaa.gov/20170903-rgb/{Z}/{X}/{Y}',
+];

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -32,21 +32,21 @@ const styleFunctions = new Map();
 
 /**
  * Returns style function for this FeatureCollection ee asset.
- * @param {String} assetName asset path
+ * @param {number} index asset index
  * @return {Function}
  */
-function getStyleFunction(assetName) {
-  return styleFunctions.has(assetName) ? styleFunctions.get(assetName) :
-                                         createStyleFunction(assetName);
+function getStyleFunction(index) {
+  return styleFunctions.has(index) ? styleFunctions.get(index) :
+                                         createStyleFunction(index);
 }
 
 /**
  * Creates and stores the style function for a FeatureCollection ee asset.
- * @param {String} assetName asset path
+ * @param {number} index asset path
  * @return {Function}
  */
-function createStyleFunction(assetName) {
-  const colorFunctionProperties = firebaseLayers[assetName]['color-function'];
+function createStyleFunction(index) {
+  const colorFunctionProperties = firebaseLayers[index]['color-function'];
   let styleFunction;
   if (colorFunctionProperties['single-color']) {
     const color = colorMap.get(colorFunctionProperties['single-color']);
@@ -63,7 +63,7 @@ function createStyleFunction(assetName) {
         createDiscreteFunction(
             field, opacity, colorFunctionProperties['colors']);
   }
-  styleFunctions.set(assetName, styleFunction);
+  styleFunctions.set(index, styleFunction);
   return styleFunction;
 }
 

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -37,7 +37,7 @@ const styleFunctions = new Map();
  */
 function getStyleFunction(index) {
   return styleFunctions.has(index) ? styleFunctions.get(index) :
-                                         createStyleFunction(index);
+                                     createStyleFunction(index);
 }
 
 /**

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -22,7 +22,6 @@ const LayerType = {
   FEATURE_COLLECTION: 1,
   IMAGE: 2,
   IMAGE_COLLECTION: 3,
-  MAP_TILES: 4,
 };
 Object.freeze(LayerType);
 

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -22,6 +22,7 @@ const LayerType = {
   FEATURE_COLLECTION: 1,
   IMAGE: 2,
   IMAGE_COLLECTION: 3,
+  MAP_TILES: 4,
 };
 Object.freeze(LayerType);
 

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -1,21 +1,8 @@
 export {
   colorMap,
-  firebaseLayers,
-  getStyleFunction,
-  initializeFirebaseLayers,
+  createStyleFunction,
   LayerType,
 };
-
-// The collection of firebase layers.
-let firebaseLayers;
-
-/**
- * Initialize the var once we receive the layers from firebase.
- * @param {Object} layers
- */
-function initializeFirebaseLayers(layers) {
-  firebaseLayers = layers;
-}
 
 const LayerType = {
   FEATURE: 0,
@@ -25,27 +12,13 @@ const LayerType = {
 };
 Object.freeze(LayerType);
 
-// Map of FeatureCollection ee asset path to style function so we don't need to
-// recreate it every time.
-const styleFunctions = new Map();
-
 /**
- * Returns style function for this FeatureCollection ee asset.
- * @param {number} index asset index
+ * Creates the style function for the given properties. Caller should cache to
+ * avoid recomputing every time.
+ * @param {Object} colorFunctionProperties
  * @return {Function}
  */
-function getStyleFunction(index) {
-  return styleFunctions.has(index) ? styleFunctions.get(index) :
-                                     createStyleFunction(index);
-}
-
-/**
- * Creates and stores the style function for a FeatureCollection ee asset.
- * @param {number} index asset path
- * @return {Function}
- */
-function createStyleFunction(index) {
-  const colorFunctionProperties = firebaseLayers[index]['color-function'];
+function createStyleFunction(colorFunctionProperties) {
   let styleFunction;
   if (colorFunctionProperties['single-color']) {
     const color = colorMap.get(colorFunctionProperties['single-color']);
@@ -62,7 +35,6 @@ function createStyleFunction(index) {
         createDiscreteFunction(
             field, opacity, colorFunctionProperties['colors']);
   }
-  styleFunctions.set(index, styleFunction);
   return styleFunction;
 }
 

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -169,8 +169,8 @@ function addImageLayer(map, imageAsset, layer) {
     visParams: imgStyles,
     callback: (layerId, failure) => {
       if (layerId) {
-        layerArray[index].overlay = addLayerFromId(map, layerId, index,
-            layerArray[index].displayed);
+        layerArray[index].overlay =
+            addLayerFromId(map, layerId, index, layerArray[index].displayed);
       } else {
         // TODO: if there's an error, disable checkbox, add tests for this.
         layerArray[index].displayed = false;

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -150,8 +150,7 @@ function addImageLayer(map, imageAsset, layer) {
     callback: (layerId, failure) => {
       if (layerId) {
         layerArray[index].overlay = addLayerFromId(
-            map, layer['ee-name'], layerId, index,
-            layerArray[index].displayed);
+            map, layer['ee-name'], layerId, index, layerArray[index].displayed);
       } else {
         // TODO: if there's an error, disable checkbox, add tests for this.
         layerArray[index].displayed = false;

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -6,10 +6,10 @@ import {addLoadingElement, loadingElementFinished} from './loading.js';
 import {convertEeObjectToPromise} from './map_util.js';
 
 export {
-  DeckParams,
   addLayer,
   addNullLayer,
   addScoreLayer,
+  DeckParams,
   redrawLayers,
   removeScoreLayer,
   scoreLayerName,

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -90,7 +90,7 @@ function toggleLayerOn(layer, map) {
   const layerMapValue = mapOverlayArray[index];
   layerMapValue.displayed = true;
   if (layerMapValue.data) {
-    addLayerFromFeatures(layer, index);
+    addLayerFromFeatures(layerMapValue, index);
   } else {
     addLayer(layer, map);
   }

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -357,8 +357,8 @@ function redrawLayers() {
  */
 function processLayerArray() {
   const filteredArray = deckGlArray.filter(valIsNotNull);
-  if (deckGlArray['score']) {
-    filteredArray.push(deckGlArray['score']);
+  if (deckGlArray[scoreLayerName]) {
+    filteredArray.push(deckGlArray[scoreLayerName]);
   }
   return filteredArray;
 }

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -169,8 +169,8 @@ function addImageLayer(map, imageAsset, layer) {
     visParams: imgStyles,
     callback: (layerId, failure) => {
       if (layerId) {
-        layerArray[index].overlay = addLayerFromId(
-            map, layer['ee-name'], layerId, index, layerArray[index].displayed);
+        layerArray[index].overlay = addLayerFromId(map, layerId, index,
+            layerArray[index].displayed);
       } else {
         // TODO: if there's an error, disable checkbox, add tests for this.
         layerArray[index].displayed = false;
@@ -186,13 +186,12 @@ function addImageLayer(map, imageAsset, layer) {
  * callbacks or similar to that overlay.
  *
  * @param {google.maps.Map} map
- * @param {string} layerName
  * @param {Object} layerId
  * @param {number} index
  * @param {boolean} displayed
  * @return {ee.MapLayerOverlay}
  */
-function addLayerFromId(map, layerName, layerId, index, displayed) {
+function addLayerFromId(map, layerId, index, displayed) {
   const overlay = new ee.MapLayerOverlay(
       'https://earthengine.googleapis.com/map', layerId.mapid, layerId.token,
       {});

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -22,11 +22,12 @@ export {deckGlArray, DisplayedLayerData, layerArray};
 const scoreLayerName = 'score';
 
 /**
- * All map overlay layers. Data is lazily generated i.e. layers that
- * don't display by default will have an entry in this map, but the
- * DisplayedLayerData will have a null data/overlay field (depending on whether
- * or not we render it with deck) until we fetch the data when
- * the user wants to display it. Score layer gets its own special 'score' index.
+ * All map overlay layers. Data is lazily generated: layers that don't display
+ * by default will have an entry in this map, but the DisplayedLayerData will
+ * have a null data/overlay field (depending on whether or not we render it with
+ * deck) until we fetch the data when the user wants to display it. Score layer
+ * gets its own special 'score' index, exploiting Javascript's tolerance for
+ * non-numerical indices on arrays.
  */
 const layerArray = [];
 

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -6,6 +6,7 @@ import {addLoadingElement, loadingElementFinished} from './loading.js';
 import {convertEeObjectToPromise} from './map_util.js';
 
 export {
+  DeckParams,
   addLayer,
   addNullLayer,
   addScoreLayer,

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -87,10 +87,10 @@ function setMapToDrawLayersOn(map) {
  */
 function toggleLayerOn(layer, map) {
   const index = layer['index'];
-  const currentLayerMapValue = mapOverlayArray[index];
-  currentLayerMapValue.displayed = true;
-  if (currentLayerMapValue.data) {
-    addLayerFromFeatures(currentLayerMapValue, index);
+  const layerMapValue = mapOverlayArray[index];
+  layerMapValue.displayed = true;
+  if (layerMapValue.data) {
+    addLayerFromFeatures(layer, index);
   } else {
     addLayer(layer, map);
   }
@@ -254,11 +254,11 @@ function addLayer(layer, map) {
       addLayerFromGeoJsonPromise(
           convertEeObjectToPromise(
               ee.FeatureCollection(layerName).toList(maxNumFeaturesExpected)),
-          layer['ee-name'], index);
+          layer['ee-name'], layer['index']);
       break;
     default:
       createError('parsing layer type during add')(
-          '[' + index + ']: ' + layer + ' not recognized layer type');
+          '[' + layer['index'] + ']: ' + layer['asset-name'] + ' not recognized layer type');
   }
 }
 
@@ -296,7 +296,7 @@ function addLayerFromGeoJsonPromise(featuresPromise, layerName, index) {
   featuresPromise
       .then((features) => {
         layerMapValue.data = features;
-        addLayerFromFeatures(layerMapValue, layerName);
+        addLayerFromFeatures(layerMapValue, index);
         loadingElementFinished(mapContainerId);
       })
       .catch(createError('Error rendering ' + layerName));

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -8,7 +8,7 @@ import {convertEeObjectToPromise} from './map_util.js';
 export {
   addLayer,
   addNullLayer,
-    addScoreLayer,
+  addScoreLayer,
   redrawLayers,
   removeScoreLayer,
   scoreLayerName,
@@ -49,8 +49,8 @@ let deckGlOverlay;
 
 /**
  * Values of layerArray. In addition to basic data from constructor, will
- * have a data attribute for deck layers, and an overlay attribute for image/other
- *  layers.
+ * have a data attribute for deck layers, and an overlay attribute for
+ * image/other layers.
  */
 class DisplayedLayerData {
   /**

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -18,7 +18,7 @@ export {
   toggleLayerOn,
 };
 // @VisibleForTesting
-export {deckGlArray, LayerDisplayData, layerArray};
+export {deckGlArray, layerArray, LayerDisplayData};
 
 const scoreLayerName = 'score';
 

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -323,7 +323,7 @@ function addLayerFromGeoJsonPromise(featuresPromise, deckParams, index) {
         addLayerFromFeatures(layerMapValue, index);
         loadingElementFinished(mapContainerId);
       })
-      .catch(createError('Error rendering layer #' + index));
+      .catch(createError('Error rendering ' + deckParams.deckId));
 }
 
 /**

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -36,7 +36,8 @@ const layerArray = [];
  * in redrawLayers() (after filtering out absent elements).
  *
  * Contains one GeoJsonLayer per DisplayedLayerData with non-null data attribute
- * (from layerArray), ordered by DisplayedLayerData.index.
+ * (from layerArray), ordered by DisplayedLayerData.index. Same trick as with
+ * layerArray for score index.
  *
  * @type {Array<deck.GeoJsonLayer>}
  */
@@ -83,7 +84,7 @@ class DeckParams {
    * @constructor
    *
    * @param {!string} deckId
-   * @param {Object} colorFunctionProperties Parameters used to calculate style
+   * @param {Object} colorFunctionProperties Parameters used to calculate color
    *     function
    */
   constructor(deckId, colorFunctionProperties) {
@@ -111,7 +112,7 @@ function setMapToDrawLayersOn(map) {
 /**
  * Toggles on displaying an asset on the map.
  *
- * @param {Object} layer
+ * @param {Object} layer Data for layer coming from Firestore
  * @param {google.maps.Map} map main map
  */
 function toggleLayerOn(layer, map) {
@@ -152,7 +153,7 @@ function toggleLayerOff(index, map) {
  *
  * @param {google.maps.Map} map
  * @param {ee.Element} imageAsset
- * @param {Object} layer
+ * @param {Object} layer Data for layer coming from Firestore
  */
 function addImageLayer(map, imageAsset, layer) {
   const imgStyles = layer['vis-params'];

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -81,7 +81,8 @@ class DeckParams {
    * @constructor
    *
    * @param {!string} deckId
-   * @param {Object} colorFunctionProperties Parameters used to calculate style function
+   * @param {Object} colorFunctionProperties Parameters used to calculate style
+   *     function
    */
   constructor(deckId, colorFunctionProperties) {
     /** @const */
@@ -235,7 +236,8 @@ function addLayerFromId(map, layerName, layerId, index, displayed) {
 function addLayerFromFeatures(layerMapValue, index) {
   const deckParams = layerMapValue.deckParams;
   if (!deckParams.colorFunction) {
-    deckParams.colorFunction = createStyleFunction(deckParams.colorFunctionProperties);
+    deckParams.colorFunction =
+        createStyleFunction(deckParams.colorFunctionProperties);
   }
   deckGlArray[index] = new deck.GeoJsonLayer({
     id: layerMapValue.deckParams.deckId,
@@ -348,8 +350,12 @@ function addLayerFromGeoJsonPromise(featuresPromise, layer) {
  */
 function addNullLayer(layer) {
   const assetType = layer['asset-type'];
-  layerArray[layer['index']] = new DisplayedLayerData(assetType === LayerType.FEATURE_COLLECTION || assetType === LayerType.FEATURE ?
-      DeckParams.fromLayer(layer) : null, false);
+  layerArray[layer['index']] = new DisplayedLayerData(
+      assetType === LayerType.FEATURE_COLLECTION ||
+              assetType === LayerType.FEATURE ?
+          DeckParams.fromLayer(layer) :
+          null,
+      false);
 }
 
 /**

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -17,15 +17,15 @@ export {
   toggleLayerOn,
 };
 // @VisibleForTesting
-export {deckGlArray, mapOverlayArray, LayerMapValue};
+export {deckGlArray, LayerMapValue, mapOverlayArray};
 
 const scoreLayerName = 'score';
 
 /**
- * All map overlay layers. Data is lazily generated i.e. pre-known layers that don't display by default will have an
- * entry in this map, but the LayerMapValue will have a null data field until we
- * fetch the data when the user wants to display it. Score layer gets its own
- * special 'score' index.
+ * All map overlay layers. Data is lazily generated i.e. pre-known layers that
+ * don't display by default will have an entry in this map, but the
+ * LayerMapValue will have a null data field until we fetch the data when the
+ * user wants to display it. Score layer gets its own special 'score' index.
  */
 const mapOverlayArray = [];
 
@@ -128,8 +128,8 @@ function getColorOfFeature(feature) {
  * to avoid blocking on the result. This also populates mapOverlayArray.
  *
  * This should only be called once per asset when its overlay is initialized
- * for the first time. After the overlay is non-null in mapOverlayArray, any displaying
- * should be able to call {@code map.overlayMapTypes.setAt(...)}.
+ * for the first time. After the overlay is non-null in mapOverlayArray, any
+ * displaying should be able to call {@code map.overlayMapTypes.setAt(...)}.
  *
  * @param {google.maps.Map} map
  * @param {ee.Element} imageAsset
@@ -147,7 +147,8 @@ function addImageLayer(map, imageAsset, layer) {
     callback: (layerId, failure) => {
       if (layerId) {
         mapOverlayArray[index].overlay = addLayerFromId(
-            map, layer['ee-name'], layerId, index, mapOverlayArray[index].displayed);
+            map, layer['ee-name'], layerId, index,
+            mapOverlayArray[index].displayed);
       } else {
         // TODO: if there's an error, disable checkbox, add tests for this.
         mapOverlayArray[index].displayed = false;
@@ -216,7 +217,7 @@ function addLayerFromFeatures(layerMapValue, index) {
     // automatically color the features, but it doesn't appear to work:
     // https://deck.gl/#/documentation/deckgl-api-reference/layers/geojson-layer?section=getelevation-function-number-optional-transition-enabled
     getFillColor: index === scoreLayerName ? getColorOfFeature :
-                                                 getStyleFunction(index),
+                                             getStyleFunction(index),
     visible: layerMapValue.displayed,
   });
   redrawLayers();
@@ -258,7 +259,8 @@ function addLayer(layer, map) {
       break;
     default:
       createError('parsing layer type during add')(
-          '[' + layer['index'] + ']: ' + layer['asset-name'] + ' not recognized layer type');
+          '[' + layer['index'] + ']: ' + layer['asset-name'] +
+          ' not recognized layer type');
   }
 }
 
@@ -279,7 +281,8 @@ function processImageCollection(layerName) {
  populates mapOverlayArray.
  *
  * This should only be called once per asset when its data is initialized
- * for the first time. After the data is non-null in mapOverlayArray, any displaying
+ * for the first time. After the data is non-null in mapOverlayArray, any
+ displaying
  * should be able to set its visibility and redraw the layers.
  *
  * @param {Promise<Array<GeoJson>>}featuresPromise
@@ -303,14 +306,19 @@ function addLayerFromGeoJsonPromise(featuresPromise, layerName, index) {
 }
 
 /**
- * Adds an entry to mapOverlayArray when we haven't actually gotten the data yet.
- * Useful for layers that we don't want to display by default.
+ * Adds an entry to mapOverlayArray when we haven't actually gotten the data
+ * yet. Useful for layers that we don't want to display by default.
  *
  * @param {Object} layer
  */
 function addNullLayer(layer) {
   const assetType = layer['asset-type'];
-  mapOverlayArray[layer['index']] = new LayerMapValue(assetType === LayerType.FEATURE || assetType === LayerType.FEATURE_COLLECTION ? layer['ee-name'] : null, false);
+  mapOverlayArray[layer['index']] = new LayerMapValue(
+      assetType === LayerType.FEATURE ||
+              assetType === LayerType.FEATURE_COLLECTION ?
+          layer['ee-name'] :
+          null,
+      false);
 }
 
 /**
@@ -322,7 +330,8 @@ function redrawLayers() {
 }
 
 /**
- * Filters out null elements and appends element at 'score' to end of filtered array.
+ * Filters out null elements and appends element at 'score' to end of filtered
+ * array.
  * @return {deck.GeoJsonLayer[]}
  */
 function processLayerArray() {
@@ -350,8 +359,7 @@ function valIsNotNull(val) {
  * @param {number|string} index
  * @param {google.maps.Map} map main map
  */
-function removeLayer(index, map) {
-}
+function removeLayer(index, map) {}
 
 /**
  * Removes the score layer before a parameter update. Must actually be

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -24,8 +24,8 @@ const scoreLayerName = 'score';
 /**
  * All map overlay layers. Data is lazily generated i.e. pre-known layers that
  * don't display by default will have an entry in this map, but the
- * DisplayedLayerData will have a null data field until we fetch the data when the
- * user wants to display it. Score layer gets its own special 'score' index.
+ * DisplayedLayerData will have a null data field until we fetch the data when
+ * the user wants to display it. Score layer gets its own special 'score' index.
  */
 const mapOverlayArray = [];
 

--- a/docs/run.js
+++ b/docs/run.js
@@ -109,7 +109,7 @@ function createLayerCheckboxes(map) {
       .forEach(
           (layerName) => createNewCheckboxForLayer(layerName, sidebarDiv, map));
   createCheckboxForUserFeatures(sidebarDiv);
-  createNewCheckboxForLayer(scoreLayerName, sidebarDiv, map);
+  createNewCheckboxForLayer({'display-name': scoreLayerName, index: scoreLayerName, 'display-on-load': true}, sidebarDiv, map);
 }
 
 /**
@@ -145,23 +145,22 @@ function createNewCheckbox(name, displayName, parentDiv) {
  * Creates a new checkbox for the given layer. The only layer not recorded in
  * firebase should be the score layer.
  *
- * @param {String} layerName
+ * @param {Object} layer
  * @param {Element} parentDiv
  * @param {google.maps.Map} map main map
  */
-function createNewCheckboxForLayer(layerName, parentDiv, map) {
-  const properties = firebaseLayers[layerName];
+function createNewCheckboxForLayer(layer, parentDiv, map) {
+  const index = layer['index'];
   const newBox = createNewCheckbox(
-      layerName, properties ? properties['display-name'] : layerName,
-      parentDiv);
-  if (properties && !properties['display-on-load']) {
+      index, layer['display-name'], parentDiv);
+  if (!layer['display-on-load']) {
     newBox.checked = false;
   }
   newBox.onclick = () => {
     if (newBox.checked) {
-      toggleLayerOn(layerName, map);
+      toggleLayerOn(layer, map);
     } else {
-      toggleLayerOff(layerName, map);
+      toggleLayerOff(index, map);
     }
   };
 }
@@ -179,24 +178,25 @@ function createCheckboxForUserFeatures(parentDiv) {
 
 /**
  * Runs through layers map. For those that we auto-display on page load, creates
- * overlays and displays. Also populates the layerMap.
+ * overlays and displays. Also populates the mapOverlayArray.
  *
  * @param {google.maps.Map} map main map
  */
 function addLayers(map) {
-  Object.keys(firebaseLayers).forEach((layer) => {
-    const properties = firebaseLayers[layer];
+  for (let i = 0; i < firebaseLayers.length; i++) {
+    const properties = firebaseLayers[i];
+    properties['index'] = i;
     if (properties['display-on-load']) {
-      addLayer(layer, properties['index'], map);
+      addLayer(properties, map);
     } else {
-      addNullLayer(layer, properties['index']);
+      addNullLayer(properties);
     }
-  });
+  }
   createLayerCheckboxes(map);
 }
 
 /**
- * Creates and displays overlay for score + adds layerMap entry. The score
+ * Creates and displays overlay for score + adds mapOverlayArray entry. The score
  * layer sits at the end of all the layers. Having it last ensures it displays
  * on top.
  *

--- a/docs/run.js
+++ b/docs/run.js
@@ -43,7 +43,7 @@ function run(map, firebaseAuthPromise, disasterMetadataPromise) {
       initialPovertyWeight);
   processUserRegions(map, firebaseAuthPromise);
   disasterMetadataPromise.then((doc) => {
-    initializeFirebaseLayers(doc.data().layers);
+    initializeFirebaseLayers(doc.data().layerArray);
     addLayers(map);
   });
 }
@@ -96,20 +96,6 @@ function createAndDisplayJoinedData(
               table, tableData);
         });
       });
-}
-
-/**
- * Creates checkboxes for all known layers (including user features and score).
- *
- * @param {google.maps.Map} map main map
- */
-function createLayerCheckboxes(map) {
-  const sidebarDiv = document.getElementById(sidebarDatasetsId);
-  Object.keys(firebaseLayers)
-      .forEach(
-          (layerName) => createNewCheckboxForLayer(layerName, sidebarDiv, map));
-  createCheckboxForUserFeatures(sidebarDiv);
-  createNewCheckboxForLayer({'display-name': scoreLayerName, index: scoreLayerName, 'display-on-load': true}, sidebarDiv, map);
 }
 
 /**
@@ -178,11 +164,12 @@ function createCheckboxForUserFeatures(parentDiv) {
 
 /**
  * Runs through layers map. For those that we auto-display on page load, creates
- * overlays and displays. Also populates the mapOverlayArray.
+ * overlays and displays. Also creates checkboxes.
  *
  * @param {google.maps.Map} map main map
  */
 function addLayers(map) {
+  const sidebarDiv = document.getElementById(sidebarDatasetsId);
   for (let i = 0; i < firebaseLayers.length; i++) {
     const properties = firebaseLayers[i];
     properties['index'] = i;
@@ -191,8 +178,10 @@ function addLayers(map) {
     } else {
       addNullLayer(properties);
     }
+    createNewCheckboxForLayer(properties, sidebarDiv, map);
   }
-  createLayerCheckboxes(map);
+  createCheckboxForUserFeatures(sidebarDiv);
+  createNewCheckboxForLayer({'display-name': scoreLayerName, index: scoreLayerName, 'display-on-load': true}, sidebarDiv, map);
 }
 
 /**
@@ -203,7 +192,7 @@ function addLayers(map) {
  * @param {Promise<Array<GeoJson>>} layer
  */
 function addScoreLayer(layer) {
-  addLayerFromGeoJsonPromise(layer, scoreLayerName, 'lastElement');
+  addLayerFromGeoJsonPromise(layer, scoreLayerName, scoreLayerName);
   // Checkbox may not exist yet if layer metadata not retrieved yet. The
   // checkbox creation will check the box by default. We check it here in case
   // it was unchecked by the user, and this is coming from a weight/threshold

--- a/docs/run.js
+++ b/docs/run.js
@@ -128,7 +128,7 @@ function createNewCheckbox(name, displayName, parentDiv) {
  * Creates a new checkbox for the given layer. The only layer not recorded in
  * firebase should be the score layer.
  *
- * @param {Object} layer
+ * @param {Object} layer Data for layer coming from Firestore
  * @param {Element} parentDiv
  * @param {google.maps.Map} map main map
  */

--- a/docs/run.js
+++ b/docs/run.js
@@ -137,8 +137,7 @@ function createNewCheckbox(name, displayName, parentDiv) {
  */
 function createNewCheckboxForLayer(layer, parentDiv, map) {
   const index = layer['index'];
-  const newBox = createNewCheckbox(
-      index, layer['display-name'], parentDiv);
+  const newBox = createNewCheckbox(index, layer['display-name'], parentDiv);
   if (!layer['display-on-load']) {
     newBox.checked = false;
   }
@@ -181,13 +180,19 @@ function addLayers(map) {
     createNewCheckboxForLayer(properties, sidebarDiv, map);
   }
   createCheckboxForUserFeatures(sidebarDiv);
-  createNewCheckboxForLayer({'display-name': scoreLayerName, index: scoreLayerName, 'display-on-load': true}, sidebarDiv, map);
+  createNewCheckboxForLayer(
+      {
+        'display-name': scoreLayerName,
+        index: scoreLayerName,
+        'display-on-load': true
+      },
+      sidebarDiv, map);
 }
 
 /**
- * Creates and displays overlay for score + adds mapOverlayArray entry. The score
- * layer sits at the end of all the layers. Having it last ensures it displays
- * on top.
+ * Creates and displays overlay for score + adds mapOverlayArray entry. The
+ * score layer sits at the end of all the layers. Having it last ensures it
+ * displays on top.
  *
  * @param {Promise<Array<GeoJson>>} layer
  */

--- a/docs/run.js
+++ b/docs/run.js
@@ -1,7 +1,6 @@
 import {clickFeature, selectHighlightedFeatures} from './click_feature.js';
 import {sidebarDatasetsId, tableContainerId} from './dom_constants.js';
 import {drawTable} from './draw_table.js';
-import {firebaseLayers, initializeFirebaseLayers} from './firebase_layers.js';
 import {highlightFeatures} from './highlight_features.js';
 import {addLayer, addLayerFromGeoJsonPromise, addNullLayer, scoreLayerName, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from './layer_util.js';
 import {addLoadingElement, loadingElementFinished} from './loading.js';

--- a/docs/run.js
+++ b/docs/run.js
@@ -2,7 +2,7 @@ import {clickFeature, selectHighlightedFeatures} from './click_feature.js';
 import {sidebarDatasetsId, tableContainerId} from './dom_constants.js';
 import {drawTable} from './draw_table.js';
 import {highlightFeatures} from './highlight_features.js';
-import {addLayer, addLayerFromGeoJsonPromise, addNullLayer, scoreLayerName, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from './layer_util.js';
+import {addLayer, addNullLayer, addScoreLayer, scoreLayerName, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from './layer_util.js';
 import {addLoadingElement, loadingElementFinished} from './loading.js';
 import {convertEeObjectToPromise} from './map_util.js';
 import {processUserRegions} from './polygon_draw.js';
@@ -73,6 +73,7 @@ function createAndDisplayJoinedData(
       snapAndDamagePromise, scalingFactor, povertyThreshold, damageThreshold,
       povertyWeight);
   addScoreLayer(processedData);
+  maybeCheckScoreCheckbox();
   drawTable(
       processedData, (features) => highlightFeatures(features, map, true),
       (table, tableData) => {
@@ -191,18 +192,11 @@ function addLayers(map, firebaseLayers) {
 }
 
 /**
- * Creates and displays overlay for score + adds layerArray entry. The
- * score layer sits at the end of all the layers. Having it last ensures it
- * displays on top.
- *
- * @param {Promise<Array<GeoJson>>} layer
+ * Checkbox may not exist yet if layer metadata not retrieved yet. The checkbox
+ * creation will check the box by default. This manually checks it in case it
+ * was unchecked by the user, and this is coming from a weight/threshold update.
  */
-function addScoreLayer(layer) {
-  addLayerFromGeoJsonPromise(layer, scoreLayerName);
-  // Checkbox may not exist yet if layer metadata not retrieved yet. The
-  // checkbox creation will check the box by default. We check it here in case
-  // it was unchecked by the user, and this is coming from a weight/threshold
-  // update.
+function maybeCheckScoreCheckbox() {
   const checkbox = document.getElementById(getCheckBoxId(scoreLayerName));
   if (checkbox) {
     checkbox.checked = true;

--- a/docs/run.js
+++ b/docs/run.js
@@ -190,7 +190,7 @@ function addLayers(map) {
 }
 
 /**
- * Creates and displays overlay for score + adds mapOverlayArray entry. The
+ * Creates and displays overlay for score + adds layerArray entry. The
  * score layer sits at the end of all the layers. Having it last ensures it
  * displays on top.
  *

--- a/docs/run.js
+++ b/docs/run.js
@@ -41,9 +41,7 @@ function run(map, firebaseAuthPromise, disasterMetadataPromise) {
       map, initialPovertyThreshold, initialDamageThreshold,
       initialPovertyWeight);
   processUserRegions(map, firebaseAuthPromise);
-  disasterMetadataPromise.then((doc) => {
-    addLayers(map, doc.data().layerArray);
-  });
+  disasterMetadataPromise.then((doc) => addLayers(map, doc.data().layerArray));
 }
 
 let mapSelectListener = null;

--- a/docs/run.js
+++ b/docs/run.js
@@ -183,8 +183,8 @@ function addLayers(map) {
   createNewCheckboxForLayer(
       {
         'display-name': scoreLayerName,
-        index: scoreLayerName,
-        'display-on-load': true
+        'index': scoreLayerName,
+        'display-on-load': true,
       },
       sidebarDiv, map);
 }

--- a/docs/run.js
+++ b/docs/run.js
@@ -161,13 +161,13 @@ function createCheckboxForUserFeatures(parentDiv) {
 }
 
 /**
- * Runs through layers list. For those that we auto-display on page load, creates
- * overlays and displays. Also creates checkboxes.
+ * Runs through layers list. For those that we auto-display on page load,
+ * creates overlays and displays. Also creates checkboxes.
  *
  * @param {google.maps.Map} map main map
- * @param {Array<Object>} firebaseLayers layer metadata retrieved from Firestore,
- *     ordered by the order they should be drawn on the map (higher indices are
- *     displayed over lower ones)
+ * @param {Array<Object>} firebaseLayers layer metadata retrieved from
+ *     Firestore, ordered by the order they should be drawn on the map (higher
+ *     indices are displayed over lower ones)
  */
 function addLayers(map, firebaseLayers) {
   const sidebarDiv = document.getElementById(sidebarDatasetsId);

--- a/docs/run.js
+++ b/docs/run.js
@@ -43,8 +43,7 @@ function run(map, firebaseAuthPromise, disasterMetadataPromise) {
       initialPovertyWeight);
   processUserRegions(map, firebaseAuthPromise);
   disasterMetadataPromise.then((doc) => {
-    initializeFirebaseLayers(doc.data().layerArray);
-    addLayers(map);
+    addLayers(map, doc.data().layerArray);
   });
 }
 
@@ -162,12 +161,15 @@ function createCheckboxForUserFeatures(parentDiv) {
 }
 
 /**
- * Runs through layers map. For those that we auto-display on page load, creates
+ * Runs through layers list. For those that we auto-display on page load, creates
  * overlays and displays. Also creates checkboxes.
  *
  * @param {google.maps.Map} map main map
+ * @param {Array<Object>} firebaseLayers layer metadata retrieved from Firestore,
+ *     ordered by the order they should be drawn on the map (higher indices are
+ *     displayed over lower ones)
  */
-function addLayers(map) {
+function addLayers(map, firebaseLayers) {
   const sidebarDiv = document.getElementById(sidebarDatasetsId);
   for (let i = 0; i < firebaseLayers.length; i++) {
     const properties = firebaseLayers[i];
@@ -197,7 +199,7 @@ function addLayers(map) {
  * @param {Promise<Array<GeoJson>>} layer
  */
 function addScoreLayer(layer) {
-  addLayerFromGeoJsonPromise(layer, scoreLayerName, scoreLayerName);
+  addLayerFromGeoJsonPromise(layer, scoreLayerName);
   // Checkbox may not exist yet if layer metadata not retrieved yet. The
   // checkbox creation will check the box by default. We check it here in case
   // it was unchecked by the user, and this is coming from a weight/threshold


### PR DESCRIPTION
Using asset names like this has a few disadvantages:
1. Not all assets have obvious names (map tiles, for instance).
2. We might want to treat the same FeatureCollection as two different layers in the future (say, pull a different property from it for each layer).
3. A fundamental property we want, that assets have unique indices, is not enforced by design in our data structure.
4. Having a global map (needed for looking up asset names) is a code smell.

Instead, using indices everywhere we can. This lets us get rid of the global firebaseLayers object entirely, which is nice. Also this spurs some clean-ups/restructurings in layer_util.js.

We need to pass the actual Firestore data object into toggleLayerOn, which makes me a little sad, but it's ok. (I think in the future we might want to render all layers eagerly, even if we don't display them: I think that Julie may have suggested this a while ago, and I pushed back? But I'm coming around, assuming we can handle the stress it would put on our local page.)

I've populated Firestore with the new data format.
