### PR TITLE
Improve layer_util: cache EE results, start loading indicator earlier

### DIFF
--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -250,11 +250,10 @@ describe('Unit test for toggleLayerOn', () => {
 
     // Release evaluation.
     latch.release();
-    cy.wrap(promise)
-        .then(() => {
-          expect(loadingFinishedStub).to.be.calledOnce;
-          expect(map.overlayMapTypes.getAt(3)).to.not.be.null;
-        });
+    cy.wrap(promise).then(() => {
+      expect(loadingFinishedStub).to.be.calledOnce;
+      expect(map.overlayMapTypes.getAt(3)).to.not.be.null;
+    });
   });
 
   it('tests score layer and deck management', () => {
@@ -356,8 +355,8 @@ function createGoogleMap() {
 }
 
 /**
- * Stubs out the ee.Image constructor to use a dummy image and returns a CallbackLatch
- * that will release the image's #getMap callback.
+ * Stubs out the ee.Image constructor to use a dummy image and returns a
+ * CallbackLatch that will release the image's #getMap callback.
  * @return {CallbackLatch}
  */
 function stubOutImageAndGetLatch() {

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -252,7 +252,7 @@ describe('Unit test for toggleLayerOn', () => {
     // Still before evaluation finishes, toggle back on.
     const togglePromise = toggleLayerOn(mockFirebaseLayers[3], map);
     expect(togglePromise).equals(promise);
-    // Overlay list now has null instead of undefined, but no biggie.
+    // Still null.
     expect(map.overlayMapTypes.getAt(3)).to.be.null;
 
     // Loading can't finish until EE evaluation finishes, which we've frozen.
@@ -272,9 +272,7 @@ describe('Unit test for toggleLayerOn', () => {
     setMapToDrawLayersOn(null);
     const overlaySpy = cy.spy(deckSpy.returnValues[0], 'setProps');
     let numCalls = 0;
-    /**
-     * @return {array<deck.GeoJsonLayer>}
-     */
+    /** @return {array<deck.GeoJsonLayer>} */
     function getLatestLayer() {
       return overlaySpy.args[numCalls++][0].layers;
     }

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -86,6 +86,7 @@ describe('Unit test for toggleLayerOn', () => {
     let callback = null;
     stubForEmptyList((callb) => callback = callb);
     const promise = toggleLayerOn(mockFirebaseLayers[2]);
+    expect(promise).to.not.be.null;
     expect(layerArray[2].displayed).to.be.true;
     expect(layerArray[2].data).to.be.undefined;
     callback(emptyList);
@@ -107,6 +108,7 @@ describe('Unit test for toggleLayerOn', () => {
     let callback = null;
     stubForEmptyList((callb) => callback = callb);
     const promise = toggleLayerOn(mockFirebaseLayers[2]);
+    expect(promise).to.not.be.null;
     expect(layerArray[2].displayed).to.be.true;
     expect(layerArray[2].data).to.be.undefined;
     toggleLayerOff(2);
@@ -129,6 +131,7 @@ describe('Unit test for toggleLayerOn', () => {
     let callback = null;
     stubForEmptyList((callb) => callback = callb);
     const promise = toggleLayerOn(mockFirebaseLayers[2]);
+    expect(promise).to.not.be.null;
     expect(layerArray[2].displayed).to.be.true;
     expect(layerArray[2].data).to.be.undefined;
     toggleLayerOff(2);
@@ -161,6 +164,7 @@ describe('Unit test for toggleLayerOn', () => {
 
     // Start the test.
     const promise = addLayer(mockFirebaseLayers[3], map);
+    expect(promise).to.not.be.null;
     expect(loadingStartedStub).to.be.calledOnce;
     // Loading can't finish until EE evaluation finishes, which we've frozen.
     expect(loadingFinishedStub).to.not.be.called;
@@ -178,7 +182,9 @@ describe('Unit test for toggleLayerOn', () => {
           expect(map.overlayMapTypes.getAt(3)).is.null;
 
           // Turn overlay back on.
-          return toggleLayerOn(mockFirebaseLayers[3], map);
+          const togglePromise = toggleLayerOn(mockFirebaseLayers[3], map);
+          expect(togglePromise).to.not.be.null;
+          return togglePromise;
         })
         .then(() => {
           const nextOverlay = map.overlayMapTypes.getAt(3);
@@ -196,6 +202,7 @@ describe('Unit test for toggleLayerOn', () => {
 
     // Start the test.
     const promise = addLayer(mockFirebaseLayers[3], map);
+    expect(promise).to.not.be.null;
     // Loading has started, but map is unaffected.
     expect(loadingStartedStub).to.be.calledOnce;
     expect(map.overlayMapTypes).to.have.length(0);
@@ -216,7 +223,9 @@ describe('Unit test for toggleLayerOn', () => {
           expect(map.overlayMapTypes.getAt(3)).to.be.null;
 
           // Turn overlay back on.
-          return toggleLayerOn(mockFirebaseLayers[3], map);
+          const togglePromise = toggleLayerOn(mockFirebaseLayers[3], map);
+          expect(togglePromise).to.not.be.null;
+          return togglePromise;
         })
         .then(() => expect(map.overlayMapTypes.getAt(3)).is.not.null);
   });
@@ -229,6 +238,7 @@ describe('Unit test for toggleLayerOn', () => {
 
     // Start the test.
     const promise = addLayer(mockFirebaseLayers[3], map);
+    expect(promise).to.not.be.null;
     // Loading has started, but map is unaffected.
     expect(loadingStartedStub).to.be.calledOnce;
     expect(map.overlayMapTypes).to.have.length(0);
@@ -273,6 +283,7 @@ describe('Unit test for toggleLayerOn', () => {
     const promise = new Promise((resolve) => resolveFunction = resolve);
 
     const scorePromise = addScoreLayer(promise);
+    expect(scorePromise).to.not.be.null;
     // Nothing happens until promise we passed in is resolved.
     expect(overlaySpy).to.not.be.called;
     const promiseResult = ['a'];

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -341,8 +341,8 @@ describe('Unit test for toggleLayerOff', () => {
 function toggleHiddenLayerOnAndAssert() {
   const promise = toggleLayerOn(mockFirebaseLayers[2], null);
   expect(promise).to.not.be.null;
-  expect(layerArray[i].displayed).to.be.true;
-  expect(layerArray[i].data).to.be.undefined;
+  expect(layerArray[2].displayed).to.be.true;
+  expect(layerArray[2].data).to.be.undefined;
   return promise;
 }
 

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -85,10 +85,8 @@ describe('Unit test for toggleLayerOn', () => {
     const emptyList = [];
     let callback = null;
     stubForEmptyList((callb) => callback = callb);
-    const promise = toggleLayerOn(mockFirebaseLayers[2]);
-    expect(promise).to.not.be.null;
-    expect(layerArray[2].displayed).to.be.true;
-    expect(layerArray[2].data).to.be.undefined;
+
+    const promise = toggleHiddenLayerOnAndAssert();
     callback(emptyList);
     cy.wrap(promise).then(() => {
       expect(layerArray[2].displayed).to.be.true;
@@ -100,17 +98,14 @@ describe('Unit test for toggleLayerOn', () => {
     });
   });
 
-  it('check hidden layer, then uncheck before list evaluation', () => {
+  it('check hidden layer, then uncheck before EE evaluation', () => {
     expect(layerArray[2].displayed).to.be.false;
     expect(layerArray[2].data).to.be.undefined;
 
     const emptyList = [];
     let callback = null;
     stubForEmptyList((callb) => callback = callb);
-    const promise = toggleLayerOn(mockFirebaseLayers[2]);
-    expect(promise).to.not.be.null;
-    expect(layerArray[2].displayed).to.be.true;
-    expect(layerArray[2].data).to.be.undefined;
+    const promise = toggleHiddenLayerOnAndAssert();
     toggleLayerOff(2);
     callback(emptyList);
     cy.wrap(promise).then(() => {
@@ -130,14 +125,9 @@ describe('Unit test for toggleLayerOn', () => {
     const emptyList = [];
     let callback = null;
     stubForEmptyList((callb) => callback = callb);
-    const promise = toggleLayerOn(mockFirebaseLayers[2]);
-    expect(promise).to.not.be.null;
-    expect(layerArray[2].displayed).to.be.true;
-    expect(layerArray[2].data).to.be.undefined;
+    const promise = toggleHiddenLayerOnAndAssert();
     toggleLayerOff(2);
-    const secondPromise = toggleLayerOn(mockFirebaseLayers[2]);
-    expect(layerArray[2].displayed).to.be.true;
-    expect(layerArray[2].data).to.be.undefined;
+    const secondPromise = toggleHiddenLayerOnAndAssert();
     expect(secondPromise).equals(promise);
     callback(emptyList);
     cy.wrap(promise).then(() => {
@@ -292,6 +282,7 @@ describe('Unit test for toggleLayerOn', () => {
         .then(() => {
           expect(overlaySpy).to.be.calledOnce;
           const firstLayers = getLatestLayer();
+          // 3=2 "mock" deck layers initialized in beforeEach, plus score layer.
           expect(firstLayers).to.have.length(3);
           const props = firstLayers[2].props;
           expect(props.data).to.eql(promiseResult);
@@ -340,6 +331,20 @@ describe('Unit test for toggleLayerOff', () => {
     expect(layerProps).to.have.property('data', mockData);
   });
 });
+
+/**
+ * Utility function to toggle hidden second layer on, when that toggle will have
+ * to do some work, return the non-null Promise that results, and make some
+ * basic assertions about the layer.
+ * @return {Promise}
+ */
+function toggleHiddenLayerOnAndAssert() {
+  const promise = toggleLayerOn(mockFirebaseLayers[2], null);
+  expect(promise).to.not.be.null;
+  expect(layerArray[i].displayed).to.be.true;
+  expect(layerArray[i].data).to.be.undefined;
+  return promise;
+}
 
 /**
  * Mocks out a FeatureCollection created for 'asset2'. Assumes that production

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -1,6 +1,7 @@
 import {LayerType} from '../../../docs/firebase_layers.js';
-import {deckGlArray, DeckParams, layerArray, LayerDisplayData, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
+import {addLayer, addScoreLayer, deckGlArray, DeckParams, layerArray, LayerDisplayData, removeScoreLayer, scoreLayerName, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from '../../../docs/layer_util.js';
 import * as loading from '../../../docs/loading';
+import {CallbackLatch} from '../../support/callback_latch';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
 const mockData = {};
@@ -33,6 +34,13 @@ const mockFirebaseLayers = [
     'color-function': colorProperties,
     'index': 2,
   },
+  {
+    'ee-name': 'image_asset',
+    'asset-type': LayerType.IMAGE,
+    'display-name': 'image',
+    'display-on-load': true,
+    'index': 3,
+  },
 ];
 
 describe('Unit test for toggleLayerOn', () => {
@@ -53,16 +61,17 @@ describe('Unit test for toggleLayerOn', () => {
         new LayerDisplayData(new DeckParams('asset2', colorProperties), false);
     // Initialize deck object in production.
     setMapToDrawLayersOn(null);
+    deckGlArray.length = 0;
     deckGlArray[0] = new deck.GeoJsonLayer({});
     deckGlArray[1] = new deck.GeoJsonLayer({});
   });
 
   it('displays a hidden but loaded layer', () => {
-    expect(layerArray[1].displayed).to.equals(false);
+    expect(layerArray[1].displayed).to.be.false;
     expect(layerArray[1].data).to.not.be.null;
 
-    toggleLayerOn(mockFirebaseLayers[1]);
-    expect(layerArray[1].displayed).to.equals(true);
+    expect(toggleLayerOn(mockFirebaseLayers[1])).to.be.null;
+    expect(layerArray[1].displayed).to.be.true;
     const layerProps = deckGlArray[1].props;
     expect(layerProps).to.have.property('id', 'asset1');
     expect(layerProps).to.have.property('visible', true);
@@ -70,19 +79,18 @@ describe('Unit test for toggleLayerOn', () => {
   });
 
   it('loads a hidden layer and displays', () => {
-    expect(layerArray[2].displayed).to.equals(false);
+    expect(layerArray[2].displayed).to.be.false;
     expect(layerArray[2].data).to.be.undefined;
 
     const emptyList = [];
     let callback = null;
     stubForEmptyList((callb) => callback = callb);
-    toggleLayerOn(mockFirebaseLayers[2]);
+    const promise = toggleLayerOn(mockFirebaseLayers[2]);
+    expect(layerArray[2].displayed).to.be.true;
+    expect(layerArray[2].data).to.be.undefined;
     callback(emptyList);
-    // Evaluate after the promise finishes by using an instant wait.
-    // TODO(janakr): Here and below, consider returning a Promise from
-    //  toggleLayerOn that can be waited on instead of this event-loop push.
-    cy.wait(0).then(() => {
-      expect(layerArray[2].displayed).to.equals(true);
+    cy.wrap(promise).then(() => {
+      expect(layerArray[2].displayed).to.be.true;
       expect(layerArray[2].data).to.not.be.null;
       const layerProps = deckGlArray[2].props;
       expect(layerProps).to.have.property('id', 'asset2');
@@ -92,19 +100,19 @@ describe('Unit test for toggleLayerOn', () => {
   });
 
   it('check hidden layer, then uncheck before list evaluation', () => {
-    expect(layerArray[2].displayed).to.equals(false);
+    expect(layerArray[2].displayed).to.be.false;
     expect(layerArray[2].data).to.be.undefined;
 
     const emptyList = [];
     let callback = null;
     stubForEmptyList((callb) => callback = callb);
-    toggleLayerOn(mockFirebaseLayers[2]);
+    const promise = toggleLayerOn(mockFirebaseLayers[2]);
+    expect(layerArray[2].displayed).to.be.true;
+    expect(layerArray[2].data).to.be.undefined;
     toggleLayerOff(2);
     callback(emptyList);
-
-    // Evaluate after the promise finishes by using an instant wait.
-    cy.wait(0).then(() => {
-      expect(layerArray[2].displayed).to.equals(false);
+    cy.wrap(promise).then(() => {
+      expect(layerArray[2].displayed).to.be.false;
       expect(layerArray[2].data).to.not.be.null;
       const layerProps = deckGlArray[2].props;
       expect(layerProps).to.have.property('id', 'asset2');
@@ -112,15 +120,132 @@ describe('Unit test for toggleLayerOn', () => {
       expect(layerProps).to.have.property('data', emptyList);
     });
   });
+
+  it('caches computed image overlay and starts loading on EE request', () => {
+    // Set test up:
+    // 1. Use a real map, since we want to see that it has an entry in its
+    // overlayMapTypes.
+    // 2. Sub in trivial image, and control the #getMap method of that image so
+    // that we can delay the callback until we're ready.
+    // 3. Stub the loading elements, so we can check when loading starts/ends.
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const map = new google.maps.Map(div, {center: {lat: 0, lng: 0}, zoom: 1});
+
+    const image = ee.Image.constant(0);
+    const oldImageFunction = ee.Image;
+    ee.Image = () => {
+      ee.Image = oldImageFunction;
+      return image;
+    };
+    const oldGetMap = image.getMap;
+    const latch = new CallbackLatch();
+    image.getMap = (props) => {
+      image.getMap = oldGetMap;
+      props.callback = latch.delayedCallback(props.callback);
+      return image.getMap(props);
+    };
+
+    const loadingStartedStub = cy.stub(loading, 'addLoadingElement');
+    const loadingFinishedStub = cy.stub(loading, 'loadingElementFinished');
+
+    // Start the test.
+    const promise = addLayer(mockFirebaseLayers[3], map);
+    expect(loadingStartedStub).to.be.calledOnce;
+    // Loading can't finish until EE evaluation finishes, which we've frozen.
+    expect(loadingFinishedStub).to.not.be.called;
+    expect(map.overlayMapTypes).to.have.length(0);
+    // Release evaluation.
+    latch.release();
+    let overlay = null;
+    cy.wrap(promise)
+        .then(() => {
+          expect(loadingFinishedStub).to.be.calledOnce;
+          overlay = map.overlayMapTypes.getAt(3);
+          expect(overlay).is.not.null;
+          // Turn layer off: disappears from map.
+          toggleLayerOff(3, map);
+          expect(map.overlayMapTypes.getAt(3)).is.null;
+
+          // Turn overlay back on.
+          return toggleLayerOn(mockFirebaseLayers[3], map);
+        })
+        .then(() => {
+          const nextOverlay = map.overlayMapTypes.getAt(3);
+          expect(nextOverlay).is.not.null;
+          // We got the exact same object! Note that expect({}).not.equals({}).
+          expect(nextOverlay).equals(overlay);
+        });
+  });
+
+  it('tests score layer and deck management', () => {
+    // Re-initialize deck, this time with a spy so we can observe what happens.
+    const deckSpy = cy.spy(deck, 'GoogleMapsOverlay');
+    setMapToDrawLayersOn(null);
+    const overlaySpy = cy.spy(deckSpy.returnValues[0], 'setProps');
+    let numCalls = 0;
+    /**
+     * @return {array<deck.GeoJsonLayer>}
+     */
+    function getLatestLayer() {
+      return overlaySpy.args[numCalls++][0].layers;
+    }
+
+    let resolveFunction = null;
+    const promise = new Promise((resolve) => resolveFunction = resolve);
+
+    const scorePromise = addScoreLayer(promise);
+    // Nothing happens until promise we passed in is resolved.
+    expect(overlaySpy).to.not.be.called;
+    const promiseResult = ['a'];
+    const secondPromiseResult = ['b'];
+    resolveFunction(promiseResult);
+
+    cy.wrap(scorePromise)
+        .then(() => {
+          expect(overlaySpy).to.be.calledOnce;
+          const firstLayers = getLatestLayer();
+          expect(firstLayers).to.have.length(3);
+          const props = firstLayers[2].props;
+          expect(props.data).to.eql(promiseResult);
+          expect(props.visible).to.be.true;
+          expect(props.id).to.eql(scoreLayerName);
+
+          // Test remove.
+          removeScoreLayer();
+          expect(overlaySpy).to.be.calledTwice;
+          const secondLayers = getLatestLayer();
+          expect(secondLayers).to.have.length(2);
+          expect(secondLayers[1].props.id).to.not.eql(scoreLayerName);
+
+          // Add score layer back in, with a different value.
+          const secondPromise =
+              new Promise((resolve) => resolveFunction = resolve);
+          const secondScorePromise = addScoreLayer(secondPromise);
+          // Nothing happens until promise is resolved.
+          expect(overlaySpy).to.be.calledTwice;
+          resolveFunction(secondPromiseResult);
+          return secondScorePromise;
+        })
+        .then(() => {
+          expect(overlaySpy).to.be.calledThrice;
+          const thirdLayers = getLatestLayer();
+          expect(thirdLayers).to.have.length(3);
+          const props = thirdLayers[2].props;
+          expect(props.data).to.eql(secondPromiseResult);
+          expect(props.visible).to.be.true;
+          expect(props.id).to.eql(scoreLayerName);
+        });
+  });
 });
 
 describe('Unit test for toggleLayerOff', () => {
   it('hides a displayed layer', () => {
-    expect(layerArray[0].displayed).to.equals(true);
+    expect(layerArray[0].displayed).to.be.true;
     expect(layerArray[0].data).to.not.be.null;
 
     toggleLayerOff(0);
-    expect(layerArray[0].displayed).to.equals(false);
+    expect(layerArray[0].displayed).to.be.false;
     expect(layerArray[0].data).to.not.be.null;
     const layerProps = deckGlArray[0].props;
     expect(layerProps).to.have.property('id', 'asset0');

--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -3,6 +3,7 @@ import * as loading from '../../../docs/loading';
 import {processUserRegions, setUpPolygonDrawing, StoredShapeData} from '../../../docs/polygon_draw';
 import * as resourceGetter from '../../../docs/resources';
 import SettablePromise from '../../../docs/settable_promise';
+import {CallbackLatch} from '../../support/callback_latch';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
 const polyCoords = [
@@ -181,12 +182,10 @@ describe('Unit test for ShapeData', () => {
   it('Shows calculating before update finishes', () => {
     // polygon_draw.update creates an ee.List to evaluate the numbers it needs.
     // To make sure that update calculation does not finish until we're ready,
-    // lightly wrap ee.List.evaluate and wait on a Promise to finish.
-    // This function will be called below when we're ready for the calculation
+    // lightly wrap ee.List.evaluate and wait on a CallbackLatch. The
+    // CallbackLatch will be released below when we're ready for the calculation
     // to be finished.
-    let callWhenCalculationCanComplete = null;
-    const promiseThatAllPreCalculationAssertionsAreDone =
-        new Promise((resolve) => callWhenCalculationCanComplete = resolve);
+    const latch = new CallbackLatch();
     // Replace ee.List so that we can have access to the returned object and
     // change its evaluate call.
     const oldList = ee.List;
@@ -200,9 +199,7 @@ describe('Unit test for ShapeData', () => {
         returnValue.evaluate = oldEvaluate;
         // Do the evaluate, but don't return back to polygon_draw.update's
         // callback handler until our pre-calculation assertions are done.
-        returnValue.evaluate(
-            (result, err) => promiseThatAllPreCalculationAssertionsAreDone.then(
-                () => callback(result, err)));
+        returnValue.evaluate(latch.delayedCallback(callback));
       };
       return returnValue;
     };
@@ -230,7 +227,7 @@ describe('Unit test for ShapeData', () => {
     cy.get('.popup-calculated-data')
         .should('have.css', 'color')
         .and('eq', 'rgb(128, 128, 128)')
-        .then(() => callWhenCalculationCanComplete(null));
+        .then(() => latch.release());
     cy.wrap(updatePromise.getPromise());
     cy.get('.popup-calculated-data')
         .should('have.css', 'color')

--- a/cypress/support/callback_latch.js
+++ b/cypress/support/callback_latch.js
@@ -1,0 +1,28 @@
+export {CallbackLatch};
+
+/**
+ * Utility class (currently only needed by tests) that can delay a function from
+ * being called until it is told to release it.
+ */
+class CallbackLatch {
+  /** @constructor */
+  constructor() {
+    this.promise = new Promise((resolve) => this.latch = resolve);
+  }
+
+  /**
+   * Returns a "delayed callback" that only calls the given callback after
+   * {@code release} is called.
+   * @param {Function} callback
+   * @return {Function} Function that, when called, waits for promise to
+   *     complete (performed by {@code release} before calling callback
+   */
+  delayedCallback(callback) {
+    return (...params) => this.promise.then(() => callback(...params));
+  }
+
+  /** Releases the delayed callback to be called. */
+  release() {
+    this.latch();
+  }
+}

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -181,32 +181,34 @@ function addImageLayer(map, imageAsset, layer) {
   const index = layer['index'];
   const layerDisplayData = new LayerDisplayData(null, true);
   layerArray[index] = layerDisplayData;
-  layerDisplayData.pendingPromise = createLoadingAwarePromise((resolve, reject) => {
-    imageAsset.getMap({
-      visParams: imgStyles,
-      callback: (layerId, failure) => {
-        if (layerId) {
-          const overlay = new ee.MapLayerOverlay(
-              'https://earthengine.googleapis.com/map', layerId.mapid,
-              layerId.token, {});
-          layerDisplayData.overlay = overlay;
-          // Check in case the status has changed while the callback was
-          // running.
-          if (layerDisplayData.displayed) {
-            resolveOnTilesFinished(layerDisplayData, resolve);
-            showOverlayLayer(overlay, index, map);
-          } else {
-            resolve();
-          }
-        } else {
-          // TODO: if there's an error, disable checkbox, add tests for this.
-          layerDisplayData.displayed = false;
-          reject(failure);
-        }
-        layerDisplayData.pendingPromise = null;
-      },
-    });
-  });
+  layerDisplayData.pendingPromise =
+      createLoadingAwarePromise((resolve, reject) => {
+        imageAsset.getMap({
+          visParams: imgStyles,
+          callback: (layerId, failure) => {
+            if (layerId) {
+              const overlay = new ee.MapLayerOverlay(
+                  'https://earthengine.googleapis.com/map', layerId.mapid,
+                  layerId.token, {});
+              layerDisplayData.overlay = overlay;
+              // Check in case the status has changed while the callback was
+              // running.
+              if (layerDisplayData.displayed) {
+                resolveOnTilesFinished(layerDisplayData, resolve);
+                showOverlayLayer(overlay, index, map);
+              } else {
+                resolve();
+              }
+            } else {
+              // TODO: if there's an error, disable checkbox, add tests for
+              // this.
+              layerDisplayData.displayed = false;
+              reject(failure);
+            }
+            layerDisplayData.pendingPromise = null;
+          },
+        });
+      });
   return layerDisplayData.pendingPromise;
 }
 

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -428,7 +428,8 @@ function valIsNotNull(val) {
 }
 
 const scoreDeckParams = new DeckParams(scoreLayerName, null);
-scoreDeckParams.colorFunction = (feature) => showColor(feature.properties['color']);
+scoreDeckParams.colorFunction = (feature) =>
+    showColor(feature.properties['color']);
 
 /**
  * Creates and displays overlay for score + adds layerArray entry. The

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -369,13 +369,12 @@ function processImageCollection(layerName) {
 function addLayerFromGeoJsonPromise(featuresPromise, deckParams, index) {
   const layerDisplayData = new LayerDisplayData(deckParams, true);
   layerArray[index] = layerDisplayData;
-  const result = wrapPromiseLoadingAware(featuresPromise.then((features) => {
+  layerDisplayData.pendingPromise = wrapPromiseLoadingAware(featuresPromise.then((features) => {
     layerDisplayData.data = features;
     addLayerFromFeatures(layerDisplayData, index);
     layerDisplayData.pendingPromise = null;
   }));
-  layerDisplayData.pendingPromise = result;
-  return result;
+  return layerDisplayData.pendingPromise;
 }
 
 /**

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -54,7 +54,7 @@ let deckGlOverlay;
  * Values of layerArray. In addition to basic data from constructor, will
  * have a data attribute for deck layers, and an overlay attribute for
  * image/other layers. Will also have a "pendingPromise" field to detect if an
- * EarthEngine operation is currently in flight.
+ * initial rendering operation is currently in flight.
  */
 class LayerDisplayData {
   /**
@@ -130,6 +130,10 @@ function toggleLayerOn(layer, map) {
     return null;
   }
   if (layerDisplayData.overlay) {
+    // This promise does not need to be stored in the pendingPromise field
+    // because it will complete immediately if this layer is toggled off (see
+    // the resolveOnTilesFinished doc). That means that if toggleLayerOn is
+    // called again for this layer, the promise will already have completed.
     return createLoadingAwarePromise((resolve) => {
       // TODO(janakr): When we add non-EE assets, they will have to know how
       //  to call the finish loading callback too.

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -123,8 +123,6 @@ function toggleLayerOn(layer, map) {
   const index = layer['index'];
   const layerDisplayData = layerArray[index];
   layerDisplayData.displayed = true;
-  // TODO(janakr): this doesn't check the .overlay property to see if we already
-  // did computation for a non-deck layer. Add that caching in.
   if (layerDisplayData.data) {
     addLayerFromFeatures(layerDisplayData, index);
     return null;

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -369,11 +369,12 @@ function processImageCollection(layerName) {
 function addLayerFromGeoJsonPromise(featuresPromise, deckParams, index) {
   const layerDisplayData = new LayerDisplayData(deckParams, true);
   layerArray[index] = layerDisplayData;
-  layerDisplayData.pendingPromise = wrapPromiseLoadingAware(featuresPromise.then((features) => {
-    layerDisplayData.data = features;
-    addLayerFromFeatures(layerDisplayData, index);
-    layerDisplayData.pendingPromise = null;
-  }));
+  layerDisplayData.pendingPromise =
+      wrapPromiseLoadingAware(featuresPromise.then((features) => {
+        layerDisplayData.data = features;
+        addLayerFromFeatures(layerDisplayData, index);
+        layerDisplayData.pendingPromise = null;
+      }));
   return layerDisplayData.pendingPromise;
 }
 

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -115,6 +115,8 @@ function setMapToDrawLayersOn(map) {
  *
  * @param {Object} layer Data for layer coming from Firestore
  * @param {google.maps.Map} map main map
+ * @return {Promise|null} Promise that resolves when layer is rendered, or null
+ *     if layer is rendered synchronously
  */
 function toggleLayerOn(layer, map) {
   const index = layer['index'];
@@ -124,9 +126,17 @@ function toggleLayerOn(layer, map) {
   // did computation for a non-deck layer. Add that caching in.
   if (layerDisplayData.data) {
     addLayerFromFeatures(layerDisplayData, index);
-  } else {
-    addLayer(layer, map);
+    return null;
   }
+  if (layerDisplayData.overlay) {
+    return createLoadingAwarePromise((resolve) => {
+      // TODO(janakr): When we add non-EE assets, they will have to know how
+      //  to call the finish loading callback too.
+      resolveOnTilesFinished(layerDisplayData, resolve);
+      showOverlayLayer(layerDisplayData.overlay, index, map);
+    });
+  }
+  return addLayer(layer, map);
 }
 
 /**
@@ -147,8 +157,8 @@ function toggleLayerOff(index, map) {
 }
 
 /**
- * Asynchronous wrapper for addLayerFromId that calls getMap() with a callback
- * to avoid blocking on the result. This also populates layerArray.
+ * Asynchronous wrapper for createLayerFromEeId that calls getMap() with a
+ * callback to avoid blocking on the result. This also populates layerArray.
  *
  * This should only be called once per asset when its overlay is initialized
  * for the first time. After the overlay is non-null in layerArray, any
@@ -157,6 +167,7 @@ function toggleLayerOff(index, map) {
  * @param {google.maps.Map} map
  * @param {ee.Element} imageAsset
  * @param {Object} layer Data for layer coming from Firestore
+ * @return {Promise} Promise that completes when layer is processed
  */
 function addImageLayer(map, imageAsset, layer) {
   const imgStyles = layer['vis-params'];
@@ -164,52 +175,80 @@ function addImageLayer(map, imageAsset, layer) {
     imageAsset = terrainStyle(imageAsset);
   }
   const index = layer['index'];
-  layerArray[index] = new LayerDisplayData(null, true);
-  imageAsset.getMap({
-    visParams: imgStyles,
-    callback: (layerId, failure) => {
-      if (layerId) {
-        layerArray[index].overlay =
-            addLayerFromId(map, layerId, index, layerArray[index].displayed);
-      } else {
-        // TODO: if there's an error, disable checkbox, add tests for this.
-        layerArray[index].displayed = false;
-        createError('getting id')(failure);
-      }
-    },
+  const layerDisplayData = new LayerDisplayData(null, true);
+  layerArray[index] = layerDisplayData;
+  return createLoadingAwarePromise((resolve, reject) => {
+    imageAsset.getMap({
+      visParams: imgStyles,
+      callback: (layerId, failure) => {
+        if (layerId) {
+          const overlay = new ee.MapLayerOverlay(
+              'https://earthengine.googleapis.com/map', layerId.mapid,
+              layerId.token, {});
+          layerDisplayData.overlay = overlay;
+          // Check in case the status has changed while the callback was
+          // running.
+          if (layerDisplayData.displayed) {
+            resolveOnTilesFinished(layerDisplayData, resolve);
+            showOverlayLayer(overlay, index, map);
+          } else {
+            resolve();
+          }
+        } else {
+          // TODO: if there's an error, disable checkbox, add tests for this.
+          layerDisplayData.displayed = false;
+          reject(failure);
+        }
+      },
+    });
   });
 }
 
 /**
- * Create an EarthEngine layer (from EEObject.getMap()), potentially add to the
- * given Google Map and returns the overlay, in case the caller wants to add
- * callbacks or similar to that overlay.
- *
+ * Draws the given overlay on the map.
+ * @param {google.maps.MapType} overlay
+ * @param {number} index Index of overlay (higher goes on top of lower). Each
+ *     layer has a unique index
  * @param {google.maps.Map} map
- * @param {Object} layerId
- * @param {number} index
- * @param {boolean} displayed
- * @return {ee.MapLayerOverlay}
  */
-function addLayerFromId(map, layerId, index, displayed) {
-  const overlay = new ee.MapLayerOverlay(
-      'https://earthengine.googleapis.com/map', layerId.mapid, layerId.token,
-      {});
-  // Update loading state according to layers.
-  overlay.addTileCallback((tileEvent) => {
-    if (tileEvent.count == 0) {
-      loadingElementFinished(mapContainerId);
-      layerArray[index].loading = false;
-    } else if (!layerArray[index].loading) {
-      layerArray[index].loading = true;
-      addLoadingElement(mapContainerId);
-    }
-  });
-  // Check in case the status has changed while the callback was running.
-  if (displayed) {
-    map.overlayMapTypes.setAt(index, overlay);
+function showOverlayLayer(overlay, index, map) {
+  map.overlayMapTypes.setAt(index, overlay);
+}
+
+/**
+ * Calls {@code resolve} callback the first time we finish loading tiles. This
+ * will happen if the layer is removed from the map even if it has not finished
+ * rendering (verified experimentally).
+ *
+ * On subsequent calls, adds loading element to map if not already loading, and
+ * removes it when all tiles are loaded. These calls correspond to map redraws,
+ * from pans or zooms.
+ *
+ * @param {LayerDisplayData} layerDisplayData
+ * @param {Function} resolve
+ */
+function resolveOnTilesFinished(layerDisplayData, resolve) {
+  if (layerDisplayData.tileCallbackId) {
+    layerDisplayData.overlay.removeTileCallback(
+        layerDisplayData.tileCallbackId);
   }
-  return overlay;
+  layerDisplayData.tileCallbackId =
+      layerDisplayData.overlay.addTileCallback((tileEvent) => {
+        if (tileEvent.count === 0) {
+          if (resolve) {
+            resolve();
+            // Free up reference to resolve and make future redraws add a
+            // loading element.
+            resolve = null;
+          } else {
+            loadingElementFinished(mapContainerId);
+          }
+          layerDisplayData.loading = false;
+        } else if (!resolve && !layerDisplayData.loading) {
+          layerDisplayData.loading = true;
+          addLoadingElement(mapContainerId);
+        }
+      });
 }
 
 /**
@@ -263,26 +302,25 @@ function showColor(color) {
 const maxNumFeaturesExpected = 250000000;
 
 /**
- * Convenience wrapper for addLayerFromGeoJsonPromise.
+ * Convenience wrapper for addLayerFromGeoJsonPromise/addImageLayer
  * @param {Object} layer Data for layer coming from Firestore
  * @param {google.maps.Map} map main map
+ * @return {Promise} Promise that completes when layer is processed
  */
 function addLayer(layer, map) {
   switch (layer['asset-type']) {
     case LayerType.IMAGE:
-      addImageLayer(map, ee.Image(layer['ee-name']), layer);
-      break;
+      return addImageLayer(map, ee.Image(layer['ee-name']), layer);
     case LayerType.IMAGE_COLLECTION:
-      addImageLayer(map, processImageCollection(layer['ee-name']), layer);
-      break;
+      return addImageLayer(
+          map, processImageCollection(layer['ee-name']), layer);
     case LayerType.FEATURE:
     case LayerType.FEATURE_COLLECTION:
       const layerName = layer['ee-name'];
-      addLayerFromGeoJsonPromise(
+      return addLayerFromGeoJsonPromise(
           convertEeObjectToPromise(
               ee.FeatureCollection(layerName).toList(maxNumFeaturesExpected)),
           DeckParams.fromLayer(layer), layer['index']);
-      break;
     default:
       createError('parsing layer type during add')(
           '[' + layer['index'] + ']: ' + layer['asset-name'] +
@@ -314,18 +352,15 @@ function processImageCollection(layerName) {
  * @param {DeckParams} deckParams
  * @param {number|string} index index of layer. A number unless this is the
  * score layer
+ * @return {Promise} Promise that completes when the feature is rendered
  */
 function addLayerFromGeoJsonPromise(featuresPromise, deckParams, index) {
-  addLoadingElement(mapContainerId);
   const layerDisplayData = new LayerDisplayData(deckParams, true);
   layerArray[index] = layerDisplayData;
-  featuresPromise
-      .then((features) => {
-        layerDisplayData.data = features;
-        addLayerFromFeatures(layerDisplayData, index);
-        loadingElementFinished(mapContainerId);
-      })
-      .catch(createError('Error rendering ' + deckParams.deckId));
+  return wrapPromiseLoadingAware(featuresPromise.then((features) => {
+    layerDisplayData.data = features;
+    addLayerFromFeatures(layerDisplayData, index);
+  }));
 }
 
 /**
@@ -375,28 +410,19 @@ function valIsNotNull(val) {
   return val !== null;
 }
 
+const deckParams = new DeckParams(scoreLayerName, null);
+deckParams.colorFunction = (feature) => showColor(feature.properties['color']);
+
 /**
  * Creates and displays overlay for score + adds layerArray entry. The
  * score layer sits at the end of all the layers. Having it last ensures it
  * displays on top.
  *
  * @param {Promise<Array<GeoJson>>} layer
+ * @return {Promise} Promise that completes when layer is displayed
  */
 function addScoreLayer(layer) {
-  const deckParams = new DeckParams(scoreLayerName, null);
-  deckParams.colorFunction = getColorOfFeature;
-
-  addLayerFromGeoJsonPromise(layer, deckParams, scoreLayerName);
-}
-
-/**
- * Function object to extract a color from a JSON Feature.
- *
- * @param {GeoJSON.Feature} feature
- * @return {Array} RGBA array
- */
-function getColorOfFeature(feature) {
-  return showColor(feature.properties['color']);
+  return addLayerFromGeoJsonPromise(layer, deckParams, scoreLayerName);
 }
 
 /**
@@ -407,4 +433,26 @@ function getColorOfFeature(feature) {
 function removeScoreLayer() {
   deckGlArray[scoreLayerName] = null;
   redrawLayers();
+}
+
+const mapLoadingFinished = () => loadingElementFinished(mapContainerId);
+
+/**
+ * Notes that an element has started loading, and add a handler to the Promise
+ * to note when it finishes.
+ * @param {Promise} promise
+ * @return {Promise} wrappedPromise
+ */
+function wrapPromiseLoadingAware(promise) {
+  addLoadingElement(mapContainerId);
+  return promise.then(mapLoadingFinished);
+}
+
+/**
+ * Creates a Promise that's already wrapped by {@code wrapPromiseLoadingAware}.
+ * @param {Function} lambda that is the argument to Promise constructor
+ * @return {Promise} wrapped Promise
+ */
+function createLoadingAwarePromise(lambda) {
+  return wrapPromiseLoadingAware(new Promise(lambda));
 }


### PR DESCRIPTION
Three main changes in this PR:
1. Re-use the computed LayerDisplayData.overlay on toggle on, rather than making another call to EarthEngine. I think this got lost in the shuffle of switching to deck and then adding overlay back, and it's been gone for a while.
1. If there is a pending promise in toggleOn, don't do anything. The promise will see that it should display the layer whenever it finishes. Before this change, if an EE request was taking a long time, rapidly toggling a checkbox on and off would add more and more EE requests.
1. Start the loading indicator for map images on EE computation, not on tile rendering.

Test changes:
1. Add tests for the above functionality.
1. Return Promises all the way out from layer_util.js, for easier testing.
1. Add a regression test for score layer updates being broken (https://github.com/givedirectly/Google-Partnership/pull/212)
