### PR TITLE
Support collections of map tile URLS as layers

### DIFF
--- a/cypress/integration/integration_tests/checkbox_test.js
+++ b/cypress/integration/integration_tests/checkbox_test.js
@@ -9,13 +9,13 @@ describe('Integration test', () => {
 
     cy.get('#sidebar-toggle-datasets').click();
 
-    cy.get('#score-checkbox').uncheck();
+    cy.get('#layer-score-checkbox').uncheck();
 
     cy.get('#sidebar-toggle-thresholds').click();
 
     cy.get('[id="poverty threshold"]').clear().type('1.0');
     cy.get('#update').click();
 
-    cy.get('#score-checkbox').should('be.checked');
+    cy.get('#layer-score-checkbox').should('be.checked');
   });
 });

--- a/cypress/integration/integration_tests/polygon_draw_test.js
+++ b/cypress/integration/integration_tests/polygon_draw_test.js
@@ -128,8 +128,8 @@ describe('Integration tests for drawing polygons', () => {
     saveAndAwait();
     cy.get('#mapContainer').contains(notes).should('be.visible');
     cy.get('#sidebar-toggle-datasets').click();
-    cy.get('#user-features-checkbox').should('be.checked');
-    cy.get('#user-features-checkbox').click();
+    cy.get('#layer-user-features-checkbox').should('be.checked');
+    cy.get('#layer-user-features-checkbox').click();
     cy.get('#mapContainer').contains(notes).should('not.be.visible');
     // Notes is invisible even if we click on the polygon, so it's really gone.
     // Use an offset because there's some weirdness around selecting block
@@ -138,8 +138,8 @@ describe('Integration tests for drawing polygons', () => {
     cy.get('#mapContainer').contains(notes).should('not.be.visible');
 
     // Check box again and verify that notes box can now be brought up.
-    cy.get('#user-features-checkbox').click();
-    cy.get('#user-features-checkbox').should('be.checked');
+    cy.get('#layer-user-features-checkbox').click();
+    cy.get('#layer-user-features-checkbox').should('be.checked');
     // Wait a little bit for the layer to re-render (only needed on Electron).
     cy.wait(100);
     // Notes not visible yet.
@@ -151,17 +151,17 @@ describe('Integration tests for drawing polygons', () => {
     pressPopupButton('edit');
     let alertCameUp = false;
     cy.on('window:alert', () => alertCameUp = true);
-    cy.get('#user-features-checkbox').click().then(() => {
+    cy.get('#layer-user-features-checkbox').click().then(() => {
       expect(alertCameUp).to.be.true;
     });
-    cy.get('#user-features-checkbox').should('be.checked');
+    cy.get('#layer-user-features-checkbox').should('be.checked');
     // Confirm that save is still around to be pressed.
     cy.get('[class="notes"]').type('new notes to force save');
     saveAndAwait();
 
     // After a save, the hide is successful.
-    cy.get('#user-features-checkbox').click();
-    cy.get('#user-features-checkbox').should('not.be.checked');
+    cy.get('#layer-user-features-checkbox').click();
+    cy.get('#layer-user-features-checkbox').should('not.be.checked');
   });
 
   it('Hides, draws new one, tries to hide during edit, re-shows, hides', () => {
@@ -172,8 +172,8 @@ describe('Integration tests for drawing polygons', () => {
     cy.get('[class="notes"]').type(notes);
     saveAndAwait();
     cy.get('#sidebar-toggle-datasets').click();
-    cy.get('#user-features-checkbox').click();
-    cy.get('#user-features-checkbox').should('not.be.checked');
+    cy.get('#layer-user-features-checkbox').click();
+    cy.get('#layer-user-features-checkbox').should('not.be.checked');
     // With the box unchecked, draw a new polygon, below the first one, and set
     // its notes, but don't finish editing.
     drawPolygonAndClickOnIt(100);
@@ -182,15 +182,15 @@ describe('Integration tests for drawing polygons', () => {
     // Try to re-check the box. It will fail because we're editing.
     let alertCameUp = false;
     cy.on('window:alert', () => alertCameUp = true);
-    cy.get('#user-features-checkbox').click().then(() => {
+    cy.get('#layer-user-features-checkbox').click().then(() => {
       expect(alertCameUp).to.be.true;
     });
-    cy.get('#user-features-checkbox').should('not.be.checked');
+    cy.get('#layer-user-features-checkbox').should('not.be.checked');
 
     // Save the new notes and check the box, this time it succeeds.
     saveAndAwait();
-    cy.get('#user-features-checkbox').click();
-    cy.get('#user-features-checkbox').should('be.checked');
+    cy.get('#layer-user-features-checkbox').click();
+    cy.get('#layer-user-features-checkbox').should('be.checked');
 
     // We can click on the old polygon and view its notes,
     clickOnDrawnPolygon();
@@ -200,8 +200,8 @@ describe('Integration tests for drawing polygons', () => {
     cy.get('#mapContainer').contains('new notes').should('be.visible');
 
     // Now hide both polygons, and verify that they're really gone.
-    cy.get('#user-features-checkbox').click();
-    cy.get('#user-features-checkbox').should('not.be.checked');
+    cy.get('#layer-user-features-checkbox').click();
+    cy.get('#layer-user-features-checkbox').should('not.be.checked');
     cy.get('#mapContainer').contains(notes).should('not.be.visible');
     cy.get('#mapContainer').contains('new notes').should('not.be.visible');
     clickOnDrawnPolygon(100);

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -3,6 +3,7 @@ import {addLayer, addScoreLayer, deckGlArray, DeckParams, layerArray, LayerDispl
 import * as loading from '../../../docs/loading';
 import {CallbackLatch} from '../../support/callback_latch';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
+import {createGoogleMap} from '../../support/test_map';
 
 const mockData = {};
 
@@ -40,6 +41,14 @@ const mockFirebaseLayers = [
     'display-name': 'image',
     'display-on-load': true,
     'index': 3,
+  },
+  {
+    'ee-name': 'tile_asset',
+    'asset-type': LayerType.MAP_TILES,
+    'tile-urls': ['tile-url1/{X}/{Y}/{Z}', 'tile-url2/{X}/{Y}/{Z}'],
+    'display-name': 'tiles',
+    'display-on-load': true,
+    'index': 4,
   },
 ];
 
@@ -147,22 +156,26 @@ describe('Unit test for toggleLayerOn', () => {
   // that we can delay the callback until we're ready.
   // 3. Stub the loading elements, so we can check when loading starts/ends.
   it('caches computed image overlay and starts loading on EE request', () => {
-    const map = createGoogleMap();
     const latch = stubOutImageAndGetLatch();
     const loadingStartedStub = cy.stub(loading, 'addLoadingElement');
     const loadingFinishedStub = cy.stub(loading, 'loadingElementFinished');
 
-    // Start the test.
-    const promise = addLayer(mockFirebaseLayers[3], map);
-    expect(promise).to.not.be.null;
-    expect(loadingStartedStub).to.be.calledOnce;
-    // Loading can't finish until EE evaluation finishes, which we've frozen.
-    expect(loadingFinishedStub).to.not.be.called;
-    expect(map.overlayMapTypes).to.have.length(0);
-    // Release evaluation.
-    latch.release();
     let overlay = null;
-    cy.wrap(promise)
+    let map = null;
+    createGoogleMap()
+        .then((returnedMap) => {
+          map = returnedMap;
+          const promise = addLayer(mockFirebaseLayers[3], map);
+          expect(promise).to.not.be.null;
+          expect(loadingStartedStub).to.be.calledOnce;
+          // Loading can't finish until EE evaluation finishes, which we've
+          // frozen.
+          expect(loadingFinishedStub).to.not.be.called;
+          expect(map.overlayMapTypes).to.have.length(0);
+          // Release evaluation.
+          latch.release();
+          return promise;
+        })
         .then(() => {
           expect(loadingFinishedStub).to.be.calledOnce;
           overlay = map.overlayMapTypes.getAt(3);
@@ -185,74 +198,74 @@ describe('Unit test for toggleLayerOn', () => {
   });
 
   it('toggles off computed image overlay before EE finishes', () => {
-    const map = createGoogleMap();
     const latch = stubOutImageAndGetLatch();
     const loadingStartedStub = cy.stub(loading, 'addLoadingElement');
     const loadingFinishedStub = cy.stub(loading, 'loadingElementFinished');
 
-    // Start the test.
-    const promise = addLayer(mockFirebaseLayers[3], map);
-    expect(promise).to.not.be.null;
-    // Loading has started, but map is unaffected.
-    expect(loadingStartedStub).to.be.calledOnce;
-    expect(map.overlayMapTypes).to.have.length(0);
-    expect(map.overlayMapTypes.getAt(3)).to.be.undefined;
+    createGoogleMap().then((map) => {
+      const promise = addLayer(mockFirebaseLayers[3], map);
+      expect(promise).to.not.be.null;
+      // Loading has started, but map is unaffected.
+      expect(loadingStartedStub).to.be.calledOnce;
+      expect(map.overlayMapTypes).to.have.length(0);
+      expect(map.overlayMapTypes.getAt(3)).to.be.undefined;
 
-    // Before EE rendering finishes, toggle layer off.
-    toggleLayerOff(3, map);
-    // Overlay list now has null instead of undefined, but no biggie.
-    expect(map.overlayMapTypes.getAt(3)).to.be.null;
+      // Before EE rendering finishes, toggle layer off.
+      toggleLayerOff(3, map);
+      // Overlay list now has null instead of undefined, but no biggie.
+      expect(map.overlayMapTypes.getAt(3)).to.be.null;
 
-    // Loading can't finish until EE evaluation finishes, which we've frozen.
-    expect(loadingFinishedStub).to.not.be.called;
-    // Release evaluation.
-    latch.release();
-    cy.wrap(promise)
-        .then(() => {
-          expect(loadingFinishedStub).to.be.calledOnce;
-          expect(map.overlayMapTypes.getAt(3)).to.be.null;
+      // Loading can't finish until EE evaluation finishes, which we've frozen.
+      expect(loadingFinishedStub).to.not.be.called;
+      // Release evaluation.
+      latch.release();
+      cy.wrap(promise)
+          .then(() => {
+            expect(loadingFinishedStub).to.be.calledOnce;
+            expect(map.overlayMapTypes.getAt(3)).to.be.null;
 
-          // Turn overlay back on.
-          const togglePromise = toggleLayerOn(mockFirebaseLayers[3], map);
-          expect(togglePromise).to.not.be.null;
-          return togglePromise;
-        })
-        .then(() => expect(map.overlayMapTypes.getAt(3)).is.not.null);
+            // Turn overlay back on.
+            const togglePromise = toggleLayerOn(mockFirebaseLayers[3], map);
+            expect(togglePromise).to.not.be.null;
+            return togglePromise;
+          })
+          .then(() => expect(map.overlayMapTypes.getAt(3)).is.not.null);
+    });
   });
 
   it('toggles off and on computed image overlay before EE finishes', () => {
-    const map = createGoogleMap();
     const latch = stubOutImageAndGetLatch();
     const loadingStartedStub = cy.stub(loading, 'addLoadingElement');
     const loadingFinishedStub = cy.stub(loading, 'loadingElementFinished');
 
-    // Start the test.
-    const promise = addLayer(mockFirebaseLayers[3], map);
-    expect(promise).to.not.be.null;
-    // Loading has started, but map is unaffected.
-    expect(loadingStartedStub).to.be.calledOnce;
-    expect(map.overlayMapTypes).to.have.length(0);
-    expect(map.overlayMapTypes.getAt(3)).to.be.undefined;
+    createGoogleMap().then((map) => {
+      const promise = addLayer(mockFirebaseLayers[3], map);
+      expect(promise).to.not.be.null;
+      // Loading has started, but map is unaffected.
+      expect(loadingStartedStub).to.be.calledOnce;
+      expect(map.overlayMapTypes).to.have.length(0);
+      expect(map.overlayMapTypes.getAt(3)).to.be.undefined;
 
-    // Before EE rendering finishes, toggle layer off.
-    toggleLayerOff(3, map);
-    // Overlay list now has null instead of undefined, but no biggie.
-    expect(map.overlayMapTypes.getAt(3)).to.be.null;
+      // Before EE rendering finishes, toggle layer off.
+      toggleLayerOff(3, map);
+      // Overlay list now has null instead of undefined, but no biggie.
+      expect(map.overlayMapTypes.getAt(3)).to.be.null;
 
-    // Still before evaluation finishes, toggle back on.
-    const togglePromise = toggleLayerOn(mockFirebaseLayers[3], map);
-    expect(togglePromise).equals(promise);
-    // Still null.
-    expect(map.overlayMapTypes.getAt(3)).to.be.null;
+      // Still before evaluation finishes, toggle back on.
+      const togglePromise = toggleLayerOn(mockFirebaseLayers[3], map);
+      expect(togglePromise).equals(promise);
+      // Still null.
+      expect(map.overlayMapTypes.getAt(3)).to.be.null;
 
-    // Loading can't finish until EE evaluation finishes, which we've frozen.
-    expect(loadingFinishedStub).to.not.be.called;
+      // Loading can't finish until EE evaluation finishes, which we've frozen.
+      expect(loadingFinishedStub).to.not.be.called;
 
-    // Release evaluation.
-    latch.release();
-    cy.wrap(promise).then(() => {
-      expect(loadingFinishedStub).to.be.calledOnce;
-      expect(map.overlayMapTypes.getAt(3)).to.not.be.null;
+      // Release evaluation.
+      latch.release();
+      cy.wrap(promise).then(() => {
+        expect(loadingFinishedStub).to.be.calledOnce;
+        expect(map.overlayMapTypes.getAt(3)).to.not.be.null;
+      });
     });
   });
 
@@ -315,6 +328,114 @@ describe('Unit test for toggleLayerOn', () => {
           expect(props.id).to.eql(scoreLayerName);
         });
   });
+
+  // TODO(janakr): For all the composite tile tests below, we perform 4 fetches
+  //  for each tile url, but only 2 unique ones. This doesn't happen in
+  //  production, so it's not a performance issue, seemingly just something
+  //  weird about the requests Google Maps makes in tests.
+  it('tests composite tiles', () => {
+    // Stub out HTTP fetch, so we can return a promise that waits a while.
+    const fetchStub = cy.stub(window, 'fetch');
+    // Only release the promise when we've made all our assertions.
+    let releaseResponse = null;
+    const waitPromise = new Promise((resolve) => releaseResponse = resolve);
+    fetchStub.callsFake((url) => {
+      if (url.startsWith('tile-url1')) {
+        return okHttpResponse;
+      }
+      return waitPromise;
+    });
+    let map = null;
+    let overlay;
+    let addLayerPromise = null;
+    createGoogleMap().then((returnedMap) => map = returnedMap);
+    expectNoBlobImages().then(() => {
+      // Add the layer. 4 will render quickly, 4 will hang.
+      addLayerPromise = addLayer(mockFirebaseLayers[4], map);
+      overlay = assertCompositeOverlayPresent(map);
+    });
+    expectBlobImageCount(4).then(() => {
+      // Remaining images can now render.
+      releaseResponse(okHttpResponse);
+      return addLayerPromise;
+    });
+    // All images present.
+    expectBlobImageCount(8).then(() => {
+      toggleLayerOff(4, map);
+      expect(map.overlayMapTypes.getAt(4)).to.be.null;
+    });
+    // All gone once we toggle off.
+    expectNoBlobImages().then(() => {
+      const togglePromise = toggleLayerOn(mockFirebaseLayers[4], map);
+      expect(map.overlayMapTypes.getAt(4)).equals(overlay);
+      return togglePromise;
+    });
+    // All back once we toggle on.
+    expectBlobImageCount(8);
+  });
+
+  it('tests composite tiles with 404', () => {
+    const notFoundResponse = {ok: false, status: 404};
+    cy.stub(window, 'fetch').callsFake((url) => {
+      // Never render tile-url2, and for 1/1/1 div, don't have any images.
+      if (url.startsWith('tile-url1') && url !== 'tile-url1/1/1/1') {
+        return okHttpResponse;
+      }
+      return notFoundResponse;
+    });
+    let map = null;
+    createGoogleMap().then((returnedMap) => map = returnedMap);
+    expectNoBlobImages().then(() => {
+      // Add the layer. 2 images will render quickly (tile-url1), 6 are not
+      // found.
+      const addLayerPromise = addLayer(mockFirebaseLayers[4], map);
+      assertCompositeOverlayPresent(map);
+      return addLayerPromise;
+    });
+    cy.get('img[src*="blob:"]').should('have.length', 2);
+  });
+
+  it('tests composite tiles toggles off before display', () => {
+    // Replace fetch with our stub, but keep old one around, since we want to
+    // test that we can abort the fetch successfully on a signal.
+    const oldFetch = window.fetch;
+    let promiseResolver = null;
+    // This promise will not complete until the abort signal has been sent.
+    const fetchPromise = new Promise((resolve) => promiseResolver = resolve);
+    window.fetch = (url, signal) => {
+      if (url.startsWith('tile-url1')) {
+        return okHttpResponse;
+      }
+      return fetchPromise.then(() => oldFetch(url, signal));
+    };
+    let map = null;
+    let overlay;
+    let addLayerPromise = null;
+    createGoogleMap().then((returnedMap) => map = returnedMap);
+    expectNoBlobImages().then(() => {
+      // Add the layer. 4 images will render quickly (tile-url1), but 4 will
+      // hang.
+      addLayerPromise = addLayer(mockFirebaseLayers[4], map);
+      overlay = assertCompositeOverlayPresent(map);
+    });
+    // 4 images show up very quickly.
+    expectBlobImageCount(4).then(() => {
+      // Remove the layer.
+      toggleLayerOff(4, map);
+      expect(map.overlayMapTypes.getAt(4)).to.be.null;
+      // Release the fetches. They should be aborted because the layer is
+      // now not shown.
+      promiseResolver();
+      return addLayerPromise;
+    });
+    expectNoBlobImages()
+        // Toggle images back on. This returns a promise Cypress waits for.
+        .then(() => toggleLayerOn(mockFirebaseLayers[4], map))
+        // Same overlay as before.
+        .then(() => expect(map.overlayMapTypes.getAt(4)).equals(overlay));
+    // All images now shown on page.
+    expectBlobImageCount(8);
+  });
 });
 
 describe('Unit test for toggleLayerOff', () => {
@@ -361,13 +482,6 @@ function stubForEmptyList(callbackReceiver) {
   cy.stub(emptyEeList, 'evaluate').callsFake(callbackReceiver);
 }
 
-/** @return {google.maps.Map} for use in a test */
-function createGoogleMap() {
-  const div = document.createElement('div');
-  document.body.appendChild(div);
-  return new google.maps.Map(div, {center: {lat: 0, lng: 0}, zoom: 1});
-}
-
 /**
  * Stubs out the ee.Image constructor to use a dummy image and returns a
  * CallbackLatch that will release the image's #getMap callback.
@@ -389,3 +503,44 @@ function stubOutImageAndGetLatch() {
   };
   return latch;
 }
+
+/**
+ * Returns the assertion that there are no images in the document whose src
+ * attribute is a "blob" URL (CompositeImageMapType uses images like that).
+ * @return {Cypress.Chainable}
+ */
+function expectNoBlobImages() {
+  return cy.get('img[src*="blob:"]').should('not.exist');
+}
+
+/**
+ * Returns the assertion that there are exactly {@code number} blob images in
+ * the document.
+ * @param {number} number
+ * @return {Cypress.Chainable}
+ */
+function expectBlobImageCount(number) {
+  return cy.get('img[src*="blob:"]').should('have.length', number);
+}
+
+/**
+ * Asserts that the given map has the expected CompositeImageMapType overlay in
+ * position 4, and returns the overlay.
+ * @param {google.maps.Map} map
+ * @return {CompositeImageMapType}
+ */
+function assertCompositeOverlayPresent(map) {
+  const overlay = map.overlayMapTypes.getAt(4);
+  expect(overlay).to.not.be.null;
+  expect(overlay.tileUrls).to.eql([
+    'tile-url1/{X}/{Y}/{Z}',
+    'tile-url2/{X}/{Y}/{Z}',
+  ]);
+  return overlay;
+}
+
+const okHttpResponse = {
+  ok: true,
+  blob: () => Promise.resolve(
+      new Blob([JSON.stringify({})], {type: 'application/json'})),
+};

--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -5,6 +5,7 @@ import * as resourceGetter from '../../../docs/resources';
 import SettablePromise from '../../../docs/settable_promise';
 import {CallbackLatch} from '../../support/callback_latch';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
+import {createGoogleMap} from '../../support/test_map';
 
 const polyCoords = [
   {lng: 1, lat: 1},
@@ -204,12 +205,8 @@ describe('Unit test for ShapeData', () => {
       return returnValue;
     };
     const event = new Event('overlaycomplete');
-    cy.document()
-        .then((document) => {
-          const div = document.createElement('div');
-          document.body.appendChild(div);
-          const map =
-              new google.maps.Map(div, {center: {lat: 0, lng: 0}, zoom: 1});
+    createGoogleMap()
+        .then((map) => {
           event.overlay = new google.maps.Polygon({
             map: map,
             paths: [{lat: 0, lng: 0}, {lat: 1, lng: 1}, {lat: 0, lng: 1}],
@@ -250,12 +247,8 @@ describe('Unit test for ShapeData', () => {
     const updatePromise = new SettablePromise();
     const event = new Event('overlaycomplete');
     let marker;
-    cy.document()
-        .then((document) => {
-          const div = document.createElement('div');
-          document.body.appendChild(div);
-          const map =
-              new google.maps.Map(div, {center: {lat: 0, lng: 0}, zoom: 1});
+    createGoogleMap()
+        .then((map) => {
           marker =
               new google.maps.Marker({map: map, position: {lat: 0, lng: 0}});
           event.overlay = marker;

--- a/cypress/support/test_map.js
+++ b/cypress/support/test_map.js
@@ -1,0 +1,15 @@
+export {createGoogleMap};
+
+/**
+ * Visits empty page (to empty out document), then creates and returns a Map.
+ * @return {Cypress.Chainable<google.maps.Map>} for use in a test
+ */
+function createGoogleMap() {
+  // Visit a blank page first to clear out any prior page state.
+  cy.visit('test_utils/empty.html');
+  return cy.document().then((document) => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    return new google.maps.Map(div, {center: {lat: 0, lng: 0}, zoom: 1});
+  });
+}

--- a/docs/composite_image_map_type.js
+++ b/docs/composite_image_map_type.js
@@ -1,0 +1,266 @@
+export {CompositeImageMapType};
+
+const TOO_MANY_REQUESTS_STATUS_CODE = 429;
+const NOT_FOUND_STATUS_CODE = 404;
+const MAX_RETRIES = 10;
+
+/**
+ * Custom google.maps.MapType implementation that overlays multiple tiles from
+ * different sources, so that they can all be treated as a single overlay.
+ *
+ * If a tile is released, any pending fetches are canceled. Callers can register
+ * a callback to be informed when loading starts/ends.
+ *
+ * We use a pretty complex Javascript fetch mechanism, as opposed to a much
+ * simpler img.src, because these requests might get 429 (too many requests)
+ * errors, and we want to gracefully retry them. There doesn't appear to be any
+ * way to gracefully retry 429 errors that come from image loading (that is, the
+ * image's onerror handler does not expose that the error was a 429).
+ *
+ * TODO(janakr): Google Crisis Maps doesn't appear to have any retry capability,
+ *  and they are using these same NOAA tiles. Maybe not worth the complexity
+ *  here to retry 429?
+ */
+class CompositeImageMapType {
+  /**
+   * @constructor
+   * @param {Object} options Options: should have tileUrls attribute (list of
+   *     urls with {X}, {Y}, and {Z} placeholders for coordinates and zoom). May
+   *     also have tileSize (width of each tile in pixels, defaults to 256),
+   *     maxZoom (maximum zoom level to try to fetch tiles for, defaults to 19),
+   *     and opacity (opacity of rendered tiles, defaults to 1, totally opaque)
+   */
+  constructor(options) {
+    this.tileUrls = options.tileUrls;
+    this.opacity = options.opacity ? options.opacity : 1;
+    this.tileMap = new Map();
+    this.eventTarget = new EventTarget();
+
+    // this.tileSize and this.maxZoom are read directly by Google Maps.
+    const size = options.tileSize ? options.tileSize : 256;
+    this.tileSize = new google.maps.Size(size, size);
+    this.maxZoom = options.maxZoom ? options.maxZoom : 19;
+  }
+
+  /**
+   * Sets a callback to be notified. The callback will receive an {@link Event}
+   * with a "count" attribute which is either 0 or 1, patterned after the
+   * {@link ee.TileEvent} event, so that callers can use the same callback.
+   * However, these events are only emitted for the first tile requested and
+   * last tile generated, not for every tile, unlike {@link ee.TileEvent}.
+   *
+   * Any previous registered callback is removed when this is called.
+   * @param {Function} callback
+   */
+  setTileCallback(callback) {
+    if (this.callback) {
+      this.eventTarget.removeEventListener('tile', this.callback);
+    }
+    this.callback = callback;
+    this.eventTarget.addEventListener('tile', callback);
+  }
+
+  /**
+   * Returns the tile for the given coordinates and zoom level. Tile will be a
+   * div with stacked images, one for each successfully loaded from tileUrls.
+   * @param {google.maps.Point} tileCoord coordinates for tile
+   * @param {number} zoom integer zoom level
+   * @param {Document} ownerDocument document HTML elements will be created in
+   * @return {HTMLDivElement} div element with tile images attached
+   */
+  getTile(tileCoord, zoom, ownerDocument) {
+    // Create a div to hold all the images.
+    const tileDiv = ownerDocument.createElement('div');
+    if (zoom > this.maxZoom) {
+      return tileDiv;
+    }
+    // Replace tile url template arguments with actual coordinates.
+    const tileUrls = this.tileUrls.map(
+        (url) => url.replace('{Z}', zoom)
+                     .replace('{X}', tileCoord.x)
+                     .replace('{Y}', tileCoord.y));
+    // Set things up to cancel all fetches if this tile is no longer needed, as
+    // signaled by #releaseTile below.
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+    this.maybeSendEvent(true);
+    this.tileMap.set(tileDiv, abortController);
+    let remainingTiles = tileUrls.length;
+    // Process each image as it comes in, so user can see latest images without
+    // waiting for slow-loading ones.
+    const promiseProcessor = (url) => {
+      // If releaseTile() was called for this tile before this promise
+      // completed, we are aborting.
+      if (!this.tileMap.get(tileDiv)) {
+        if (typeof (url) === 'string') {
+          // If the image was already downloaded, free it.
+          URL.revokeObjectURL(url);
+        }
+        return;
+      }
+      if (typeof (url) === 'string') {
+        this.appendImage(url, tileDiv);
+      } else if (url instanceof ErrorObject) {
+        if (url.statusCode !== NOT_FOUND_STATUS_CODE) {
+          console.error(url.statusCode, url.getMessage());
+        }
+      }
+      if (!--remainingTiles) {
+        // All fetches have completed, maybe some with errors. Tile is done.
+        this.markTileCompleted(tileDiv);
+      }
+    };
+    tileUrls.map((url) => fetchWithBackoff(url, signal).then(promiseProcessor));
+    return tileDiv;
+  }
+
+  /**
+   * Implements MapType#releaseTile. Revokes local object URL for all images in
+   * the given div, freeing up memory, and canceling any in-flight fetches.
+   * @param {HTMLDivElement} div
+   */
+  releaseTile(div) {
+    const controller = this.tileMap.get(div);
+    if (controller) {
+      controller.abort();
+      this.markTileCompleted(div);
+    }
+  }
+
+  /**
+   * Creates and appends an HTMLImageElement pointing at the given url. When the
+   * image is loaded, the url (which points at a local object) will be freed to
+   * save memory.
+   * @param {string} url URL from {@link URL#createObjectURL}
+   * @param {HTMLDivElement} tileDiv Div to attach image to.
+   */
+  appendImage(url, tileDiv) {
+    const img = tileDiv.ownerDocument.createElement('img');
+    img.src = url;
+    img.opacity = this.opacity;
+    // Stack images over each other.
+    img.style.position = 'absolute';
+    // Clear blob from memory as soon as it is loaded.
+    img.onload = () => URL.revokeObjectURL(url);
+    tileDiv.appendChild(img);
+  }
+
+  /**
+   * Removes div from {@link this#tileMap} and sends an event if no tiles remain
+   * to be rendered.
+   * @param {HTMLDivElement} div
+   */
+  markTileCompleted(div) {
+    this.tileMap.delete(div);
+    this.maybeSendEvent(false);
+  }
+
+  /**
+   * If we are transitioning from no pending fetches to pending fetches or vice
+   * versa, send an event.
+   * @param {boolean} adding True if we are about to start a fetch, false if we
+   *     have just finished all fetches
+   */
+  maybeSendEvent(adding) {
+    if (!this.tileMap.size) {
+      const event = new Event('tile');
+      event.count = adding ? 1 : 0;
+      this.eventTarget.dispatchEvent(event);
+    }
+  }
+}
+
+/**
+ * Wrapper object for HTML errors encountered during a single tile fetch, to
+ * avoid throwing errors that would shut down other tile fetches.
+ */
+class ErrorObject {
+  /**
+   * @constructor
+   * @param {number} statusCode HTTP status code (like 404, 400, 429)
+   * @param {string} message Error message from HTTP response
+   * @param {string} url Original URL requested for fetch
+   */
+  constructor(statusCode, message, url) {
+    this.statusCode = statusCode;
+    this.message = message;
+    this.url = url;
+  }
+
+  /**
+   * @return {string} Formatted error message from this error, for console
+   *     display
+   */
+  getMessage() {
+    return 'Could not retrieve ' + this.url +
+        (this.message ? ' (' + this.message + ')' : '');
+  }
+}
+
+ErrorObject.create = (response, url) => {
+  return new ErrorObject(response.status, response.statusText, url);
+};
+
+/**
+ * Performs an HTTP fetch, but with exponential backoff if the server responds
+ * with a "too many requests" error. Return response errors as an ErrorObject
+ * for ease of processing.
+ * @param {string} url URL to fetch
+ * @param {AbortSignal} signal Signal to pass to fetch to trigger abort
+ * @return {Promise<!string|ErrorObject>} Promise with local object URL for
+ *     fetched data, or ErrorObject if an error was encountered, or null if
+ * aborted by signal
+ */
+async function fetchWithBackoff(url, signal) {
+  let retryCount = 0;
+  let response;
+  const exponentialBackoff = new ExponentialBackoff();
+  while (retryCount++ < MAX_RETRIES) {
+    try {
+      response = await fetch(url, {signal: signal});
+      if (response.ok === true) {
+        const blob = await response.blob();
+        return URL.createObjectURL(blob);
+      }
+      if (response.status === TOO_MANY_REQUESTS_STATUS_CODE) {
+        await exponentialBackoff.wait();
+      } else {
+        return ErrorObject.create(response, url);
+      }
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        return null;
+      }
+      throw err;
+    }
+  }
+  return ErrorObject.create(response, url);
+}
+
+/** Utility class to wait an exponentially increasing amount of time. */
+class ExponentialBackoff {
+  /** @constructor */
+  constructor() {
+    this.retryCount = 0;
+  }
+
+  /**
+   * @return {Promise<void>} Promise that is fulfilled after a random sleep of
+   *     at most 2^(this.retryCount) seconds
+   */
+  async wait() {
+    const maxSleep = 1000 * Math.pow(2, ++this.retryCount);
+    // Use random jitter to avoid all of our requests synchronizing on the
+    // server (and hammering the client event loop).
+    await pause(Math.random() * maxSleep);
+  }
+}
+
+/**
+ * @param {number} duration milliseconds to pause
+ * @return {Promise<void>} Promise that resolves after {@code duration}
+ *     milliseconds
+ */
+function pause(duration) {
+  return new Promise((resolve) => setTimeout(resolve, duration));
+}

--- a/docs/composite_image_map_type.js
+++ b/docs/composite_image_map_type.js
@@ -33,12 +33,26 @@ class CompositeImageMapType {
   constructor(options) {
     this.tileUrls = options.tileUrls;
     this.opacity = options.opacity ? options.opacity : 1;
+    /**
+     * Holds the AbortController for the image downloads of each div tile. Once
+     * all fetches complete for a given div, it is removed from this map. Hence
+     * the size of this map is the number of tiles currently in flight. We fire
+     * an event when this map goes from empty to non-empty (indicating that this
+     * layer has started loading) and when this map goes from non-empty to empty
+     * (indicating that loading is complete). Depending on the vagaries of when
+     * Google Maps requests tiles, it is possible that only some tiles might be
+     * requested, they would complete, and then more tiles would be requested,
+     * leading to a stuttering loading indicator, but in practice this does not
+     * happen, because Google Maps requests all of the relevant tiles at once.
+     * @type {Map<HTMLDivElement, AbortController>}
+     */
     this.tileMap = new Map();
     this.eventTarget = new EventTarget();
 
     // this.tileSize and this.maxZoom are read directly by Google Maps.
     const size = options.tileSize ? options.tileSize : 256;
     this.tileSize = new google.maps.Size(size, size);
+    // NOAA tile imagery seems to go up to zoom level 19.
     this.maxZoom = options.maxZoom ? options.maxZoom : 19;
   }
 

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -9,6 +9,7 @@ const LayerType = {
   FEATURE_COLLECTION: 1,
   IMAGE: 2,
   IMAGE_COLLECTION: 3,
+  MAP_TILES: 4,
 };
 Object.freeze(LayerType);
 

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -59,11 +59,11 @@ let deckGlOverlay;
  *
  * There are three kinds of layers, corresponding to different types of source
  * data:
- * 1. FeatureCollections are rendered using deck. They will have a "loading"
- * status until their EarthEngine computation completes, and then render near-
- * instantly. These have non-null deckParams, and a pendingPromise until the
- * EarthEngine computation is finished.
- * 2. ImageCollections are rendered using EarthEngine. They will have a
+ * 1. Features/FeatureCollections are rendered using deck. They will have a
+ * "loading" status until their EarthEngine computation completes, and then
+ * render near-instantly. These have non-null deckParams, and a pendingPromise
+ * until the EarthEngine computation is finished.
+ * 2. Images/ImageCollections are rendered using EarthEngine. They will have a
  * "loading" status until their #getMap() call completes *and* their tiles have
  * been rendered. These have null deckParams, and a pendingPromise until tiles
  * are rendered. On map pan/zoom or layer toggling, the EarthEngine computation

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -273,6 +273,10 @@ function resolveOnEeTilesFinished(layerDisplayData, resolve) {
  * first time loading completes, so that the application can be notified that
  * this layer has been rendered.
  *
+ * On subsequent calls, adds loading element to map if not already loading, and
+ * removes it when all tiles are loaded. These calls correspond to map redraws,
+ * from pans or zooms.
+ *
  * Loading completion will be triggered if the layer is toggled off from the map
  * (verified experimentally, and also through reading code: when the layer is
  * toggled off, releaseTile() is called on all of its tiles, enabling the
@@ -288,19 +292,22 @@ function createTileCallback(layerDisplayData, resolve) {
   return (tileEvent) => {
     if (tileEvent.count === 0) {
       if (resolve) {
+        // This is the first time we've finished loading, so inform caller.
         resolve();
-        // Free up reference to resolve and make future redraws add a loading
-        // element.
+        // Free up reference to resolve and make future redraws add a
+        // loading element.
         resolve = null;
       } else {
+        // Loading has finished for a pan/zoom-triggered load.
         loadingElementFinished(mapContainerId);
       }
       layerDisplayData.loading = false;
     } else if (!resolve && !layerDisplayData.loading) {
+      // We've started loading again after the first time completed (because
+      // of a pan/zoom of the map). Enable loading indicator.
       layerDisplayData.loading = true;
       addLoadingElement(mapContainerId);
-    }
-  };
+    }  };
 }
 
 /**

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -251,7 +251,7 @@ function showOverlayLayer(overlay, index, map) {
 }
 
 /**
- * Wrapper for adding {@link createTileCallback} to the given ee.OverlayMapData\
+ * Wrapper for adding {@link createTileCallback} to the given ee.OverlayMapData
  * layer.
  * @param {LayerDisplayData} layerDisplayData containing an ee.OverlayMapData
  * @param {Function} resolve Function to be called the first time this layer

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -307,7 +307,8 @@ function createTileCallback(layerDisplayData, resolve) {
       // of a pan/zoom of the map). Enable loading indicator.
       layerDisplayData.loading = true;
       addLoadingElement(mapContainerId);
-    }  };
+    }
+  };
 }
 
 /**

--- a/docs/run.js
+++ b/docs/run.js
@@ -41,7 +41,7 @@ function run(map, firebaseAuthPromise, disasterMetadataPromise) {
       map, initialPovertyThreshold, initialDamageThreshold,
       initialPovertyWeight);
   processUserRegions(map, firebaseAuthPromise);
-  disasterMetadataPromise.then((doc) => addLayers(map, doc.data().layerArray));
+  disasterMetadataPromise.then((doc) => addLayers(map, doc.data().layers));
 }
 
 let mapSelectListener = null;
@@ -98,17 +98,17 @@ function createAndDisplayJoinedData(
 /**
  * Creates a checkbox for showing/hiding layers.
  *
- * @param {String} name checkbox name, basis for id
+ * @param {number|string} index checkbox index, basis for id
  * @param {String} displayName checkbox display name
  * @param {div} parentDiv div to attach checkbox to
  * @return {HTMLInputElement} the checkbox
  */
-function createNewCheckbox(name, displayName, parentDiv) {
+function createNewCheckbox(index, displayName, parentDiv) {
   const newRow = document.createElement('div');
   newRow.className = 'checkbox-row';
   const newBox = document.createElement('input');
   newBox.type = 'checkbox';
-  newBox.id = getCheckBoxId(name);
+  newBox.id = getCheckBoxId(index);
   newBox.className = 'checkbox';
   newBox.checked = true;
   newRow.appendChild(newBox);
@@ -208,5 +208,5 @@ function maybeCheckScoreCheckbox() {
  * @return {string}
  */
 function getCheckBoxId(baseName) {
-  return baseName + '-checkbox';
+  return 'layer-' + baseName + '-checkbox';
 }

--- a/docs/test_utils/empty.html
+++ b/docs/test_utils/empty.html
@@ -1,0 +1,1 @@
+<!-- This page is loaded by tests to give a clean document -->


### PR DESCRIPTION
NOAA imagery is available as map tiles, which avoids the issue of having to upload images to EarthEngine. Because the user will want to view/hide all the tiles as a set, we implement our own custom CompositeImageMapType, similar to ImageMapType, but able to handle a collection of URLS. It fetches all of them, and for all the ones that returned images, stacks them on top of each other and displays the whole stack (inside a div).

We render images as they come in, cancel pending fetches if the tile is no longer relevant, and gracefully retry rate-limited requests.

I've added a map tile asset in the new "layers" array in Firestore, and switched to using "layers" in this PR. It's not a huge problem if we switch to using "layers" before this PR goes in: there will be a console error if you try to enable the "NOAA Tiles" layer, but everything else still works.

There are two potential ways this PR could change. The first is that users are supposed to enter a list of URL templates. NOAA's templates haven't changed in a while. You can figure out the end (just the date with a suffix) from looking at app.js in the NOAA map:
<img width="927" alt="NOAA source" src="https://user-images.githubusercontent.com/10134896/69009907-23ab6b80-0928-11ea-98bc-df3a7a65aa3e.png">

Note that those URLs are not the template URLs, they're JSON pointing to the template URLs. We should probably support those JSON URLs as well, retrieve the JSON, and then use that to construct the template URLs. We can disambiguate because template URLs have {X}, {Y}, {Z} in their paths.

The second change is internal: a lot of the complexity in composite_image_map_type.js comes from using fetch to retrieve images, rather than just sticking them in an img.src tag directly. We do that so we can gracefully handle 429 (too many requests) errors. But perhaps NOAA, our main source of imagery, won't give us those errors, and so we could somewhat simplify that file. I don't think it would have a perceptible difference on performance, though.

This isn't actually work towards #173, but it makes that issue much less urgent.

Also fixed some leftover naming issues around checkboxes.

Work towards #177