### PR TITLE
Change disaster name to include the year

### DIFF
--- a/docs/firestore_document.js
+++ b/docs/firestore_document.js
@@ -1,5 +1,5 @@
 import {getTestCookie, inProduction} from './in_test_util.js';
-import {getDisaster, getResources} from './resources.js';
+import {getDisaster} from './resources.js';
 
 export {disasterDocumentReference, getFirestoreRoot, readDisasterDocument};
 

--- a/docs/firestore_document.js
+++ b/docs/firestore_document.js
@@ -19,9 +19,7 @@ function getFirestoreRoot() {
  * @return {firebase.firestore.DocumentReference}
  */
 function disasterDocumentReference() {
-  return getFirestoreRoot()
-      .collection('disaster-metadata')
-      .doc(getDisaster());
+  return getFirestoreRoot().collection('disaster-metadata').doc(getDisaster());
 }
 
 /**

--- a/docs/firestore_document.js
+++ b/docs/firestore_document.js
@@ -21,7 +21,7 @@ function getFirestoreRoot() {
 function disasterDocumentReference() {
   return getFirestoreRoot()
       .collection('disaster-metadata')
-      .doc(getResources().year + '-' + getDisaster());
+      .doc(getDisaster());
 }
 
 /**

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -1,5 +1,5 @@
-import {inProduction} from './in_test_util.js';
 import {gdEePathPrefix} from './ee_paths.js';
+import {inProduction} from './in_test_util.js';
 
 export {getDisaster, getResources};
 
@@ -65,14 +65,16 @@ const harveyPathPrefix = gdEePathPrefix + harveyName + '/';
 // florida and georgia.
 disasters.set(
     michaelName,
-    new DisasterMapValue(michaelName, michaelPathPrefix + 'FEMA_Damage_Assessments',
+    new DisasterMapValue(
+        michaelName, michaelPathPrefix + 'FEMA_Damage_Assessments',
         michaelPathPrefix + 'snap', michaelPathPrefix + 'tiger',
         michaelPathPrefix + 'income', michaelPathPrefix + 'svi',
         michaelPathPrefix + 'relevant_buildings'));
 
 disasters.set(
     harveyName,
-    new DisasterMapValue(harveyName, harveyPathPrefix + 'FEMA_Damage_Assessments',
+    new DisasterMapValue(
+        harveyName, harveyPathPrefix + 'FEMA_Damage_Assessments',
         harveyPathPrefix + 'snap', harveyPathPrefix + 'tiger',
         harveyPathPrefix + 'income', harveyPathPrefix + 'svi',
         harveyPathPrefix + 'buildings'));

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -59,7 +59,7 @@ class DisasterMapValue {
 const michaelName = '2018-michael';
 const michaelPathPrefix = gdEePathPrefix + michaelName + '/';
 
-const harveyName = '2018-harvey';
+const harveyName = '2017-harvey';
 const harveyPathPrefix = gdEePathPrefix + harveyName + '/';
 
 disasters.set(

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -54,15 +54,14 @@ class DisasterMapValue {
   }
 }
 
+// TODO(janakr): get all the data below here from Firestore instead of hard-
+//  coding here. That will also need to support multiple states per disaster.
 const michaelName = '2018-michael';
 const michaelPathPrefix = gdEePathPrefix + michaelName + '/';
 
 const harveyName = '2018-harvey';
 const harveyPathPrefix = gdEePathPrefix + harveyName + '/';
 
-// TODO: Don't store census/svi data in relation to a disaster so we can handle
-// scenarios that are not 1:1 state:disaster e.g. michael which hit both
-// florida and georgia.
 disasters.set(
     michaelName,
     new DisasterMapValue(

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -1,4 +1,5 @@
 import {inProduction} from './in_test_util.js';
+import {gdEePathPrefix} from './ee_paths.js';
 
 export {getDisaster, getResources};
 
@@ -16,11 +17,11 @@ function getResources() {
  * @return {string} current disaster
  */
 function getDisaster() {
-  return inProduction() ? disaster : 'harvey';
+  return inProduction() ? disaster : '2017-harvey';
 }
 
 /** The current disaster. */
-const disaster = 'harvey';
+const disaster = '2017-harvey';
 
 /** Disaster asset names and other constants. */
 const disasters = new Map();
@@ -29,8 +30,7 @@ const disasters = new Map();
 class DisasterMapValue {
   /**
    * @constructor
-   * @param {string} name
-   * @param {number} year
+   * @param {string} name (includes year)
    * @param {string} damage ee asset path
    * @param {string} snap ee asset path to snap info
    * @param {string} bg ee asset path to block group info
@@ -38,8 +38,7 @@ class DisasterMapValue {
    * @param {string} svi ee asset path to svi info
    * @param {string} buildings ee asset path to building footprint info
    */
-  constructor(name, year, damage, snap, bg, income, svi, buildings) {
-    this.year = year;
+  constructor(name, damage, snap, bg, income, svi, buildings) {
     this.name = name;
     this.damage = damage;
     this.rawSnap = snap;
@@ -51,25 +50,29 @@ class DisasterMapValue {
 
   /** @return {string} The combined SNAP/damage asset name */
   getCombinedAsset() {
-    return 'users/gd/' + this.name + '/data-ms-as-nod';
+    return gdEePathPrefix + this.name + '/data-ms-as-nod';
   }
 }
+
+const michaelName = '2018-michael';
+const michaelPathPrefix = gdEePathPrefix + michaelName + '/';
+
+const harveyName = '2018-harvey';
+const harveyPathPrefix = gdEePathPrefix + harveyName + '/';
 
 // TODO: Don't store census/svi data in relation to a disaster so we can handle
 // scenarios that are not 1:1 state:disaster e.g. michael which hit both
 // florida and georgia.
 disasters.set(
-    'michael',
-    new DisasterMapValue(
-        'michael', 2018, 'users/gd/michael/FEMA_Damage_Assessments',
-        'users/gd/michael/snap', 'users/gd/michael/tiger',
-        'users/gd/michael/income', 'users/gd/michael/svi',
-        'users/gd/michael/relevant_buildings'));
+    michaelName,
+    new DisasterMapValue(michaelName, michaelPathPrefix + 'FEMA_Damage_Assessments',
+        michaelPathPrefix + 'snap', michaelPathPrefix + 'tiger',
+        michaelPathPrefix + 'income', michaelPathPrefix + 'svi',
+        michaelPathPrefix + 'relevant_buildings'));
 
 disasters.set(
-    'harvey',
-    new DisasterMapValue(
-        'harvey', 2017, 'users/gd/harvey/FEMA_Damage_Assessments',
-        'users/gd/harvey/snap', 'users/gd/harvey/tiger',
-        'users/gd/harvey/income', 'users/gd/harvey/svi',
-        'users/gd/harvey/buildings'));
+    harveyName,
+    new DisasterMapValue(harveyName, harveyPathPrefix + 'FEMA_Damage_Assessments',
+        harveyPathPrefix + 'snap', harveyPathPrefix + 'tiger',
+        harveyPathPrefix + 'income', harveyPathPrefix + 'svi',
+        harveyPathPrefix + 'buildings'));


### PR DESCRIPTION
This is an incompatible change. I renamed the EarthEngine folders to have the right form and modified Firestore data to point to the new assets.

Most of the work in resources.js is wasted, because we'll be deleting it in favor of Firestore-based disaster metadata retrieval, but whatever.