### PR TITLE
Fix add_disaster_test

### DIFF
--- a/docs/import/add_disaster.js
+++ b/docs/import/add_disaster.js
@@ -1,6 +1,5 @@
 import {eeStatePrefixLength, legacyStateDir} from '../ee_paths.js';
 import {getFirestoreRoot} from '../firestore_document.js';
-import {loadNavbar} from '../navbar.js';
 
 export {enableWhenReady, toggleState};
 // Visible for testing
@@ -326,5 +325,3 @@ function createOptionFrom(innerTextAndValue) {
       .val(innerTextAndValue)
       .prop('id', innerTextAndValue);
 }
-
-loadNavbar('Add Disaster');

--- a/docs/import/add_disaster_startup.js
+++ b/docs/import/add_disaster_startup.js
@@ -2,6 +2,7 @@ import {authenticateToFirebase, Authenticator} from '../authenticate.js';
 import SettablePromise from '../settable_promise.js';
 import {enableWhenReady, toggleState} from './add_disaster.js';
 import TaskAccumulator from './task_accumulator.js';
+import {loadNavbar} from "../navbar";
 
 export {taskAccumulator};
 
@@ -23,3 +24,5 @@ authenticator.start();
 
 $('#create-new-disaster').on('click', () => toggleState(false));
 $('#cancel-new-disaster').on('click', () => toggleState(true));
+
+loadNavbar('Add disaster');

--- a/docs/import/add_disaster_startup.js
+++ b/docs/import/add_disaster_startup.js
@@ -1,8 +1,9 @@
 import {authenticateToFirebase, Authenticator} from '../authenticate.js';
+import {loadNavbar} from '../navbar.js';
 import SettablePromise from '../settable_promise.js';
+
 import {enableWhenReady, toggleState} from './add_disaster.js';
 import TaskAccumulator from './task_accumulator.js';
-import {loadNavbar} from "../navbar";
 
 export {taskAccumulator};
 


### PR DESCRIPTION
Have unconditional use of jQuery happen only in add_disaster_startup.js. 