### PR TITLE
Remove calls to getResources()

### DIFF
--- a/docs/polygon_draw.js
+++ b/docs/polygon_draw.js
@@ -354,7 +354,7 @@ function setUpPolygonDrawing(map, firebasePromise) {
  * @param {Promise<any>} firebasePromise Promise with Firebase damage data (also
  *     implies that authentication is complete)
  * @return {Promise} promise that is resolved when all initialization is done
- *     (only used by tests) 
+ *     (only used by tests)
  */
 function initializeAndProcessUserRegions(map, firebasePromise) {
   addLoadingElement(mapContainerId);

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -1,6 +1,6 @@
 import {gdEePathPrefix} from './ee_paths.js';
 
-export {getDisaster, getDisasters, getResources};
+export {getDisaster, getDisasters, getResources, getScoreAsset};
 
 /**
  * Gets all the ee assets relevant to the current disaster.
@@ -18,8 +18,13 @@ function getDisaster() {
   if (localStorage.getItem('disaster')) {
     return localStorage.getItem('disaster');
   }
-  localStorage.setItem('disaster', default_disaster);
-  return default_disaster;
+  localStorage.setItem('disaster', defaultDisaster);
+  return defaultDisaster;
+}
+
+/** @return {string} EE asset path for score asset for the current disaster */
+function getScoreAsset() {
+  return gdEePathPrefix + getDisaster() + '/data-ms-as-nod';
 }
 
 /**
@@ -33,7 +38,7 @@ function getDisasters() {
 }
 
 /** The default disaster. */
-const default_disaster = '2017-harvey';
+const defaultDisaster = '2017-harvey';
 
 /** Disaster asset names and other constants. */
 const disasters = new Map();
@@ -58,11 +63,6 @@ class DisasterMapValue {
     this.income = income;
     this.svi = svi;
     this.buildings = buildings;
-  }
-
-  /** @return {string} The combined SNAP/damage asset name */
-  getCombinedAsset() {
-    return gdEePathPrefix + this.name + '/data-ms-as-nod';
   }
 }
 

--- a/docs/run.js
+++ b/docs/run.js
@@ -5,10 +5,10 @@ import {highlightFeatures} from './highlight_features.js';
 import {addLayer, addNullLayer, addScoreLayer, scoreLayerName, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from './layer_util.js';
 import {addLoadingElement, loadingElementFinished} from './loading.js';
 import {convertEeObjectToPromise} from './map_util.js';
-import {processUserRegions} from './polygon_draw.js';
+import {initializeAndProcessUserRegions} from './polygon_draw.js';
 import {setUserFeatureVisibility} from './popup.js';
 import processJoinedData from './process_joined_data.js';
-import {getResources} from './resources.js';
+import {getScoreAsset} from './resources.js';
 import {createToggles, initialDamageThreshold, initialPovertyThreshold, initialPovertyWeight} from './update.js';
 
 export {
@@ -16,7 +16,7 @@ export {
   run as default,
 };
 
-const snapAndDamageAsset = getResources().getCombinedAsset();
+const snapAndDamageAsset = getScoreAsset();
 // Promise for snapAndDamageAsset. After it's first resolved, we never need to
 // download it from EarthEngine again.
 let snapAndDamagePromise;
@@ -40,7 +40,7 @@ function run(map, firebaseAuthPromise, disasterMetadataPromise) {
   createAndDisplayJoinedData(
       map, initialPovertyThreshold, initialDamageThreshold,
       initialPovertyWeight);
-  processUserRegions(map, firebaseAuthPromise);
+  initializeAndProcessUserRegions(map, disasterMetadataPromise);
   disasterMetadataPromise.then((doc) => addLayers(map, doc.data().layers));
 }
 


### PR DESCRIPTION
Disasters are going to be retrieved live from Firestore, not hard-coded in resources.js, so we can't really depend on this data.

Also make our map tolerant to a missing damage layer. After this, if import_data produces a "score" asset with no damage, our map should work as expected.