### PR TITLE
Explicitly store color schema choice in firestore

### DIFF
--- a/cypress/integration/unit_tests/add_disaster_test.js
+++ b/cypress/integration/unit_tests/add_disaster_test.js
@@ -1,10 +1,10 @@
 import {gdEeStatePrefix, legacyStateDir, legacyStatePrefix} from '../../../docs/ee_paths.js';
 import {getFirestoreRoot} from '../../../docs/firestore_document.js';
 import {addDisaster, createAssetPickers, createOptionFrom, createTd, deleteDisaster, disasterData, emptyCallback, getAssetsFromEe, getCurrentLayers, onCheck, onInputBlur, onListBlur, stateAssets, updateAfterSort, withCheckbox, withInput, withList, withType, writeNewDisaster} from '../../../docs/import/add_disaster.js';
+import {withColor} from '../../../docs/import/color_function_util.js'
 import * as loading from '../../../docs/loading.js';
 import {getDisaster} from '../../../docs/resources';
 import {addFirebaseHooks, loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
-import {withColor} from '../../../docs/import/color_function_util.js'
 
 const KNOWN_STATE = 'WF';
 const UNKNOWN_STATE = 'DN';
@@ -233,21 +233,27 @@ describe('Unit tests for add_disaster page', () => {
     expect(noColor.hasClass('na')).to.be.true;
 
     const yellow = 'yellow';
-    const singleColor =
-        withColor(createTd(), {color: {'current-style': 2, 'single-color': yellow}}, property, 0);
+    const singleColor = withColor(
+        createTd(), {color: {'current-style': 2, 'single-color': yellow}},
+        property, 0);
     expect(singleColor.children('.box').length).to.equal(1);
     expect(singleColor.children().eq(0).css('background-color'))
         .to.equal(yellow);
 
-    const baseColor =
-        withColor(createTd(), {color: {'current-style': 0, 'base-color': yellow}}, property, 0);
+    const baseColor = withColor(
+        createTd(), {color: {'current-style': 0, 'base-color': yellow}},
+        property, 0);
     expect(baseColor.children('.box').length).to.equal(1);
     expect(baseColor.children().eq(0).css('background-color')).to.equal(yellow);
 
     const red = 'red';
     const discrete = withColor(
-        createTd(),
-        {color: {'current-style': 1, colors: {'squash': yellow, 'tomato': red, 'pepper': red}}},
+        createTd(), {
+          color: {
+            'current-style': 1,
+            colors: {'squash': yellow, 'tomato': red, 'pepper': red}
+          }
+        },
         property, 0);
     expect(discrete.children('.box').length).to.equal(2);
     expect(discrete.children().eq(1).css('background-color')).to.equal(red);

--- a/cypress/integration/unit_tests/add_disaster_test.js
+++ b/cypress/integration/unit_tests/add_disaster_test.js
@@ -1,7 +1,7 @@
 import {gdEeStatePrefix, legacyStateDir, legacyStatePrefix} from '../../../docs/ee_paths.js';
 import {getFirestoreRoot} from '../../../docs/firestore_document.js';
 import {addDisaster, createAssetPickers, createOptionFrom, createTd, deleteDisaster, disasterData, emptyCallback, getAssetsFromEe, getCurrentLayers, onCheck, onInputBlur, onListBlur, stateAssets, updateAfterSort, withCheckbox, withInput, withList, withType, writeNewDisaster} from '../../../docs/import/add_disaster.js';
-import {withColor} from '../../../docs/import/color_function_util.js'
+import {withColor} from '../../../docs/import/color_function_util.js';
 import * as loading from '../../../docs/loading.js';
 import {getDisaster} from '../../../docs/resources';
 import {addFirebaseHooks, loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
@@ -251,8 +251,8 @@ describe('Unit tests for add_disaster page', () => {
         createTd(), {
           color: {
             'current-style': 1,
-            colors: {'squash': yellow, 'tomato': red, 'pepper': red}
-          }
+            'colors': {'squash': yellow, 'tomato': red, 'pepper': red},
+          },
         },
         property, 0);
     expect(discrete.children('.box').length).to.equal(2);

--- a/cypress/integration/unit_tests/add_disaster_test.js
+++ b/cypress/integration/unit_tests/add_disaster_test.js
@@ -1,9 +1,10 @@
 import {gdEeStatePrefix, legacyStateDir, legacyStatePrefix} from '../../../docs/ee_paths.js';
 import {getFirestoreRoot} from '../../../docs/firestore_document.js';
-import {addDisaster, createAssetPickers, createOptionFrom, createTd, deleteDisaster, disasterData, emptyCallback, getAssetsFromEe, getCurrentLayers, onCheck, onInputBlur, onListBlur, stateAssets, updateAfterSort, withCheckbox, withColor, withInput, withList, withType, writeNewDisaster} from '../../../docs/import/add_disaster.js';
+import {addDisaster, createAssetPickers, createOptionFrom, createTd, deleteDisaster, disasterData, emptyCallback, getAssetsFromEe, getCurrentLayers, onCheck, onInputBlur, onListBlur, stateAssets, updateAfterSort, withCheckbox, withInput, withList, withType, writeNewDisaster} from '../../../docs/import/add_disaster.js';
 import * as loading from '../../../docs/loading.js';
 import {getDisaster} from '../../../docs/resources';
 import {addFirebaseHooks, loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
+import {withColor} from '../../../docs/import/color_function_util.js'
 
 const KNOWN_STATE = 'WF';
 const UNKNOWN_STATE = 'DN';
@@ -224,7 +225,7 @@ describe('Unit tests for add_disaster page', () => {
         .then((doc) => expect(doc.exists).to.be.false);
   });
 
-  it('tests color cell', () => {
+  it.only('tests color cell', () => {
     const property = 'color';
 
     const noColor = withColor(createTd(), {}, property, 0);
@@ -233,20 +234,20 @@ describe('Unit tests for add_disaster page', () => {
 
     const yellow = 'yellow';
     const singleColor =
-        withColor(createTd(), {color: {'single-color': yellow}}, property, 0);
+        withColor(createTd(), {color: {'current-style': 2, 'single-color': yellow}}, property, 0);
     expect(singleColor.children('.box').length).to.equal(1);
     expect(singleColor.children().eq(0).css('background-color'))
         .to.equal(yellow);
 
     const baseColor =
-        withColor(createTd(), {color: {'base-color': yellow}}, property, 0);
+        withColor(createTd(), {color: {'current-style': 0, 'base-color': yellow}}, property, 0);
     expect(baseColor.children('.box').length).to.equal(1);
     expect(baseColor.children().eq(0).css('background-color')).to.equal(yellow);
 
     const red = 'red';
     const discrete = withColor(
         createTd(),
-        {color: {colors: {'squash': yellow, 'tomato': red, 'pepper': red}}},
+        {color: {'current-style': 1, colors: {'squash': yellow, 'tomato': red, 'pepper': red}}},
         property, 0);
     expect(discrete.children('.box').length).to.equal(2);
     expect(discrete.children().eq(1).css('background-color')).to.equal(red);

--- a/cypress/integration/unit_tests/style_functions_test.js
+++ b/cypress/integration/unit_tests/style_functions_test.js
@@ -3,7 +3,7 @@ import {colorMap, createStyleFunction} from '../../../docs/firebase_layers.js';
 describe('Unit test for generating style functions', () => {
   it('calculates a discrete function', () => {
     const fxn = createStyleFunction({
-      'style': 1,
+      'current-style': 1,
       'field': 'flavor',
       'opacity': 100,
       'colors': {
@@ -21,7 +21,7 @@ describe('Unit test for generating style functions', () => {
 
   it('calculates a continuous function', () => {
     const fxn = createStyleFunction({
-      'style': 0,
+      'current-style': 0,
       'field': 'oranges',
       'base-color': 'orange',
       'opacity': 83,
@@ -39,7 +39,7 @@ describe('Unit test for generating style functions', () => {
 
   it('calculates a single-color function', () => {
     const fxn = createStyleFunction({
-      'style': 2,
+      'current-style': 2,
       'single-color': 'blue',
       'opacity': 83,
     });

--- a/cypress/integration/unit_tests/style_functions_test.js
+++ b/cypress/integration/unit_tests/style_functions_test.js
@@ -3,7 +3,7 @@ import {colorMap, createStyleFunction} from '../../../docs/firebase_layers.js';
 describe('Unit test for generating style functions', () => {
   it('calculates a discrete function', () => {
     const fxn = createStyleFunction({
-      'continuous': false,
+      'style': 1,
       'field': 'flavor',
       'opacity': 100,
       'colors': {
@@ -21,7 +21,7 @@ describe('Unit test for generating style functions', () => {
 
   it('calculates a continuous function', () => {
     const fxn = createStyleFunction({
-      'continuous': true,
+      'style': 0,
       'field': 'oranges',
       'base-color': 'orange',
       'opacity': 83,
@@ -39,6 +39,7 @@ describe('Unit test for generating style functions', () => {
 
   it('calculates a single-color function', () => {
     const fxn = createStyleFunction({
+      'style': 2,
       'single-color': 'blue',
       'opacity': 83,
     });

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,14 @@ all `<data>` instances contain the following fields:
 ### Color Functions
 We have three types of coloring schemes: continuous, discrete, and single color. Each has a different schema for the <code>color-function</code> object:
 
+#### ColorStyle Enum:
+
+* Continuous: 0
+* Discrete: 1
+* Single Color: 2
+
 **continuous:**
-* continuous `{boolean}`: set to true
+* style `{enum}`: set to 0
 * base-color `{string}`: from known colors
 * field `{string}`: name of property we're using to calculate color
 * max `{number}`: max value of field
@@ -27,12 +33,13 @@ We have three types of coloring schemes: continuous, discrete, and single color.
 * opacity `{number}`: opacity level
 
 **discrete:**
-* continuous `{boolean}`: set to false
+* style `{enum}`: set to 1
 * field `{string}`: name of property we're using to calculate color
 * colors `{Map}`: map of field value `{string}` to color `{string}` (from known colors)
 * opacity `{number}`
 
 **single-color:**
+* style `{enum}`: set to 2
 * single-color `{string}`: from set of known colors
 * opacity `{number}`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ We have three types of coloring schemes: continuous, discrete, and single color.
 * Single Color: 2
 
 **continuous:**
-* style `{enum}`: set to 0
+* current-style `{enum}`: set to 0
 * base-color `{string}`: from known colors
 * field `{string}`: name of property we're using to calculate color
 * max `{number}`: max value of field
@@ -33,13 +33,13 @@ We have three types of coloring schemes: continuous, discrete, and single color.
 * opacity `{number}`: opacity level
 
 **discrete:**
-* style `{enum}`: set to 1
+* current-style `{enum}`: set to 1
 * field `{string}`: name of property we're using to calculate color
 * colors `{Map}`: map of field value `{string}` to color `{string}` (from known colors)
 * opacity `{number}`
 
 **single-color:**
-* style `{enum}`: set to 2
+* current-style `{enum}`: set to 2
 * single-color `{string}`: from set of known colors
 * opacity `{number}`
 

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -2,6 +2,7 @@ export {
   colorMap,
   createStyleFunction,
   LayerType,
+    ColorStyle,
 };
 
 const LayerType = {
@@ -13,6 +14,13 @@ const LayerType = {
 };
 Object.freeze(LayerType);
 
+const ColorStyle = {
+  CONTINUOUS: 0,
+  DISCRETE: 1,
+  SINGLE: 2,
+};
+Object.freeze(ColorStyle);
+
 /**
  * Creates the style function for the given properties. Caller should cache to
  * avoid recomputing every time.
@@ -20,23 +28,21 @@ Object.freeze(LayerType);
  * @return {Function}
  */
 function createStyleFunction(colorFunctionProperties) {
-  let styleFunction;
-  if (colorFunctionProperties['single-color']) {
-    const color = colorMap.get(colorFunctionProperties['single-color']);
-    styleFunction = () => color;
-  } else {
-    const continuous = colorFunctionProperties['continuous'];
-    const field = colorFunctionProperties['field'];
-    const opacity = colorFunctionProperties['opacity'];
-    styleFunction = continuous ?
-        createContinuousFunction(
-            field, opacity, colorFunctionProperties['min'],
-            colorFunctionProperties['max'],
-            colorFunctionProperties['base-color']) :
-        createDiscreteFunction(
-            field, opacity, colorFunctionProperties['colors']);
+  const field = colorFunctionProperties['field'];
+  const opacity = colorFunctionProperties['opacity'];
+  switch (colorFunctionProperties['style']) {
+    case ColorStyle.SINGLE:
+      const color = colorMap.get(colorFunctionProperties['single-color']);
+      return () => color;
+    case ColorStyle.CONTINUOUS:
+      return createContinuousFunction(
+          field, opacity, colorFunctionProperties['min'],
+          colorFunctionProperties['max'],
+          colorFunctionProperties['base-color']);
+    case ColorStyle.DISCRETE:
+      return createDiscreteFunction(
+          field, opacity, colorFunctionProperties['colors']);
   }
-  return styleFunction;
 }
 
 /**

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -1,8 +1,8 @@
 export {
   colorMap,
+  ColorStyle,
   createStyleFunction,
   LayerType,
-    ColorStyle,
 };
 
 const LayerType = {
@@ -30,7 +30,7 @@ Object.freeze(ColorStyle);
 function createStyleFunction(colorFunctionProperties) {
   const field = colorFunctionProperties['field'];
   const opacity = colorFunctionProperties['opacity'];
-  switch (colorFunctionProperties['style']) {
+  switch (colorFunctionProperties['current-style']) {
     case ColorStyle.SINGLE:
       const color = colorMap.get(colorFunctionProperties['single-color']);
       return () => color;

--- a/docs/import/add_disaster.js
+++ b/docs/import/add_disaster.js
@@ -5,7 +5,6 @@ import {getFirestoreRoot} from '../firestore_document.js';
 import {disasterCollectionReference, getDisasters} from '../firestore_document.js';
 import {addLoadingElement, loadingElementFinished} from '../loading.js';
 import {getDisaster} from '../resources.js';
-
 import {clearStatus, ILLEGAL_STATE_ERR, setStatus} from './add_disaster_util.js';
 import {withColor} from './color_function_util.js';
 

--- a/docs/import/add_disaster.js
+++ b/docs/import/add_disaster.js
@@ -5,7 +5,8 @@ import {getFirestoreRoot} from '../firestore_document.js';
 import {disasterCollectionReference, getDisasters} from '../firestore_document.js';
 import {addLoadingElement, loadingElementFinished} from '../loading.js';
 import {getDisaster} from '../resources.js';
-import {setStatus, clearStatus, ILLEGAL_STATE_ERR} from './add_disaster_util.js';
+
+import {clearStatus, ILLEGAL_STATE_ERR, setStatus} from './add_disaster_util.js';
 import {withColor} from './color_function_util.js';
 
 export {enableWhenReady, toggleState, updateAfterSort};

--- a/docs/import/add_disaster.js
+++ b/docs/import/add_disaster.js
@@ -5,6 +5,8 @@ import {getFirestoreRoot} from '../firestore_document.js';
 import {disasterCollectionReference, getDisasters} from '../firestore_document.js';
 import {addLoadingElement, loadingElementFinished} from '../loading.js';
 import {getDisaster} from '../resources.js';
+import {setStatus, clearStatus, ILLEGAL_STATE_ERR} from './add_disaster_util.js';
+import {withColor} from './color_function_util.js';
 
 export {enableWhenReady, toggleState, updateAfterSort};
 // Visible for testing
@@ -25,7 +27,6 @@ export {
   stateAssets,
   updateLayersInFirestore,
   withCheckbox,
-  withColor,
   withInput,
   withList,
   withType,
@@ -87,14 +88,14 @@ function toggleDisaster(disaster) {
   return populateStateAssetPickers();
 }
 
-const STATE = {
+const State = {
   SAVED: 0,
   WRITING: 1,
   QUEUED_WRITE: 2,
 };
-Object.freeze(STATE);
+Object.freeze(State);
 
-let state = STATE.SAVED;
+let state = State.SAVED;
 let pendingWriteCount = 0;
 
 window.onbeforeunload = () => pendingWriteCount > 0 ? true : null;
@@ -105,12 +106,12 @@ window.onbeforeunload = () => pendingWriteCount > 0 ? true : null;
  * queued a write and doesn't know when that will finish.
  */
 function updateLayersInFirestore() {
-  if (state !== STATE.SAVED) {
-    state = STATE.QUEUED_WRITE;
+  if (state !== State.SAVED) {
+    state = State.QUEUED_WRITE;
     return null;
   }
   addLoadingElement(writeWaiterId);
-  state = STATE.WRITING;
+  state = State.WRITING;
   pendingWriteCount++;
   return getFirestoreRoot()
       .collection('disaster-metadata')
@@ -119,15 +120,15 @@ function updateLayersInFirestore() {
       .then(() => {
         pendingWriteCount--;
         const oldState = state;
-        state = STATE.SAVED;
+        state = State.SAVED;
         switch (oldState) {
-          case STATE.WRITING:
+          case State.WRITING:
             loadingElementFinished(writeWaiterId);
             return null;
-          case STATE.QUEUED_WRITE:
+          case State.QUEUED_WRITE:
             loadingElementFinished(writeWaiterId);
             return updateLayersInFirestore();
-          case STATE.SAVED:
+          case State.SAVED:
             console.error('Unexpected layer write state');
             return null;
         }
@@ -296,49 +297,6 @@ function withCheckbox(td, layer, property) {
                        .prop('checked', layer[property])
                        .on('change', (event) => onCheck(event, property));
   return td.append(checkbox);
-}
-
-/**
- * Creates an instance of the color boxes for the color col.
- * @param {string} color what color to make the box.
- * @return {JQuery<HTMLDivElement>}
- */
-function createColorBox(color) {
-  return $(document.createElement('div'))
-      .addClass('box')
-      .css('background-color', color);
-}
-
-/**
- * Adds color function info to the given td.
- * @param {JQuery<HTMLElement>} td
- * @param {Object} layer
- * @param {string} property
- * @param {number} index
- * @return {JQuery<HTMLElement>}
- */
-function withColor(td, layer, property, index) {
-  const colorFunction = layer[property];
-  if (!colorFunction) {
-    td.text('N/A').addClass('na');
-  } else if (colorFunction['single-color']) {
-    td.append(createColorBox(colorFunction['single-color']));
-  } else if (colorFunction['base-color']) {
-    td.append(createColorBox(colorFunction['base-color']));
-  } else if (colorFunction['colors']) {
-    const colorObject = colorFunction['colors'];
-    const colorSet = new Set();
-    Object.keys(colorObject).forEach((propertyValue) => {
-      const color = colorObject[propertyValue];
-      if (!colorSet.has(color)) {
-        colorSet.add(color);
-        td.append(createColorBox(colorObject[propertyValue]));
-      }
-    });
-  } else {
-    setStatus(ILLEGAL_STATE_ERR + 'unrecognized color function: ' + layer);
-  }
-  return td;
 }
 
 /** Populates the layers table with layers of current disaster. */
@@ -613,19 +571,6 @@ function deleteDisaster() {
 }
 
 /**
- * Utility function for setting the status div.
- * @param {String} text
- */
-function setStatus(text) {
-  $('#status').text(text).show();
-}
-
-/** Utility function for clearing status div. */
-function clearStatus() {
-  $('#status').hide();
-}
-
-/**
  * Utility function for creating an option with the same val and innerText.
  * @param {String} innerTextAndValue
  * @return {JQuery<HTMLOptionElement>}
@@ -660,6 +605,3 @@ function getCurrentLayers() {
 function setCurrentDisaster(disasterId) {
   localStorage.setItem('disaster', disasterId);
 }
-
-const ILLEGAL_STATE_ERR =
-    'Internal Error: contact developer with the following information: ';

--- a/docs/import/add_disaster_util.js
+++ b/docs/import/add_disaster_util.js
@@ -1,4 +1,4 @@
-export {setStatus, clearStatus, ILLEGAL_STATE_ERR};
+export {clearStatus, ILLEGAL_STATE_ERR, setStatus};
 
 /**
  * Utility function for setting the status div.

--- a/docs/import/add_disaster_util.js
+++ b/docs/import/add_disaster_util.js
@@ -1,0 +1,17 @@
+export {setStatus, clearStatus, ILLEGAL_STATE_ERR};
+
+/**
+ * Utility function for setting the status div.
+ * @param {String} text
+ */
+function setStatus(text) {
+  $('#status').text(text).show();
+}
+
+/** Utility function for clearing status div. */
+function clearStatus() {
+  $('#status').hide();
+}
+
+const ILLEGAL_STATE_ERR =
+    'Internal Error: contact developer with the following information: ';

--- a/docs/import/color_function_util.js
+++ b/docs/import/color_function_util.js
@@ -1,5 +1,6 @@
-import {setStatus, ILLEGAL_STATE_ERR} from './add_disaster_util.js';
 import {ColorStyle} from '../firebase_layers.js';
+
+import {ILLEGAL_STATE_ERR, setStatus} from './add_disaster_util.js';
 
 export {withColor};
 
@@ -16,7 +17,7 @@ function withColor(td, layer, property, index) {
   if (!colorFunction) {
     return td.text('N/A').addClass('na');
   }
-  switch (colorFunction['style']) {
+  switch (colorFunction['current-style']) {
     case ColorStyle.SINGLE:
       td.append(createColorBox(colorFunction['single-color']));
       break;

--- a/docs/import/color_function_util.js
+++ b/docs/import/color_function_util.js
@@ -1,0 +1,52 @@
+import {setStatus, ILLEGAL_STATE_ERR} from './add_disaster_util.js';
+import {ColorStyle} from '../firebase_layers.js';
+
+export {withColor};
+
+/**
+ * Adds color function info to the given td.
+ * @param {JQuery<HTMLElement>} td
+ * @param {Object} layer
+ * @param {string} property
+ * @param {number} index
+ * @return {JQuery<HTMLElement>}
+ */
+function withColor(td, layer, property, index) {
+  const colorFunction = layer[property];
+  if (!colorFunction) {
+    return td.text('N/A').addClass('na');
+  }
+  switch (colorFunction['style']) {
+    case ColorStyle.SINGLE:
+      td.append(createColorBox(colorFunction['single-color']));
+      break;
+    case ColorStyle.CONTINUOUS:
+      td.append(createColorBox(colorFunction['base-color']));
+      break;
+    case ColorStyle.DISCRETE:
+      const colorObject = colorFunction['colors'];
+      const colorSet = new Set();
+      Object.keys(colorObject).forEach((propertyValue) => {
+        const color = colorObject[propertyValue];
+        if (!colorSet.has(color)) {
+          colorSet.add(color);
+          td.append(createColorBox(colorObject[propertyValue]));
+        }
+      });
+      break;
+    default:
+      setStatus(ILLEGAL_STATE_ERR + 'unrecognized color function: ' + layer);
+  }
+  return td;
+}
+
+/**
+ * Creates an instance of the color boxes for the color col.
+ * @param {string} color what color to make the box.
+ * @return {JQuery<HTMLDivElement>}
+ */
+function createColorBox(color) {
+  return $(document.createElement('div'))
+      .addClass('box')
+      .css('background-color', color);
+}


### PR DESCRIPTION
This will allow up to store more than one schema if the user is switching back and forth between color schemas. 

Along the way, rename STATE -> State to keep with other enums we've created. Also, section out a new color function file and a util file for add disaster because it's getting big and will probably continue to grow. 