### PR TITLE
Combine 'single-color' and 'base-color' fields in firestore

### DIFF
--- a/cypress/integration/unit_tests/add_disaster_test.js
+++ b/cypress/integration/unit_tests/add_disaster_test.js
@@ -234,14 +234,14 @@ describe('Unit tests for add_disaster page', () => {
 
     const yellow = 'yellow';
     const singleColor = withColor(
-        createTd(), {color: {'current-style': 2, 'single-color': yellow}},
+        createTd(), {color: {'current-style': 2, 'color': yellow}},
         property, 0);
     expect(singleColor.children('.box').length).to.equal(1);
     expect(singleColor.children().eq(0).css('background-color'))
         .to.equal(yellow);
 
     const baseColor = withColor(
-        createTd(), {color: {'current-style': 0, 'base-color': yellow}},
+        createTd(), {color: {'current-style': 0, 'color': yellow}},
         property, 0);
     expect(baseColor.children('.box').length).to.equal(1);
     expect(baseColor.children().eq(0).css('background-color')).to.equal(yellow);

--- a/cypress/integration/unit_tests/add_disaster_test.js
+++ b/cypress/integration/unit_tests/add_disaster_test.js
@@ -234,15 +234,15 @@ describe('Unit tests for add_disaster page', () => {
 
     const yellow = 'yellow';
     const singleColor = withColor(
-        createTd(), {color: {'current-style': 2, 'color': yellow}},
-        property, 0);
+        createTd(), {color: {'current-style': 2, 'color': yellow}}, property,
+        0);
     expect(singleColor.children('.box').length).to.equal(1);
     expect(singleColor.children().eq(0).css('background-color'))
         .to.equal(yellow);
 
     const baseColor = withColor(
-        createTd(), {color: {'current-style': 0, 'color': yellow}},
-        property, 0);
+        createTd(), {color: {'current-style': 0, 'color': yellow}}, property,
+        0);
     expect(baseColor.children('.box').length).to.equal(1);
     expect(baseColor.children().eq(0).css('background-color')).to.equal(yellow);
 

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -8,7 +8,7 @@ import {createGoogleMap} from '../../support/test_map';
 const mockData = {};
 
 const colorProperties = {
-  'single-color': 'yellow',
+  'color': 'yellow',
 };
 const mockFirebaseLayers = [
   {

--- a/cypress/integration/unit_tests/style_functions_test.js
+++ b/cypress/integration/unit_tests/style_functions_test.js
@@ -23,7 +23,7 @@ describe('Unit test for generating style functions', () => {
     const fxn = createStyleFunction({
       'current-style': 0,
       'field': 'oranges',
-      'base-color': 'orange',
+      'color': 'orange',
       'opacity': 83,
       'min': 14,
       'max': 10005,
@@ -40,7 +40,7 @@ describe('Unit test for generating style functions', () => {
   it('calculates a single-color function', () => {
     const fxn = createStyleFunction({
       'current-style': 2,
-      'single-color': 'blue',
+      'color': 'blue',
       'opacity': 83,
     });
     const trueBlue = fxn({});

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ We have three types of coloring schemes: continuous, discrete, and single color.
 
 **continuous:**
 * current-style `{enum}`: set to 0
-* color `{string}`: from known colors
+* color `{string}`: from set of known colors
 * field `{string}`: name of property we're using to calculate color
 * max `{number}`: max value of field
 * min `{number}`: min value of field

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ We have three types of coloring schemes: continuous, discrete, and single color.
 
 **continuous:**
 * current-style `{enum}`: set to 0
-* base-color `{string}`: from known colors
+* color `{string}`: from known colors
 * field `{string}`: name of property we're using to calculate color
 * max `{number}`: max value of field
 * min `{number}`: min value of field
@@ -40,7 +40,7 @@ We have three types of coloring schemes: continuous, discrete, and single color.
 
 **single-color:**
 * current-style `{enum}`: set to 2
-* single-color `{string}`: from set of known colors
+* color `{string}`: from set of known colors
 * opacity `{number}`
 
 Note - all `color-fxn` objects have the opacity field. 

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -37,8 +37,7 @@ function createStyleFunction(colorFunctionProperties) {
     case ColorStyle.CONTINUOUS:
       return createContinuousFunction(
           field, opacity, colorFunctionProperties['min'],
-          colorFunctionProperties['max'],
-          colorFunctionProperties['color']);
+          colorFunctionProperties['max'], colorFunctionProperties['color']);
     case ColorStyle.DISCRETE:
       return createDiscreteFunction(
           field, opacity, colorFunctionProperties['colors']);

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -32,13 +32,13 @@ function createStyleFunction(colorFunctionProperties) {
   const opacity = colorFunctionProperties['opacity'];
   switch (colorFunctionProperties['current-style']) {
     case ColorStyle.SINGLE:
-      const color = colorMap.get(colorFunctionProperties['single-color']);
+      const color = colorMap.get(colorFunctionProperties['color']);
       return () => color;
     case ColorStyle.CONTINUOUS:
       return createContinuousFunction(
           field, opacity, colorFunctionProperties['min'],
           colorFunctionProperties['max'],
-          colorFunctionProperties['base-color']);
+          colorFunctionProperties['color']);
     case ColorStyle.DISCRETE:
       return createDiscreteFunction(
           field, opacity, colorFunctionProperties['colors']);

--- a/docs/import/color_function_util.js
+++ b/docs/import/color_function_util.js
@@ -19,10 +19,10 @@ function withColor(td, layer, property, index) {
   }
   switch (colorFunction['current-style']) {
     case ColorStyle.SINGLE:
-      td.append(createColorBox(colorFunction['single-color']));
+      td.append(createColorBox(colorFunction['color']));
       break;
     case ColorStyle.CONTINUOUS:
-      td.append(createColorBox(colorFunction['base-color']));
+      td.append(createColorBox(colorFunction['color']));
       break;
     case ColorStyle.DISCRETE:
       const colorObject = colorFunction['colors'];


### PR DESCRIPTION
We have an explicit current schema field now so we don't need these to be separate. This also means if a user is switching between continuous and single the property gets reused across the different schemas. 