### PR TITLE
Use relative path to load navbar

### DIFF
--- a/docs/navbar.js
+++ b/docs/navbar.js
@@ -6,7 +6,7 @@ export {loadNavbar, loadNavbarWithTitle};
  * @param {Function} callback the callback invoked upon load
  */
 function loadNavbar(callback) {
-  $('#navbar').load('/navbar.html', callback);
+  $('#navbar').load('./navbar.html', callback);
 }
 
 /**


### PR DESCRIPTION
This should fix being able to see the navbar on our github pages served site