### PR TITLE
Fix import data test

### DIFF
--- a/cypress/integration/integration_tests/polygon_draw_test.js
+++ b/cypress/integration/integration_tests/polygon_draw_test.js
@@ -334,5 +334,5 @@ function saveAndAwait() {
  * click because page may still be loading, causing "animation".
  */
 function startDrawing() {
-  cy.get('[title="Draw a shape"]', {timeout: 10000}).click({force: true});
+  cy.get('[title="Draw a shape"]', {timeout: 20000}).click({force: true});
 }

--- a/cypress/integration/unit_tests/add_disaster_test.js
+++ b/cypress/integration/unit_tests/add_disaster_test.js
@@ -4,7 +4,7 @@ import {addDisaster, createAssetPickers, createOptionFrom, createTd, deleteDisas
 import {withColor} from '../../../docs/import/color_function_util.js';
 import * as loading from '../../../docs/loading.js';
 import {getDisaster} from '../../../docs/resources';
-import {addFirebaseHooks, loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
+import {initFirebaseForUnitTest, loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
 
 const KNOWN_STATE = 'WF';
 const UNKNOWN_STATE = 'DN';
@@ -15,10 +15,8 @@ let loadingFinishedStub;
 
 describe('Unit tests for add_disaster page', () => {
   loadScriptsBeforeForUnitTests('ee', 'firebase', 'jquery');
-  addFirebaseHooks();
+  initFirebaseForUnitTest();
   before(() => {
-    cy.wrap(firebase.auth().signInWithCustomToken(firestoreCustomToken));
-
     const disasterPicker = createAndAppend('select', 'disaster');
     disasterPicker.append(createOptionFrom('2003-spring'));
     disasterPicker.append(createOptionFrom('2001-summer'));

--- a/cypress/integration/unit_tests/center_test.js
+++ b/cypress/integration/unit_tests/center_test.js
@@ -1,9 +1,6 @@
 import {computeAndSaveBounds} from '../../../docs/import/center';
 import {assertFirestoreMapBounds, expectLatLngBoundsWithin} from '../../support/firestore_map_bounds';
-import {
-  initFirebaseForUnitTest,
-  loadScriptsBeforeForUnitTests
-} from '../../support/script_loader';
+import {initFirebaseForUnitTest, loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
 describe('Unit test for center.js', () => {
   loadScriptsBeforeForUnitTests('ee', 'firebase');

--- a/cypress/integration/unit_tests/center_test.js
+++ b/cypress/integration/unit_tests/center_test.js
@@ -1,13 +1,13 @@
 import {computeAndSaveBounds} from '../../../docs/import/center';
 import {assertFirestoreMapBounds, expectLatLngBoundsWithin} from '../../support/firestore_map_bounds';
-import {addFirebaseHooks, loadScriptsBeforeForUnitTests} from '../../support/script_loader';
+import {
+  initFirebaseForUnitTest,
+  loadScriptsBeforeForUnitTests
+} from '../../support/script_loader';
 
 describe('Unit test for center.js', () => {
   loadScriptsBeforeForUnitTests('ee', 'firebase');
-  addFirebaseHooks();
-  before(
-      () =>
-          cy.wrap(firebase.auth().signInWithCustomToken(firestoreCustomToken)));
+  initFirebaseForUnitTest();
 
   it('calculates bounds', () => {
     const damageCollection = ee.FeatureCollection([

--- a/cypress/integration/unit_tests/import_data_test.js
+++ b/cypress/integration/unit_tests/import_data_test.js
@@ -1,10 +1,7 @@
 import {run} from '../../../docs/import/import_data';
 import {convertEeObjectToPromise} from '../../../docs/map_util';
 import {assertFirestoreMapBounds} from '../../support/firestore_map_bounds';
-import {
-  initFirebaseForUnitTest,
-  loadScriptsBeforeForUnitTests
-} from '../../support/script_loader';
+import {initFirebaseForUnitTest, loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
 describe('Unit tests for import_data.js', () => {
   loadScriptsBeforeForUnitTests('ee', 'firebase', 'jquery');

--- a/cypress/integration/unit_tests/import_data_test.js
+++ b/cypress/integration/unit_tests/import_data_test.js
@@ -1,10 +1,14 @@
 import {run} from '../../../docs/import/import_data';
 import {convertEeObjectToPromise} from '../../../docs/map_util';
 import {assertFirestoreMapBounds} from '../../support/firestore_map_bounds';
-import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
+import {
+  initFirebaseForUnitTest,
+  loadScriptsBeforeForUnitTests
+} from '../../support/script_loader';
 
 describe('Unit tests for import_data.js', () => {
   loadScriptsBeforeForUnitTests('ee', 'firebase', 'jquery');
+  initFirebaseForUnitTest();
   let testData;
   let exportStub;
   beforeEach(() => {

--- a/cypress/integration/unit_tests/import_data_test.js
+++ b/cypress/integration/unit_tests/import_data_test.js
@@ -71,7 +71,8 @@ describe('Unit tests for import_data.js', () => {
     };
   });
   it('Basic test', () => {
-    const {boundsPromise, mapBoundsCallback} = makeCallbackForTextAndPromise('Found bounds');
+    const {boundsPromise, mapBoundsCallback} =
+        makeCallbackForTextAndPromise('Found bounds');
     expect(run(testData, mapBoundsCallback)).to.be.true;
     expect(exportStub).to.be.calledOnce;
     cy.wrap(convertEeObjectToPromise(exportStub.firstCall.args[0]))
@@ -105,7 +106,8 @@ describe('Unit tests for import_data.js', () => {
     testData.asset_data.map_bounds_ne =
         expectedLatLngBounds.ne.lat + ', ' + expectedLatLngBounds.ne.lng;
 
-    const {boundsPromise, mapBoundsCallback} = makeCallbackForTextAndPromise('Wrote bounds');
+    const {boundsPromise, mapBoundsCallback} =
+        makeCallbackForTextAndPromise('Wrote bounds');
     expect(run(testData, mapBoundsCallback)).to.be.true;
     expect(exportStub).to.be.calledOnce;
     cy.wrap(convertEeObjectToPromise(exportStub.firstCall.args[0]))
@@ -232,7 +234,8 @@ function scaleObject(object) {
  * Creates a callback for use with {@link run} so that we will be informed when
  * the Firestore write has completed. Returns a Promise that can be waited on
  * for that write to complete.
- * @param {string} expectedText Text contained in message when Firestore write is complete
+ * @param {string} expectedText Text contained in message when Firestore write
+ *     is complete
  * @return {{boundsPromise: Promise, mapBoundsCallback: Function}}
  */
 function makeCallbackForTextAndPromise(expectedText) {

--- a/cypress/integration/unit_tests/import_data_test.js
+++ b/cypress/integration/unit_tests/import_data_test.js
@@ -8,6 +8,9 @@ describe('Unit tests for import_data.js', () => {
   let testData;
   let exportStub;
   beforeEach(() => {
+    const computeStatusDiv = document.createElement('div');
+    computeStatusDiv.id = 'compute-status';
+    document.body.appendChild(computeStatusDiv);
     // Create a pretty trivial world: 2 block groups, each a 1x2 vertical
     // stripes. Under the covers, we scale all dimensions down because
     // production code creates an "envelope" 1 km wide around damage, and that
@@ -87,6 +90,8 @@ describe('Unit tests for import_data.js', () => {
             'TOTAL HOUSEHOLDS': 15,
           });
         });
+    cy.wrap(waitForText($('#compute-status'), 'Found bounds'));
+
     assertFirestoreMapBounds(
         scaleObject({sw: {lng: 0.4, lat: 0.5}, ne: {lng: 10, lat: 12}}));
   });
@@ -119,6 +124,7 @@ describe('Unit tests for import_data.js', () => {
             'TOTAL HOUSEHOLDS': 15,
           });
         });
+    cy.wrap(waitForText($('#compute-status'), 'Wrote bounds'));
     assertFirestoreMapBounds(expectedLatLngBounds);
   });
 
@@ -219,4 +225,16 @@ function scaleObject(object) {
     newObject[key] = scaleObject(object[key]);
   }
   return newObject;
+}
+
+function waitForText(div, text, timeout = 4000, startTime = new Date()) {
+  if (new Date() - startTime > timeout) {
+    expect(div.text()).to.contain(text);
+  }
+  if (div.text().includes(text)) {
+    return Promise.resolve();
+  }
+  return new Promise(
+      (resolve) => setTimeout(
+          () => resolve(waitForText(div, text, timeout, startTime)), 100));
 }

--- a/cypress/integration/unit_tests/import_data_test.js
+++ b/cypress/integration/unit_tests/import_data_test.js
@@ -8,9 +8,6 @@ describe('Unit tests for import_data.js', () => {
   let testData;
   let exportStub;
   beforeEach(() => {
-    const computeStatusDiv = document.createElement('div');
-    computeStatusDiv.id = 'compute-status';
-    document.body.appendChild(computeStatusDiv);
     // Create a pretty trivial world: 2 block groups, each a 1x2 vertical
     // stripes. Under the covers, we scale all dimensions down because
     // production code creates an "envelope" 1 km wide around damage, and that

--- a/cypress/support/firestore_map_bounds.js
+++ b/cypress/support/firestore_map_bounds.js
@@ -9,7 +9,8 @@ export {assertFirestoreMapBounds, expectLatLngBoundsWithin};
  *     expectedLatLngBounds
  */
 function assertFirestoreMapBounds(expectedLatLngBounds) {
-  cy.wrap(readDisasterDocument()).then((doc) => {
+  // Make sure we don't call readDisasterDocument until Cypress is ready.
+  cy.wrap(null).then(readDisasterDocument).then((doc) => {
     // Expect that result retrieved from Firestore is correct.
     const mapBounds = doc.data()['map-bounds'];
     expectLatLngBoundsWithin(

--- a/cypress/support/script_loader.js
+++ b/cypress/support/script_loader.js
@@ -4,7 +4,7 @@ import {cypressTestCookieName, earthEngineTestTokenCookieName, firebaseTestToken
 export {
   addFirebaseHooks,
   initFirebaseForUnitTest,
-  loadScriptsBeforeForUnitTests
+  loadScriptsBeforeForUnitTests,
 };
 
 /**

--- a/cypress/support/script_loader.js
+++ b/cypress/support/script_loader.js
@@ -1,7 +1,7 @@
 import {CLIENT_ID, getFirebaseConfig} from '../../docs/authenticate';
 import {cypressTestCookieName, earthEngineTestTokenCookieName, firebaseTestTokenCookieName} from '../../docs/in_test_util';
 
-export {addFirebaseHooks, loadScriptsBeforeForUnitTests};
+export {addFirebaseHooks, loadScriptsBeforeForUnitTests, initFirebaseForUnitTest};
 
 /**
  * Scripts that unit tests may want to load. Values have script and callback
@@ -124,10 +124,9 @@ function loadScriptsBeforeForUnitTests(...scriptKeys) {
     });
   }
   if (usesFirebase) {
-    // Currently no unit test actually writes to Firestore, they just use the
-    // library. A unit test that really writes to Firestore will be responsible
-    // for calling the necessary functions (addFirebaseHooks and logging in with
-    // the custom token, similar to what is done in prod).
+    // Some unit tests just use the Firebase library, so that's all we prepare
+    // for here. A unit test that really writes to Firestore has to call
+    // initFirebaseForUnitTest.
     before(() => {
       firebase.initializeApp(getFirebaseConfig(/* inProduction */ false));
     });
@@ -152,6 +151,14 @@ function addFirebaseHooks() {
     cy.setCookie(cypressTestCookieName, testCookieValue);
   });
   afterEach(() => cy.task('deleteTestData', testCookieValue));
+}
+
+/** Prepares this unit test to actually write to and read from Firestore. */
+function initFirebaseForUnitTest() {
+  addFirebaseHooks();
+  before(
+      () =>
+          cy.wrap(firebase.auth().signInWithCustomToken(firestoreCustomToken)));
 }
 
 /**

--- a/cypress/support/script_loader.js
+++ b/cypress/support/script_loader.js
@@ -1,7 +1,11 @@
 import {CLIENT_ID, getFirebaseConfig} from '../../docs/authenticate';
 import {cypressTestCookieName, earthEngineTestTokenCookieName, firebaseTestTokenCookieName} from '../../docs/in_test_util';
 
-export {addFirebaseHooks, loadScriptsBeforeForUnitTests, initFirebaseForUnitTest};
+export {
+  addFirebaseHooks,
+  initFirebaseForUnitTest,
+  loadScriptsBeforeForUnitTests
+};
 
 /**
  * Scripts that unit tests may want to load. Values have script and callback

--- a/docs/import/import_data.js
+++ b/docs/import/import_data.js
@@ -341,7 +341,9 @@ function calculateDamage(assetData) {
   const ne = makeLatLngFromString(damageNe);
   const damageEnvelope =
       ee.Geometry.Rectangle([sw.lng, sw.lat, ne.lng, ne.lat]);
-  saveBounds(makeGeoJsonRectangle(sw, ne)).catch(firestoreError);
+  saveBounds(makeGeoJsonRectangle(sw, ne))
+      .then(() => centerStatusSpan.innerText = 'Wrote bounds')
+      .catch(firestoreError);
   return {
     damage: null,
     damageEnvelope: damageEnvelope,

--- a/docs/import/import_data.js
+++ b/docs/import/import_data.js
@@ -142,7 +142,7 @@ function addTractInfo(feature) {
   return feature.set(tractTag, ee.String(feature.get(geoidTag)).slice(0, -1));
 }
 
-let setMapBoundsInfoCalled = false;
+let setMapBoundsInfoCalledOnce = false;
 
 /**
  * Utility function that sets the label for the bounds status the first time it
@@ -152,7 +152,7 @@ let setMapBoundsInfoCalled = false;
  *     called, and then result the second time
  */
 function setMapBoundsInfo(message) {
-  if (setMapBoundsInfoCalled) {
+  if (setMapBoundsInfoCalledOnce) {
     $('#bounds-status-span').text(message);
   } else {
     const boundsStatusSpan = document.createElement('span');
@@ -160,6 +160,7 @@ function setMapBoundsInfo(message) {
     boundsStatusSpan.id = 'bounds-status-span';
     $('#compute-status').append(boundsStatusLabel).append(boundsStatusSpan);
     boundsStatusSpan.innerText = 'in progress...';
+    setMapBoundsInfoCalledOnce = true;
   }
 }
 

--- a/docs/import/import_data.js
+++ b/docs/import/import_data.js
@@ -148,7 +148,8 @@ let setMapBoundsInfoCalled = false;
  * Utility function that sets the label for the bounds status the first time it
  * is called, then sets the status the second time. Useful for injecting over in
  * tests.
- * @param {string} message Description of task to be done the first time this is called, and then result the second time
+ * @param {string} message Description of task to be done the first time this is
+ *     called, and then result the second time
  */
 function setMapBoundsInfo(message) {
   if (setMapBoundsInfoCalled) {
@@ -165,7 +166,9 @@ function setMapBoundsInfo(message) {
 /**
  * Performs operation of processing inputs and creating output asset.
  * @param {Object} disasterData Data for current disaster coming from Firestore
- * @param {Function} setMapBoundsInfoFunction Function to be called when map bounds-related operations are complete. First called with a message about the task, then called with the results
+ * @param {Function} setMapBoundsInfoFunction Function to be called when map
+ *     bounds-related operations are complete. First called with a message about
+ *     the task, then called with the results
  * @return {boolean} Whether in-thread operations succeeded
  */
 function run(disasterData, setMapBoundsInfoFunction = setMapBoundsInfo) {
@@ -219,7 +222,8 @@ function run(disasterData, setMapBoundsInfoFunction = setMapBoundsInfo) {
   if (!buildingPaths) {
     return missingAssetError('building data asset paths');
   }
-  const {damage, damageEnvelope} = calculateDamage(assetData, setMapBoundsInfoFunction);
+  const {damage, damageEnvelope} =
+      calculateDamage(assetData, setMapBoundsInfoFunction);
   if (!damageEnvelope) {
     // Must have been an error.
     return false;
@@ -313,7 +317,8 @@ const damageBuffer = 1000;
  * Calculates damage if there is a damage asset, or simply writes the
  * user-provided bounds to Firestore if not.
  * @param {Object} assetData
- * @param {Function} setMapBoundsInfo Function to call with information about map bounds work. First call will have the task, second call the result.
+ * @param {Function} setMapBoundsInfo Function to call with information about
+ *     map bounds work. First call will have the task, second call the result.
  * @return {{damage: ?ee.FeatureCollection, damageEnvelope:
  *     ee.Geometry.Rectangle}|{damage: null, damageEnvelope: null}} Returns
  *     the damage asset (if present) and the envelope bounding the damage, or

--- a/docs/import/import_data.js
+++ b/docs/import/import_data.js
@@ -142,12 +142,33 @@ function addTractInfo(feature) {
   return feature.set(tractTag, ee.String(feature.get(geoidTag)).slice(0, -1));
 }
 
+let setMapBoundsInfoCalled = false;
+
+/**
+ * Utility function that sets the label for the bounds status the first time it
+ * is called, then sets the status the second time. Useful for injecting over in
+ * tests.
+ * @param {string} message Description of task to be done the first time this is called, and then result the second time
+ */
+function setMapBoundsInfo(message) {
+  if (setMapBoundsInfoCalled) {
+    $('#bounds-status-span').text(message);
+  } else {
+    const boundsStatusSpan = document.createElement('span');
+    const boundsStatusLabel = document.createElement('span');
+    boundsStatusSpan.id = 'bounds-status-span';
+    $('#compute-status').append(boundsStatusLabel).append(boundsStatusSpan);
+    boundsStatusSpan.innerText = 'in progress...';
+  }
+}
+
 /**
  * Performs operation of processing inputs and creating output asset.
  * @param {Object} disasterData Data for current disaster coming from Firestore
+ * @param {Function} setMapBoundsInfoFunction Function to be called when map bounds-related operations are complete. First called with a message about the task, then called with the results
  * @return {boolean} Whether in-thread operations succeeded
  */
-function run(disasterData) {
+function run(disasterData, setMapBoundsInfoFunction = setMapBoundsInfo) {
   $('#compute-status').html('');
   const states = disasterData['states'];
   if (!states) {
@@ -198,7 +219,7 @@ function run(disasterData) {
   if (!buildingPaths) {
     return missingAssetError('building data asset paths');
   }
-  const {damage, damageEnvelope} = calculateDamage(assetData);
+  const {damage, damageEnvelope} = calculateDamage(assetData, setMapBoundsInfoFunction);
   if (!damageEnvelope) {
     // Must have been an error.
     return false;
@@ -292,37 +313,32 @@ const damageBuffer = 1000;
  * Calculates damage if there is a damage asset, or simply writes the
  * user-provided bounds to Firestore if not.
  * @param {Object} assetData
+ * @param {Function} setMapBoundsInfo Function to call with information about map bounds work. First call will have the task, second call the result.
  * @return {{damage: ?ee.FeatureCollection, damageEnvelope:
  *     ee.Geometry.Rectangle}|{damage: null, damageEnvelope: null}} Returns
  *     the damage asset (if present) and the envelope bounding the damage, or
  *     both null if an error occurs
  */
-function calculateDamage(assetData) {
+function calculateDamage(assetData, setMapBoundsInfo) {
   const damagePath = assetData['damage_asset_path'];
-  const centerStatusSpan = document.createElement('span');
-  const centerStatusLabel = document.createElement('span');
-  $('#compute-status').append(centerStatusLabel).append(centerStatusSpan);
-  centerStatusSpan.innerText = 'in progress';
-  const firestoreError = (err) => centerStatusSpan.innerText +=
-      'Error writing bounds to Firestore: ' + err;
   if (damagePath) {
     const damage = ee.FeatureCollection(damagePath);
     // Uncomment to test with a restricted damage set (14 block groups' worth).
     // damage = damage.filterBounds(
     //     ee.FeatureCollection('users/gd/2017-harvey/data-ms-as-nod')
     //         .filterMetadata('GEOID', 'starts_with', '482015417002'));
-    centerStatusLabel.innerText = 'Computing and storing bounds of map: ';
+    setMapBoundsInfo('Computing and storing bounds of map: ');
     computeAndSaveBounds(damage)
         .then(displayGeoNumbers)
-        .then((bounds) => centerStatusSpan.innerText = 'Found bounds ' + bounds)
-        .catch((err) => centerStatusSpan.innerText = err);
+        .then((bounds) => setMapBoundsInfo('Found bounds ' + bounds))
+        .catch(setMapBoundsInfo);
     return {damage, damageEnvelope: damage.geometry().buffer(damageBuffer)};
   }
   // TODO(janakr): in the no-damage case, we're storing a rectangle, but
   //  experiments show that, at least for Harvey, the page is very slow when we
   //  load the entire rectangle around the damage. Maybe allow users to select a
   //  polygon so they can draw a tighter area?
-  centerStatusLabel.innerText = 'Storing bounds of map: ';
+  setMapBoundsInfo('Storing bounds of map: ');
   const damageSw = assetData['map_bounds_sw'];
   if (!damageSw) {
     missingAssetError(
@@ -342,8 +358,8 @@ function calculateDamage(assetData) {
   const damageEnvelope =
       ee.Geometry.Rectangle([sw.lng, sw.lat, ne.lng, ne.lat]);
   saveBounds(makeGeoJsonRectangle(sw, ne))
-      .then(() => centerStatusSpan.innerText = 'Wrote bounds')
-      .catch(firestoreError);
+      .then(() => setMapBoundsInfo('Wrote bounds'))
+      .catch(setMapBoundsInfo);
   return {
     damage: null,
     damageEnvelope: damageEnvelope,

--- a/docs/import/import_data.js
+++ b/docs/import/import_data.js
@@ -150,8 +150,8 @@ function addTractInfo(feature) {
  *     called, and then result the second time
  */
 function setMapBoundsInfo(message) {
-  const boundsStatusSpan = $('#bounds-status-span');
-  if (!boundsStatusSpan.length) {
+  const boundsStatusElement = $('#bounds-status-span');
+  if (!boundsStatusElement.length) {
     // Haven't done anything yet, create and initialize.
     const boundsStatusSpan = document.createElement('span');
     const boundsStatusLabel = document.createElement('span');
@@ -160,7 +160,7 @@ function setMapBoundsInfo(message) {
     boundsStatusSpan.innerText = 'in progress...';
     boundsStatusLabel.innerText = message;
   } else {
-    boundsStatusSpan.text(message);
+    boundsStatusElement.text(message);
   }
 }
 

--- a/docs/import/import_data.js
+++ b/docs/import/import_data.js
@@ -160,6 +160,7 @@ function setMapBoundsInfo(message) {
     boundsStatusSpan.id = 'bounds-status-span';
     $('#compute-status').append(boundsStatusLabel).append(boundsStatusSpan);
     boundsStatusSpan.innerText = 'in progress...';
+    boundsStatusLabel.innerText = message;
     setMapBoundsInfoCalledOnce = true;
   }
 }
@@ -297,7 +298,7 @@ function run(disasterData, setMapBoundsInfoFunction = setMapBoundsInfo) {
   }
   const task = ee.batch.Export.table.toAsset(
       allStatesProcessing,
-      scoreAssetPath.substring(scoreAssetPath.lastIndexOf('/')),
+      scoreAssetPath.substring(scoreAssetPath.lastIndexOf('/') + 1),
       scoreAssetPath);
   task.start();
   $('#upload-status')

--- a/docs/import/import_data.js
+++ b/docs/import/import_data.js
@@ -142,8 +142,6 @@ function addTractInfo(feature) {
   return feature.set(tractTag, ee.String(feature.get(geoidTag)).slice(0, -1));
 }
 
-let setMapBoundsInfoCalledOnce = false;
-
 /**
  * Utility function that sets the label for the bounds status the first time it
  * is called, then sets the status the second time. Useful for injecting over in
@@ -152,16 +150,17 @@ let setMapBoundsInfoCalledOnce = false;
  *     called, and then result the second time
  */
 function setMapBoundsInfo(message) {
-  if (setMapBoundsInfoCalledOnce) {
-    $('#bounds-status-span').text(message);
-  } else {
+  const boundsStatusSpan = $('#bounds-status-span');
+  if (!boundsStatusSpan.length) {
+    // Haven't done anything yet, create and initialize.
     const boundsStatusSpan = document.createElement('span');
     const boundsStatusLabel = document.createElement('span');
     boundsStatusSpan.id = 'bounds-status-span';
     $('#compute-status').append(boundsStatusLabel).append(boundsStatusSpan);
     boundsStatusSpan.innerText = 'in progress...';
     boundsStatusLabel.innerText = message;
-    setMapBoundsInfoCalledOnce = true;
+  } else {
+    boundsStatusSpan.text(message);
   }
 }
 

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -18,7 +18,9 @@ function getScoreAsset() {
   // TODO(janakr): Modify map to handle no-damage scenario more intuitively.
   //  Should make damage threshold, weight 0, probably hide those toggles
   //  completely. Other changes?
-  return gdEePathPrefix + getDisaster() + '/data-ms-as-tot';
+  // TODO(janakr): switch back to -as-tot when regenerated, and make a backup
+  //  so you don't lose it again.
+  return gdEePathPrefix + getDisaster() + '/data-ms-as-nod';
 }
 
 /** The default disaster. */

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -18,9 +18,7 @@ function getScoreAsset() {
   // TODO(janakr): Modify map to handle no-damage scenario more intuitively.
   //  Should make damage threshold, weight 0, probably hide those toggles
   //  completely. Other changes?
-  // TODO(janakr): switch back to -as-tot when regenerated, and make a backup
-  //  so you don't lose it again.
-  return gdEePathPrefix + getDisaster() + '/data-ms-as-nod';
+  return gdEePathPrefix + getDisaster() + '/data-ms-as-tot';
 }
 
 /** The default disaster. */


### PR DESCRIPTION
We were kicking off the Firestore fetch without waiting for anything. ~I still don't understand how that fetch could see data from a different test case (because we wipe data between tests), but~ 
 What we were doing before was clearly wrong on two levels: we weren't waiting for the write to complete, and we were doing the read in program order, not Cypress order. Fixed both of those, with not too bad a hack on the first side, I hope.

Also, we weren't actually doing any proper setup in import_data_test for Firebase, which explains why the data was sticking around. Fixed that. We didn't need to do proper setup because I had apparently made the database global read-write during testing and forgotten to restrict it. I've tested with the restriction (it works) and undone it for now. Will restrict after this PR is in.

Also fixed an off-by-one error in the task description for import_data.js's EE export. ~, and temporarily use the old score asset since I was an idiot and deleted it while testing this page.~

Also extend polygon_draw_test timeout a bit.