### PR TITLE
Partially deflake polygon_draw_test

### DIFF
--- a/docs/popup.js
+++ b/docs/popup.js
@@ -61,9 +61,6 @@ function setUpPopup() {
      */
     setCalculatedData(calculatedData) {
       this.calculatedData = calculatedData;
-      checkPresent(
-          this.calculatedDataDiv, 'calculatedDataDiv not present when setting');
-      this.calculatedDataDiv.style.color = 'black';
       this.updateCalculatedDataDiv();
     }
 
@@ -86,6 +83,7 @@ function setUpPopup() {
         this.calculatedDataDiv.style.color = 'grey';
       } else {
         displayCalculatedData(this.calculatedData, this.calculatedDataDiv);
+        this.calculatedDataDiv.style.color = 'black';
       }
     }
 


### PR DESCRIPTION
This is actually a bug in production, though a very hard one to hit. We were assuming that by the time the calculated data for a polygon was ready, the popup's html was created. However, the popup's html is normally created in onAdd, called by the Google Map, which happens in a separate thread from popup creation (verified with console debug statements). Thus, it is possible for the calculated data task to complete and try update calculated data before the div is present. Tolerate that situation: when the div is created, it will be initialized to the proper value in createPopupHtml() anyway.