### PR TITLE
Fix a bug where we weren't initializing a layer array on new disaster creation

### DIFF
--- a/cypress/integration/unit_tests/add_disaster_test.js
+++ b/cypress/integration/unit_tests/add_disaster_test.js
@@ -1,7 +1,6 @@
 import {gdEeStatePrefix, legacyStateDir, legacyStatePrefix} from '../../../docs/ee_paths.js';
 import {getFirestoreRoot} from '../../../docs/firestore_document.js';
 import {addDisaster, createOptionFrom, createStateAssetPickers, createTd, deleteDisaster, emptyCallback, getStatesAssetsFromEe, onCheck, onDelete, onInputBlur, onListBlur, stateAssets, updateAfterSort, withCheckbox, withInput, withList, withType, writeNewDisaster} from '../../../docs/import/add_disaster.js';
-import {getCurrentData} from '../../../docs/import/add_disaster_util';
 import {disasterData, getCurrentLayers} from '../../../docs/import/add_disaster_util.js';
 import {withColor} from '../../../docs/import/color_function_util.js';
 import * as loading from '../../../docs/loading.js';

--- a/cypress/integration/unit_tests/add_disaster_test.js
+++ b/cypress/integration/unit_tests/add_disaster_test.js
@@ -1,6 +1,7 @@
 import {gdEeStatePrefix, legacyStateDir, legacyStatePrefix} from '../../../docs/ee_paths.js';
 import {getFirestoreRoot} from '../../../docs/firestore_document.js';
 import {addDisaster, createOptionFrom, createStateAssetPickers, createTd, deleteDisaster, emptyCallback, getStatesAssetsFromEe, onCheck, onDelete, onInputBlur, onListBlur, stateAssets, updateAfterSort, withCheckbox, withInput, withList, withType, writeNewDisaster} from '../../../docs/import/add_disaster.js';
+import {getCurrentData} from '../../../docs/import/add_disaster_util';
 import {disasterData, getCurrentLayers} from '../../../docs/import/add_disaster_util.js';
 import {withColor} from '../../../docs/import/color_function_util.js';
 import * as loading from '../../../docs/loading.js';
@@ -105,6 +106,8 @@ describe('Unit tests for add_disaster page', () => {
         .then((success) => {
           expect(success).to.be.true;
           expect($('#status').is(':visible')).to.be.false;
+          expect(disasterData.get(id)['layers']).to.eql([]);
+          expect(disasterData.get(id)['states']).to.eql(states);
           const disasterPicker = $('#disaster');
           expect(disasterPicker.is(':visible')).to.be.true;
           expect($('#pending-disaster').is(':visible')).to.be.false;

--- a/docs/import/add_disaster.js
+++ b/docs/import/add_disaster.js
@@ -432,7 +432,8 @@ function writeNewDisaster(disasterId, states) {
     setStatus('Error: disaster with that name and year already exists.');
     return Promise.resolve(false);
   }
-  disasterData.set(disasterId, {states: states});
+  const data = {states: states, layers: []};
+  disasterData.set(disasterId, data);
   clearStatus();
 
   const disasterPicker = $('#disaster');
@@ -454,7 +455,7 @@ function writeNewDisaster(disasterId, states) {
 
   return disasterCollectionReference()
       .doc(disasterId)
-      .set({states: states, layers: []})
+      .set(data)
       .then(() => true);
 }
 


### PR DESCRIPTION
This was causing undefined errors later on