### PR TITLE
write disaster folder on new disaster write

### DIFF
--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -22,6 +22,8 @@ describe('Unit tests for manage_disaster.js', () => {
   });
   let testData;
   let exportStub;
+  let createFolderStub;
+  let setAclsStub;
   beforeEach(() => {
     disasterData.clear();
 
@@ -54,6 +56,10 @@ describe('Unit tests for manage_disaster.js', () => {
     });
     exportStub = cy.stub(ee.batch.Export.table, 'toAsset')
                      .returns({start: () => {}, id: 'FAKE_ID'});
+    createFolderStub =
+        cy.stub(ee.data, 'createFolder')
+            .callsFake((asset, overwrite, callback) => callback());
+    setAclsStub = cy.stub(ee.data, 'setAssetAcl');
 
     // Test data is reasonably real. All of the keys should be able to vary,
     // with corresponding changes to test data (but no production changes). The
@@ -165,10 +171,11 @@ describe('Unit tests for manage_disaster.js', () => {
   it('writes a new disaster to firestore', () => {
     let id = '2002-winter';
     const states = ['DN, WF'];
-
     cy.wrap(writeNewDisaster(id, states))
         .then((success) => {
           expect(success).to.be.true;
+          expect(createFolderStub).to.be.calledOnce;
+          expect(setAclsStub).to.be.calledOnce;
           expect($('#status').is(':visible')).to.be.false;
           expect(disasterData.get(id)['layers']).to.eql([]);
           expect(disasterData.get(id)['states']).to.eql(states);

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -57,7 +57,7 @@ describe('Unit tests for manage_disaster.js', () => {
     createFolderStub =
         cy.stub(ee.data, 'createFolder')
             .callsFake((asset, overwrite, callback) => callback());
-    setAclsStub = cy.stub(ee.data, 'setAssetAcl');
+    setAclsStub = cy.stub(ee.data, 'setAssetAcl').callsFake((asset, acls, callback) => callback());
 
     // Test data is reasonably real. All of the keys should be able to vary,
     // with corresponding changes to test data (but no production changes). The

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -170,13 +170,13 @@ describe('Unit tests for manage_disaster.js', () => {
 
   it('writes a new disaster to firestore', () => {
     let id = '2002-winter';
-    const states = ['DN, WF'];
+    const states = ['DN', 'WF'];
 
     cy.wrap(writeNewDisaster(id, states))
         .then((success) => {
           expect(success).to.be.true;
-          expect(createFolderStub).to.be.calledOnce;
-          expect(setAclsStub).to.be.calledOnce;
+          expect(createFolderStub).to.be.calledThrice;
+          expect(setAclsStub).to.be.calledThrice;
           expect($('#status').is(':visible')).to.be.false;
           expect(disasterData.get(id)['layers']).to.eql([]);
           expect(disasterData.get(id)['states']).to.eql(states);

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -167,7 +167,7 @@ describe('Unit tests for manage_disaster.js', () => {
     expect(exportStub).to.not.be.called;
   });
 
-  it('writes a new disaster to firestore', () => {
+  it.only('writes a new disaster to firestore', () => {
     let id = '2002-winter';
     const states = ['DN', 'WF'];
 

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -57,9 +57,8 @@ describe('Unit tests for manage_disaster.js', () => {
     createFolderStub =
         cy.stub(ee.data, 'createFolder')
             .callsFake((asset, overwrite, callback) => callback());
-    setAclsStub = 
-        cy.stub(ee.data, 'setAssetAcl')
-            .callsFake((asset, acls, callback) => callback());
+    setAclsStub = cy.stub(ee.data, 'setAssetAcl')
+                      .callsFake((asset, acls, callback) => callback());
 
     // Test data is reasonably real. All of the keys should be able to vary,
     // with corresponding changes to test data (but no production changes). The

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -167,7 +167,7 @@ describe('Unit tests for manage_disaster.js', () => {
     expect(exportStub).to.not.be.called;
   });
 
-  it.only('writes a new disaster to firestore', () => {
+  it('writes a new disaster to firestore', () => {
     let id = '2002-winter';
     const states = ['DN', 'WF'];
 

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -51,9 +51,7 @@ describe('Unit tests for manage_disaster.js', () => {
       makePoint(1.5, 0.5),
     ]);
     // Stub out delete and export. We'll assert on what was exported, below.
-    cy.stub(ee.data, 'deleteAsset').callsFake((_, callback) => {
-      callback();
-    });
+    cy.stub(ee.data, 'deleteAsset').callsFake((_, callback) => callback());
     exportStub = cy.stub(ee.batch.Export.table, 'toAsset')
                      .returns({start: () => {}, id: 'FAKE_ID'});
     createFolderStub =

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -57,7 +57,9 @@ describe('Unit tests for manage_disaster.js', () => {
     createFolderStub =
         cy.stub(ee.data, 'createFolder')
             .callsFake((asset, overwrite, callback) => callback());
-    setAclsStub = cy.stub(ee.data, 'setAssetAcl').callsFake((asset, acls, callback) => callback());
+    setAclsStub = 
+        cy.stub(ee.data, 'setAssetAcl')
+            .callsFake((asset, acls, callback) => callback());
 
     // Test data is reasonably real. All of the keys should be able to vary,
     // with corresponding changes to test data (but no production changes). The

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -171,6 +171,7 @@ describe('Unit tests for manage_disaster.js', () => {
   it('writes a new disaster to firestore', () => {
     let id = '2002-winter';
     const states = ['DN, WF'];
+
     cy.wrap(writeNewDisaster(id, states))
         .then((success) => {
           expect(success).to.be.true;

--- a/cypress/integration/unit_tests/manage_layers_test.js
+++ b/cypress/integration/unit_tests/manage_layers_test.js
@@ -68,16 +68,14 @@ describe('Unit tests for manage_layers page', () => {
   });
 
   it('gets state asset info from ee', () => {
-    cy.wrap(getStatesAssetsFromEe([KNOWN_STATE]))
-        .then((assets) => {
-          // tests folder type asset doesn't make it through
-          expect(assets[0]).to.eql(
-              [KNOWN_STATE, new Map([[KNOWN_STATE_ASSET, 'TABLE']])]);
-          expect(ee.data.listAssets)
-              .to.be.calledWith(
-                  legacyStatePrefix + KNOWN_STATE, {},
-                  Cypress.sinon.match.func);
-        });
+    cy.wrap(getStatesAssetsFromEe([KNOWN_STATE])).then((assets) => {
+      // tests folder type asset doesn't make it through
+      expect(assets[0]).to.eql(
+          [KNOWN_STATE, new Map([[KNOWN_STATE_ASSET, 'TABLE']])]);
+      expect(ee.data.listAssets)
+          .to.be.calledWith(
+              legacyStatePrefix + KNOWN_STATE, {}, Cypress.sinon.match.func);
+    });
   });
 
   it('populates state asset pickers', () => {

--- a/cypress/integration/unit_tests/manage_layers_test.js
+++ b/cypress/integration/unit_tests/manage_layers_test.js
@@ -16,7 +16,7 @@ const KNOWN_STATE_ASSET = gdEeStatePrefix + KNOWN_STATE + '/snap';
 let loadingStartedStub;
 let loadingFinishedStub;
 
-describe('Unit tests for add_disaster page', () => {
+describe('Unit tests for manage_layers page', () => {
   loadScriptsBeforeForUnitTests('ee', 'firebase', 'jquery');
   initFirebaseForUnitTest();
   before(() => {
@@ -68,19 +68,15 @@ describe('Unit tests for add_disaster page', () => {
   });
 
   it('gets state asset info from ee', () => {
-    cy.wrap(getStatesAssetsFromEe([KNOWN_STATE, UNKNOWN_STATE]))
+    cy.wrap(getStatesAssetsFromEe([KNOWN_STATE]))
         .then((assets) => {
           // tests folder type asset doesn't make it through
           expect(assets[0]).to.eql(
               [KNOWN_STATE, new Map([[KNOWN_STATE_ASSET, 'TABLE']])]);
-          expect(assets[1]).to.eql([UNKNOWN_STATE, new Map()]);
-          expect(ee.data.listAssets)
-              .to.be.calledWith(legacyStateDir, {}, Cypress.sinon.match.func);
           expect(ee.data.listAssets)
               .to.be.calledWith(
                   legacyStatePrefix + KNOWN_STATE, {},
                   Cypress.sinon.match.func);
-          expect(ee.data.createFolder).to.be.calledOnce;
         });
   });
 

--- a/docs/import/list_ee_assets.js
+++ b/docs/import/list_ee_assets.js
@@ -1,4 +1,4 @@
-import {eeLegacyPathPrefix, eeStatePrefixLength, legacyStateDir} from '../ee_paths.js';
+import {eeLegacyPathPrefix, legacyStateDir} from '../ee_paths.js';
 import {LayerType} from '../firebase_layers.js';
 
 export {getDisasterAssetsFromEe, getStatesAssetsFromEe};

--- a/docs/import/list_ee_assets.js
+++ b/docs/import/list_ee_assets.js
@@ -13,7 +13,7 @@ function getStatesAssetsFromEe(states) {
   const promises = [];
   for (const state of states) {
     const dir = legacyStateDir + '/' + state;
-      promises.push(listEeAssets(dir).then((result) => [state, result]));
+    promises.push(listEeAssets(dir).then((result) => [state, result]));
   }
   return Promise.all(promises);
 }

--- a/docs/import/list_ee_assets.js
+++ b/docs/import/list_ee_assets.js
@@ -10,31 +10,12 @@ export {getDisasterAssetsFromEe, getStatesAssetsFromEe};
  *     retrieved assets in the form [['WA', {'asset/path': LayerType,...}], ...]
  */
 function getStatesAssetsFromEe(states) {
-  return ee.data.listAssets(legacyStateDir, {}, () => {}).then((result) => {
-    const folders = new Set();
-    for (const folder of result.assets) {
-      folders.add(folder.id.substring(eeStatePrefixLength));
-    }
-    const promises = [];
-    for (const state of states) {
-      const dir = legacyStateDir + '/' + state;
-      if (!folders.has(state)) {
-        // This will print a console error for anyone other than the gd
-        // account. Ee console seems to have the power to grant write access
-        // to non-owners but it doesn't seem to work. Sent an email to
-        // gestalt.
-        // TODO: replace with setIamPolicy when that works.
-        // TODO: add status bar for when this is finished.
-        ee.data.createFolder(
-            dir, false,
-            () => ee.data.setAssetAcl(dir, {all_users_can_read: true}));
-        promises.push(Promise.resolve([state, new Map()]));
-      } else {
-        promises.push(listEeAssets(dir).then((result) => [state, result]));
-      }
-    }
-    return Promise.all(promises);
-  });
+  const promises = [];
+  for (const state of states) {
+    const dir = legacyStateDir + '/' + state;
+      promises.push(listEeAssets(dir).then((result) => [state, result]));
+  }
+  return Promise.all(promises);
 }
 
 /**

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -657,7 +657,6 @@ function writeNewDisaster(disasterId, states) {
       .then(() => true);
 }
 
-
 /**
  * Returns true if the given string is *not* all lowercase letters.
  * @param {string} val

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -677,6 +677,14 @@ function writeNewDisaster(disasterId, states) {
 
 /**
  * Returns a promise that resolves on the creation of the given folder.
+ *
+ * This will print a console error for anyone other than the gd
+ * account. Ee console seems to have the power to grant write access
+ * to non-owners but it doesn't seem to work. Sent an email to
+ * gestalt.
+ * TODO: replace with setIamPolicy when that works.
+ * TODO: add status bar for when this is finished.
+ *
  * @param {string} dir asset path of folder to create
  * @return {Promise<void>} resolves when after the directory is created and
  * set to world readable.

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -631,8 +631,8 @@ function addDisaster() {
  * there is an existing disaster with the same details.
  * @param {string} disasterId of the form <year>-<name>
  * @param {Array<string>} states array of state (abbreviations)
- * @return {Promise<[null, boolean]>} returns when all ee folders have been
- * created and firestore write has finished.
+ * @return {Promise<boolean>} returns true after successful write to firestore
+ * and earth engine folder creations.
  */
 function writeNewDisaster(disasterId, states) {
   if (disasterData.has(disasterId)) {
@@ -672,12 +672,12 @@ function writeNewDisaster(disasterId, states) {
     disasterPicker.val(disasterId).trigger('change');
   });
 
-  return Promise.all(
-      eePromisesResult,
-      disasterCollectionReference()
-          .doc(disasterId)
-          .set(currentData)
-          .then(() => true));
+  return Promise
+      .all([
+        eePromisesResult,
+        disasterCollectionReference().doc(disasterId).set(currentData)
+      ])
+      .then(() => true);
 }
 
 /**
@@ -699,7 +699,7 @@ function getCreateFolderPromise(dir) {
       (resolve) => ee.data.createFolder(
           dir, false,
           () => ee.data.setAssetAcl(
-              dir, {all_users_can_read: true}, () => resolve())));
+              dir, {all_users_can_read: true}, () => resolve)));
 }
 
 /**

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -664,6 +664,8 @@ function writeNewDisaster(disasterId, states) {
 /**
  * Returns a promise that resolves on the creation of the given folder.
  * @param {string} dir asset path of folder to create
+ * @return {Promise<void>} resolves when after the directory is created and
+ * set to world readable.
  */
 function getCreateFolderPromise(dir) {
   return new Promise((resolve) => {

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -666,12 +666,12 @@ function writeNewDisaster(disasterId, states) {
  * @param {string} dir asset path of folder to create
  */
 function getCreateFolderPromise(dir) {
-  new Promise((resolve) => {
+  return new Promise((resolve) => {
     ee.data.createFolder(dir, false, () => {
       ee.data.setAssetAcl(dir, {all_users_can_read: true});
       resolve();
     });
-  })
+  });
 }
 
 /**

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -675,7 +675,7 @@ function writeNewDisaster(disasterId, states) {
   return Promise
       .all([
         eePromisesResult,
-        disasterCollectionReference().doc(disasterId).set(currentData)
+        disasterCollectionReference().doc(disasterId).set(currentData),
       ])
       .then(() => true);
 }

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -723,7 +723,7 @@ function getCreateFolderPromise(dir) {
       (resolve) => ee.data.createFolder(
           dir, false,
           () => ee.data.setAssetAcl(
-              dir, {all_users_can_read: true}, () => resolve)));
+              dir, {all_users_can_read: true}, () => resolve())));
 }
 
 /**

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -1,3 +1,4 @@
+import {eeLegacyPathPrefix} from '../ee_paths';
 import {LayerType} from '../firebase_layers.js';
 import {disasterCollectionReference} from '../firestore_document.js';
 import {blockGroupTag, buildingCountTag, damageTag, geoidTag, incomeTag, snapPercentageTag, snapPopTag, sviTag, totalPopTag, tractTag} from '../property_names.js';
@@ -623,6 +624,7 @@ function writeNewDisaster(disasterId, states) {
   }
   const currentData = createDisasterData(states);
   disasterData.set(disasterId, currentData);
+  disasterAssets.set(disasterId, new Map());
 
   const disasterPicker = $('#disaster-dropdown');
   const disasterOptions = disasterPicker.children();
@@ -641,13 +643,20 @@ function writeNewDisaster(disasterId, states) {
   if (!added) disasterPicker.append(createOptionFrom(disasterId));
   toggleState(true);
 
-  disasterPicker.val(disasterId).trigger('change');
+  const dir = eeLegacyPathPrefix + disasterId;
+  // TODO: replace with setIamPolicy when that works. See comment in {@code
+  // getStatesAssetsFromEe}
+  ee.data.createFolder(dir, false, () => {
+    ee.data.setAssetAcl(dir, {all_users_can_read: true});
+    disasterPicker.val(disasterId).trigger('change');
+  });
 
   return disasterCollectionReference()
       .doc(disasterId)
       .set(currentData)
       .then(() => true);
 }
+
 
 /**
  * Returns true if the given string is *not* all lowercase letters.

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -639,10 +639,9 @@ function writeNewDisaster(disasterId, states) {
     const disasterPicker = $('#disaster-dropdown');
     const disasterOptions = disasterPicker.children();
     let added = false;
-    // We expect this recently created disaster to go near the top of the list, so
-    // do a linear scan down.
-    // Note: let's hope this tool isn't being used in the year 10000.
-    // Comment needed to quiet eslint.
+    // We expect this recently created disaster to go near the top of the list,
+    // so do a linear scan down. Note: let's hope this tool isn't being used in
+    // the year 10000. Comment needed to quiet eslint.
     disasterOptions.each(/* @this HTMLElement */ function() {
       if ($(this).val() < disasterId) {
         $(createOptionFrom(disasterId)).insertBefore($(this));
@@ -662,6 +661,10 @@ function writeNewDisaster(disasterId, states) {
       .then(() => true);
 }
 
+/**
+ * Returns a promise that resolves on the creation of the given folder.
+ * @param {string} dir asset path of folder to create
+ */
 function getCreateFolderPromise(dir) {
   new Promise((resolve) => {
     ee.data.createFolder(dir, false, () => {


### PR DESCRIPTION
Create EE folders for both the disaster and the relevant states.  Wait to automatically toggle to new disaster (or let new disaster appear in picker) until these things have finished.