### PR TITLE
Remove guards around colors map

### DIFF
--- a/cypress/integration/unit_tests/color_function_util_test.js
+++ b/cypress/integration/unit_tests/color_function_util_test.js
@@ -37,6 +37,7 @@ describe('Unit tests for color function utility', () => {
           'wings': {'min': 0, 'max': 2, 'values': [0, 1, 2]},
           'legs': {'min': 0, 'max': 100, 'values': [0, 2, 4, 8, 100]},
         },
+        'colors': {},
         'color': 'yellow',
       },
     };
@@ -91,7 +92,7 @@ describe('Unit tests for color function utility', () => {
     expect(getColorFunction()['field']).to.equal('legs');
 
     // update discrete color
-    expect(getColorFunction()['colors']).to.be.undefined;
+    expect(getColorFunction()['colors']).to.be.empty;
     discreteColorPickerList.children('li')
         .first()
         .children('select')

--- a/docs/import/color_function_util.js
+++ b/docs/import/color_function_util.js
@@ -97,10 +97,6 @@ function setProperty(picker) {
 function setDiscreteColor(picker) {
   const colorFunction = getColorFunction();
   const propertyValue = picker.data(discreteColorPickerDataKey);
-  // TODO: remove, always have this around.
-  if (!colorFunction['colors']) {
-    colorFunction['colors'] = {};
-  }
   colorFunction['colors'][propertyValue] = picker.val();
   updateTdAndFirestore();
 }
@@ -325,7 +321,6 @@ function populateDiscreteColorPickers() {
     $('#too-many-values').hide();
   }
   const asColorPickers = [];
-  // TODO: remove, always have this around at this point.
   const colors = colorFunction['colors'];
   for (const value of values) {
     const li = $(document.createElement('li'));
@@ -334,7 +329,7 @@ function populateDiscreteColorPickers() {
         createColorPicker()
             .on('change', (event) => setDiscreteColor($(event.target)))
             .data(discreteColorPickerDataKey, value)
-            .val(colors ? colors[value] : null);
+            .val(colors[value]);
     li.append(colorPicker);
     asColorPickers.push(li);
   }
@@ -348,11 +343,6 @@ function populateDiscreteColorPickers() {
  */
 function createColorBoxesForDiscrete(colorFunction, td) {
   const colorObject = colorFunction['colors'];
-  // TODO: remove, always have this around.
-  // coming from a place that has never had discrete before
-  if (!colorObject) {
-    return;
-  }
   const colorSet = new Set();
   Object.keys(colorObject).forEach((propertyValue) => {
     const color = colorObject[propertyValue];


### PR DESCRIPTION
We now always initialize an empty colors map during (FC) layer creation so we don't need these anymore. 