### PR TITLE
Validate values of select rather underlying data

### DIFF
--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -323,10 +323,8 @@ describe('Unit tests for manage_disaster.js', () => {
           data.asset_data.damage_asset_path = 'pathnotfound';
           data.asset_data.snap_data.paths.NY = missingSnapPath;
           disasterData.set(getDisaster(), data);
-          Promise.all([
-            initializeScoreSelectors(['NY']),
-            initializeDamageSelector(['damage1', 'damage2']),
-          ]);
+          initializeScoreSelectors(['NY']);
+          initializeDamageSelector(['damage1', 'damage2']);
         })
         .then(validateUserFields);
     cy.get('#process-button').should('be.disabled');

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -335,12 +335,10 @@ describe('Unit tests for manage_disaster.js', () => {
     cy.get('#damage-asset-select').select('damage1');
     cy.get('#process-button').should('have.text', allStateAssetsMissingText);
     // TODO(janakr): is there a way to tell all writes are finished?
-    cy.wait(1000).then(readDisasterDocument).then((doc) => {
-      const data = doc.data();
-      // This wasn't actually in Firestore, but checking that it was written on
-      // a different change shows we're not silently overwriting it.
-      expect(data.asset_data.snap_data.paths.NY).to.eql(missingSnapPath);
-    });
+    // Data wasn't actually in Firestore before, but checking that it was
+    // written on a different change shows we're not silently overwriting it.
+    cy.wait(1000).then(readDisasterDocument).then((doc) => expect(
+        doc.data().asset_data.snap_data.paths.NY).to.eql(missingSnapPath));
   });
 
   it('writes a new disaster to firestore', () => {

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -337,8 +337,11 @@ describe('Unit tests for manage_disaster.js', () => {
     // TODO(janakr): is there a way to tell all writes are finished?
     // Data wasn't actually in Firestore before, but checking that it was
     // written on a different change shows we're not silently overwriting it.
-    cy.wait(1000).then(readDisasterDocument).then((doc) => expect(
-        doc.data().asset_data.snap_data.paths.NY).to.eql(missingSnapPath));
+    cy.wait(1000)
+        .then(readDisasterDocument)
+        .then(
+            (doc) => expect(doc.data().asset_data.snap_data.paths.NY)
+                         .to.eql(missingSnapPath));
   });
 
   it('writes a new disaster to firestore', () => {

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -325,7 +325,7 @@ describe('Unit tests for manage_disaster.js', () => {
           disasterData.set(getDisaster(), data);
           Promise.all([
             initializeScoreSelectors(['NY']),
-            initializeDamageSelector(['damage1', 'damage2'])
+            initializeDamageSelector(['damage1', 'damage2']),
           ]);
         })
         .then(validateUserFields);

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -317,19 +317,23 @@ describe('Unit tests for manage_disaster.js', () => {
 
   it('nonexistent asset not ok', () => {
     const missingSnapPath = 'whereisasset';
-    setUpAssetValidationTests().then(() => {
-      // Overwrite disaster data with multistate disaster.
-      const data = createDisasterData(['NY']);
-      data.asset_data.damage_asset_path = 'pathnotfound';
-      data.asset_data.snap_data.paths.NY = missingSnapPath;
-      disasterData.set(getDisaster(), data);
-      Promise.all([initializeScoreSelectors(['NY']), initializeDamageSelector(['damage1', 'damage2'])]);
-    }).then(validateUserFields);
+    setUpAssetValidationTests()
+        .then(() => {
+          const data = createDisasterData(['NY']);
+          data.asset_data.damage_asset_path = 'pathnotfound';
+          data.asset_data.snap_data.paths.NY = missingSnapPath;
+          disasterData.set(getDisaster(), data);
+          Promise.all([
+            initializeScoreSelectors(['NY']),
+            initializeDamageSelector(['damage1', 'damage2'])
+          ]);
+        })
+        .then(validateUserFields);
     cy.get('#process-button').should('be.disabled');
     // Everything is missing, even though we have values stored.
-    cy.get("#process-button").should('have.text', allMissingText);
+    cy.get('#process-button').should('have.text', allMissingText);
     cy.get('#damage-asset-select').select('damage1');
-    cy.get("#process-button").should('have.text', allStateAssetsMissingText);
+    cy.get('#process-button').should('have.text', allStateAssetsMissingText);
     // TODO(janakr): is there a way to tell all writes are finished?
     cy.wait(1000).then(readDisasterDocument).then((doc) => {
       const data = doc.data();

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -51,7 +51,7 @@ function validateUserFields() {
   for (const scoreAssetType of scoreAssetTypes) {
     const missingForType = [];
     for (const state of states) {
-      if (!getElementFromPath(scoreAssetType[1].concat([state]))) {
+      if (!$('#select-' + assetSelectionRowPrefix + scoreAssetType[0] + '-' + state).val()) {
         missingForType.push(state);
       }
     }
@@ -61,9 +61,8 @@ function validateUserFields() {
           (states.length > 1 ? ' [' + missingForType.join(', ') + ']' : ''));
     }
   }
-  const hasDamage = getElementFromPath(damagePropertyPath) ||
-      (getElementFromPath(swPropertyPath) &&
-       getElementFromPath(nePropertyPath));
+  const hasDamage = $('#damage-asset-select').val() ||
+      ($('#map-bounds-sw').val() && $('#map-bounds-ne').val());
   let message = '';
   if (missingItems.length) {
     message = 'Missing asset(s): ' + missingItems.join(', ');
@@ -416,7 +415,7 @@ function initializeScoreSelectors(states) {
       if (stateAssets.get(state)) {
         const statePropertyPath = propertyPath.concat([state]);
         row.append(createTd().append(addAssetDataChangeHandler(
-            createAssetDropdown(stateAssets.get(state), statePropertyPath),
+            createAssetDropdown(stateAssets.get(state), statePropertyPath).prop('id', 'select-' + id + '-' + state),
             statePropertyPath)));
       }
     }

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -51,7 +51,9 @@ function validateUserFields() {
   for (const scoreAssetType of scoreAssetTypes) {
     const missingForType = [];
     for (const state of states) {
-      if (!$('#select-' + assetSelectionRowPrefix + scoreAssetType[0] + '-' + state).val()) {
+      if (!$('#select-' + assetSelectionRowPrefix + scoreAssetType[0] + '-' +
+             state)
+               .val()) {
         missingForType.push(state);
       }
     }
@@ -415,7 +417,8 @@ function initializeScoreSelectors(states) {
       if (stateAssets.get(state)) {
         const statePropertyPath = propertyPath.concat([state]);
         row.append(createTd().append(addAssetDataChangeHandler(
-            createAssetDropdown(stateAssets.get(state), statePropertyPath).prop('id', 'select-' + id + '-' + state),
+            createAssetDropdown(stateAssets.get(state), statePropertyPath)
+                .prop('id', 'select-' + id + '-' + state),
             statePropertyPath)));
       }
     }


### PR DESCRIPTION
This improves error messaging to users when the stored value is not displayed in the select (because, for instance, the user deleted an asset after previously selecting it here).

Note that if the user then re-creates the asset, they'll have to reload the page, but that seems ok.

We don't overwrite the value in Firestore, even though it's not valid, until the user changes it manually, to avoid the user losing data if an asset is momentarily not there (because they're deleting and recreating it).