### PR TITLE
Change parameter comments that are making clang fight with itself

### DIFF
--- a/docs/authenticate.js
+++ b/docs/authenticate.js
@@ -196,7 +196,9 @@ function initializeFirebase() {
  *     defaultErrorCallback
  */
 function initializeEE(runCallback, errorCallback = defaultErrorCallback) {
-  ee.initialize(null, null, runCallback, (err) => errorCallback('Error initializing EarthEngine: ' + err));
+  ee.initialize(
+      null, null, runCallback,
+      (err) => errorCallback('Error initializing EarthEngine: ' + err));
 }
 
 /**

--- a/docs/authenticate.js
+++ b/docs/authenticate.js
@@ -197,7 +197,7 @@ function initializeFirebase() {
  */
 function initializeEE(runCallback, errorCallback = defaultErrorCallback) {
   ee.initialize(
-      /** opt_baseurl=*/ null, /** opt_tileurl=*/ null, runCallback,
+      /** opt_baseurl */ null, /** opt_tileurl */ null, runCallback,
       (err) => errorCallback('Error initializing EarthEngine: ' + err));
 }
 

--- a/docs/authenticate.js
+++ b/docs/authenticate.js
@@ -196,9 +196,7 @@ function initializeFirebase() {
  *     defaultErrorCallback
  */
 function initializeEE(runCallback, errorCallback = defaultErrorCallback) {
-  ee.initialize(
-      /* opt_baseurl=*/ null, /* opt_tileurl=*/ null, runCallback,
-      (err) => errorCallback('Error initializing EarthEngine: ' + err));
+  ee.initialize(null, null, runCallback, (err) => errorCallback('Error initializing EarthEngine: ' + err));
 }
 
 /**

--- a/docs/authenticate.js
+++ b/docs/authenticate.js
@@ -197,7 +197,7 @@ function initializeFirebase() {
  */
 function initializeEE(runCallback, errorCallback = defaultErrorCallback) {
   ee.initialize(
-      null, null, runCallback,
+      /** opt_baseurl=*/ null, /** opt_tileurl=*/ null, runCallback,
       (err) => errorCallback('Error initializing EarthEngine: ' + err));
 }
 


### PR DESCRIPTION
We have clang v7 on Travis, but Google style has apparently changed since then. Running multiple versions of clang on my Mac, I found that the choice of whether to put a space between the comment and the parameter name seems different for v7 and v9. Removing the `=` sign seems to stop the clash.