### PR TITLE
Be smarter about parsing number values during score asset creation

### DIFF
--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -348,15 +348,18 @@ describe('Unit tests for manage_disaster.js', () => {
         [makeSnapGroup('360', 10, 15), makeSnapGroup('361', 10, 15)]);
     const promise = createScoreAsset(testData);
     expect(promise).to.not.be.null;
-    cy.wrap(promise).then(() => {
-      expect(exportStub).to.be.calledOnce;
-      return convertEeObjectToPromise(exportStub.firstCall.args[0].sort('GEOID'));
-    }).then((result) => {
-      const features = result.features;
-      expect(features).to.have.length(2);
-      expect(features[0]['properties']['MEDIAN INCOME']).to.equal(250000);
-      expect(features[1]['properties']['MEDIAN INCOME']).to.be.undefined;
-    });
+    cy.wrap(promise)
+        .then(() => {
+          expect(exportStub).to.be.calledOnce;
+          return convertEeObjectToPromise(
+              exportStub.firstCall.args[0].sort('GEOID'));
+        })
+        .then((result) => {
+          const features = result.features;
+          expect(features).to.have.length(2);
+          expect(features[0]['properties']['MEDIAN INCOME']).to.equal(250000);
+          expect(features[1]['properties']['MEDIAN INCOME']).to.be.undefined;
+        });
   });
 
 

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -362,7 +362,6 @@ describe('Unit tests for manage_disaster.js', () => {
         });
   });
 
-
   it('writes a new disaster to firestore', () => {
     let id = '2002-winter';
     const states = ['DN', 'WF'];

--- a/cypress/integration/unit_tests/manage_disaster_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_test.js
@@ -341,6 +341,25 @@ describe('Unit tests for manage_disaster.js', () => {
                          .to.eql(missingSnapPath));
   });
 
+  it('handles non-numeric median income valuess', () => {
+    testData.asset_data.income_asset_paths.NY = ee.FeatureCollection(
+        [makeIncomeGroup('360', '250,000+'), makeIncomeGroup('361', '-')]);
+    testData.asset_data.snap_data.paths.NY = ee.FeatureCollection(
+        [makeSnapGroup('360', 10, 15), makeSnapGroup('361', 10, 15)]);
+    const promise = createScoreAsset(testData);
+    expect(promise).to.not.be.null;
+    cy.wrap(promise).then(() => {
+      expect(exportStub).to.be.calledOnce;
+      return convertEeObjectToPromise(exportStub.firstCall.args[0].sort('GEOID'));
+    }).then((result) => {
+      const features = result.features;
+      expect(features).to.have.length(2);
+      expect(features[0]['properties']['MEDIAN INCOME']).to.equal(250000);
+      expect(features[1]['properties']['MEDIAN INCOME']).to.be.undefined;
+    });
+  });
+
+
   it('writes a new disaster to firestore', () => {
     let id = '2002-winter';
     const states = ['DN', 'WF'];

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -62,7 +62,7 @@ function createContinuousFunction(field, minVal, maxVal, color) {
   const range = maxVal - minVal;
   return (feature) => {
     let value = feature['properties'][field];
-    if (!value) return transparent;
+    if (value === null) return transparent;
     if (value > maxVal) {
       value = maxVal;
     } else if (value < minVal) {
@@ -90,7 +90,7 @@ function createContinuousFunction(field, minVal, maxVal, color) {
 function createDiscreteFunction(field, colors) {
   return (feature) => {
     const value = feature['properties'][field];
-    if (!value) return transparent;
+    if (value === null) return transparent;
     const rgba = colorMap.get(colors[value]);
     rgba.push(opacity);
     return rgba;

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -62,6 +62,7 @@ function createContinuousFunction(field, minVal, maxVal, color) {
   const range = maxVal - minVal;
   return (feature) => {
     let value = feature['properties'][field];
+    if (!value) return transparent;
     if (value > maxVal) {
       value = maxVal;
     } else if (value < minVal) {
@@ -88,12 +89,15 @@ function createContinuousFunction(field, minVal, maxVal, color) {
  */
 function createDiscreteFunction(field, colors) {
   return (feature) => {
-    const color = colors[feature['properties'][field]];
-    const rgba = colorMap.get(color);
+    const value = feature['properties'][field];
+    if (!value) return [0, 0, 0, 0];
+    const rgba = colorMap.get(colors[value]);
     rgba.push(opacity);
     return rgba;
   };
 }
+
+const transparent = [0, 0, 0, 0];
 
 const colorMap = new Map([
   ['red', [255, 0, 0]],

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -90,7 +90,7 @@ function createContinuousFunction(field, minVal, maxVal, color) {
 function createDiscreteFunction(field, colors) {
   return (feature) => {
     const value = feature['properties'][field];
-    if (!value) return [0, 0, 0, 0];
+    if (!value) return transparent;
     const rgba = colorMap.get(colors[value]);
     rgba.push(opacity);
     return rgba;

--- a/docs/import/center.js
+++ b/docs/import/center.js
@@ -23,6 +23,7 @@ function computeAndSaveBounds(features) {
  * after Firestore write is complete.
  */
 function saveBounds(bounds) {
+  console.log(bounds);
   const coordinates = bounds.coordinates[0];
   const sw = coordinates[0];
   const ne = coordinates[2];

--- a/docs/import/center.js
+++ b/docs/import/center.js
@@ -23,7 +23,6 @@ function computeAndSaveBounds(features) {
  * after Firestore write is complete.
  */
 function saveBounds(bounds) {
-  console.log(bounds);
   const coordinates = bounds.coordinates[0];
   const sw = coordinates[0];
   const ne = coordinates[2];

--- a/docs/import/create_score_asset.js
+++ b/docs/import/create_score_asset.js
@@ -57,7 +57,7 @@ function countDamageAndBuildings(feature, damage, buildings) {
 
 // Permissive number regexp: matches optional +/- followed by 0 or more digits
 // followed by optional period with 0 or more digits. Corresponds to valid
-// inputs to ee.Number.parse. As with ee.Number.parse, the empty string is not
+// inputs to ee.Number.parse. Like ee.Number.parse, the empty string is not
 // allowed.
 const numberRegexp = '^[+-]?(([0-9]*)?[0-9](\.[0-9]*)?|\.[0-9]+)$';
 
@@ -66,7 +66,7 @@ const endsWithPlusMinusRegexp = '[+-]$';
 
 /**
  * First strips out all ',' and whitespace. Then strips any trailing '-' or '+'
- * (for threshold values like '250,000+'). Then checks if the result is matches
+ * (for threshold values like '250,000+'). Then checks if the result matches
  * our regexp for valid EE numbers. If it does, parse and return number, else
  * return null.
  * @param {string} value

--- a/docs/import/create_score_asset.js
+++ b/docs/import/create_score_asset.js
@@ -6,10 +6,9 @@ import {cdcGeoidKey, censusBlockGroupKey, censusGeoidKey, tigerGeoidKey} from '.
 export {createScoreAsset, setStatus};
 
 /**
- * Given a feature from the SNAP census data, returns a new
- * feature with GEOID, SNAP #, total pop #, total building count, building
- * counts for all damage categories, and SNAP percentage and damage percentage.
- *
+ * For the given feature representing a block group, add properties for
+ * total # buildings in the block group and # damaged buildings in the block
+ * group.
  * @param {ee.Feature} feature
  * @param {ee.FeatureCollection} damage
  * @param {ee.Dictionary} buildings geoid -> # buildings

--- a/docs/import/create_score_asset.js
+++ b/docs/import/create_score_asset.js
@@ -1,6 +1,5 @@
 import {blockGroupTag, buildingCountTag, damageTag, geoidTag, incomeTag, snapPercentageTag, snapPopTag, sviTag, totalPopTag, tractTag} from '../property_names.js';
 import {getScoreAsset} from '../resources.js';
-
 import {computeAndSaveBounds, saveBounds} from './center.js';
 import {cdcGeoidKey, censusBlockGroupKey, censusGeoidKey, tigerGeoidKey} from './import_data_keys.js';
 
@@ -108,10 +107,10 @@ function combineWithSnap(feature, snapKey, totalKey) {
  * @return {ee.Feature}
  */
 function combineWithAsset(feature, tag, key) {
-  const incomeFeature = ee.Feature(feature.get('secondary'));
+  const featureWithNewData = ee.Feature(feature.get('secondary'));
   return ee.Feature(feature.get('primary')).set(ee.Dictionary([
     tag,
-    convertToNumber(incomeFeature.get(key)),
+    convertToNumber(featureWithNewData.get(key)),
   ]));
 }
 


### PR DESCRIPTION
Run SVI, median income, snap and total pop values through a parser while creating the score asset. The parser takes care of values like "250,000+" (250000) and non-numerics (null). Also make null values transparent for layer creation. 

closes #269