### PR TITLE
Zoom to disaster states in map when polygon coordinates absent

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "defaultCommandTimeout": 40000,
   "projectId": "jr8ks8",
   "nodeVersion": "system",
   "animationDistanceThreshold": 20,

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
-  "defaultCommandTimeout": 40000,
   "projectId": "jr8ks8",
   "nodeVersion": "system",
   "animationDistanceThreshold": 20,

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -54,7 +54,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
                      .to.eql('asset2'));
   });
 
-  it.only('no map coordinates to start', () => {
+  it('no map coordinates to start', () => {
     const data = setUpDefaultData();
     data.asset_data.score_bounds_coordinates = null;
     callEnableWhenReady(data);

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -54,7 +54,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
                      .to.eql('asset2'));
   });
 
-  it('no map coordinates to start', () => {
+  it.only('no map coordinates to start', () => {
     const data = setUpDefaultData();
     data.asset_data.score_bounds_coordinates = null;
     callEnableWhenReady(data);
@@ -66,24 +66,25 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     // We add the zoom_changed listener only after the state promise finishes
     // out of an abundance of caution, so if the production code zooms for
     // some other reason at startup we won't react to that.
-    cy.wrap(scoreBoundsMap.stateBoundsPromise)
+    cy.wrap(Promise.all([scoreBoundsMap.stateBoundsPromise, new Promise(
+        (resolve) => google.maps.event.addListenerOnce(
+            scoreBoundsMap.map, 'zoom_changed', () => {
+              resolve();
+            }))]))
         .then(
-            () => new Promise(
-                (resolve) => google.maps.event.addListenerOnce(
-                    scoreBoundsMap.map, 'zoom_changed', () => {
-                      // Has NY in view after EE promise finishes and zoom
-                      // happens.
-                      expect(scoreBoundsMap.map.getBounds().contains({
-                        lng: -74,
-                        lat: 41.7,
-                      })).to.be.true;
-                      // Does not have Texas in view.
-                      expect(underTest.map.getBounds().contains({
-                        lng: -100,
-                        lat: 32,
-                      })).to.be.false;
-                      resolve();
-                    })));
+            () => {
+              // Has NY in view after EE promise finishes and zoom
+              // happens.
+              expect(scoreBoundsMap.map.getBounds().contains({
+                lng: -74,
+                lat: 41.7,
+              })).to.be.true;
+              // Does not have Texas in view.
+              expect(underTest.map.getBounds().contains({
+                lng: -100,
+                lat: 32,
+              })).to.be.false;
+            });
     cy.get('#damage-asset-select').select('asset2').blur();
     cy.get('#map-bounds-div').should('not.be.visible');
     readFirestoreAfterWritesFinish().then(

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -4,7 +4,6 @@ import {createDisasterData} from '../../../docs/import/create_disaster_lib.js';
 import * as ListEeAssets from '../../../docs/import/list_ee_assets.js';
 import {assetSelectionRowPrefix, disasterData, scoreAssetTypes, scoreBoundsMap, setUpScoreBoundsMap, setUpScoreSelectorTable, stateAssets, validateUserFields} from '../../../docs/import/manage_disaster';
 import {enableWhenFirestoreReady} from '../../../docs/import/manage_disaster.js';
-import * as MapUtil from '../../../docs/map_util.js';
 import {getDisaster} from '../../../docs/resources.js';
 import {cyQueue} from '../../support/commands.js';
 import {setUpSavingStubs} from '../../support/import_test_util.js';
@@ -516,25 +515,6 @@ function checkSelectBorder(selector, rgbString) {
  */
 function checkHoverText(selector, text) {
   cy.get(selector).invoke('attr', 'title').should('eq', text);
-}
-
-/**
- * A wrapper for {@link convertEeObjectToPromise} that returns a resolve
- * function for releasing the result.
- * @return {Function}
- */
-function getConvertEeObjectToPromiseRelease() {
-  let resolveFunction = null;
-  const promise = new Promise((resolve) => resolveFunction = resolve);
-  const oldConvert = MapUtil.convertEeObjectToPromise;
-  MapUtil.convertEeObjectToPromise = (eeObject) => {
-    MapUtil.convertEeObjectToPromise = oldConvert;
-    return MapUtil.convertEeObjectToPromise(eeObject).then(async (result) => {
-      await promise;
-      return result;
-    });
-  };
-  return resolveFunction;
 }
 
 /**

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -54,37 +54,34 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
                      .to.eql('asset2'));
   });
 
-  it.only('no map coordinates to start', () => {
+  it('no map coordinates to start', () => {
     const data = setUpDefaultData();
     data.asset_data.score_bounds_coordinates = null;
     callEnableWhenReady(data);
     cy.get('#damage-asset-select').should('have.value', '');
     cy.get('#map-bounds-div').should('be.visible');
     cy.get('.score-bounds-delete-button').should('not.be.visible');
-    // Wait for bounds promise to finish, and then wait for the zoom level to
+    // Wait for bounds promise to finish, and wait for the zoom level to
     // change, so that we can assert that the map has been zoomed to NY state.
-    // We add the zoom_changed listener only after the state promise finishes
-    // out of an abundance of caution, so if the production code zooms for
-    // some other reason at startup we won't react to that.
-    cy.wrap(Promise.all([scoreBoundsMap.stateBoundsPromise, new Promise(
-        (resolve) => google.maps.event.addListenerOnce(
-            scoreBoundsMap.map, 'zoom_changed', () => {
-              resolve();
-            }))]))
-        .then(
-            () => {
-              // Has NY in view after EE promise finishes and zoom
-              // happens.
-              expect(scoreBoundsMap.map.getBounds().contains({
-                lng: -74,
-                lat: 41.7,
-              })).to.be.true;
-              // Does not have Texas in view.
-              expect(scoreBoundsMap.map.getBounds().contains({
-                lng: -100,
-                lat: 32,
-              })).to.be.false;
-            });
+    cy.wrap(Promise.all([
+        scoreBoundsMap.stateBoundsPromise,
+        new Promise(
+            (resolve) => google.maps.event.addListenerOnce(
+                scoreBoundsMap.map, 'zoom_changed', resolve)),
+      ]))
+        .then(() => {
+          // Has NY in view after EE promise finishes and zoom
+          // happens.
+          expect(scoreBoundsMap.map.getBounds().contains({
+            lng: -74,
+            lat: 41.7,
+          })).to.be.true;
+          // Does not have Texas in view.
+          expect(scoreBoundsMap.map.getBounds().contains({
+            lng: -100,
+            lat: 32,
+          })).to.be.false;
+        });
     cy.get('#damage-asset-select').select('asset2').blur();
     cy.get('#map-bounds-div').should('not.be.visible');
     readFirestoreAfterWritesFinish().then(

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -66,11 +66,13 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     // We add the zoom_changed listener only after the state promise finishes
     // out of an abundance of caution, so if the production code zooms for
     // some other reason at startup we won't react to that.
-    cy.wrap(Promise.all([scoreBoundsMap.stateBoundsPromise, new Promise(
-        (resolve) => google.maps.event.addListenerOnce(
-            scoreBoundsMap.map, 'zoom_changed', () => {
-              resolve();
-            }))]))
+    cy.wrap(Promise.all([scoreBoundsMap.stateBoundsPromise,
+      // new Promise(
+      //   (resolve) => google.maps.event.addListenerOnce(
+      //       scoreBoundsMap.map, 'zoom_changed', () => {
+      //         resolve();
+      //       }))
+    ]))
         .then(
             () => {
               // Has NY in view after EE promise finishes and zoom

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -80,7 +80,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
                 lat: 41.7,
               })).to.be.true;
               // Does not have Texas in view.
-              expect(underTest.map.getBounds().contains({
+              expect(scoreBoundsMap.map.getBounds().contains({
                 lng: -100,
                 lat: 32,
               })).to.be.false;

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -66,13 +66,11 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     // We add the zoom_changed listener only after the state promise finishes
     // out of an abundance of caution, so if the production code zooms for
     // some other reason at startup we won't react to that.
-    cy.wrap(Promise.all([scoreBoundsMap.stateBoundsPromise,
-      // new Promise(
-      //   (resolve) => google.maps.event.addListenerOnce(
-      //       scoreBoundsMap.map, 'zoom_changed', () => {
-      //         resolve();
-      //       }))
-    ]))
+    cy.wrap(Promise.all([scoreBoundsMap.stateBoundsPromise, new Promise(
+        (resolve) => google.maps.event.addListenerOnce(
+            scoreBoundsMap.map, 'zoom_changed', () => {
+              resolve();
+            }))]))
         .then(
             () => {
               // Has NY in view after EE promise finishes and zoom

--- a/cypress/integration/unit_tests/score_bounds_map_test.js
+++ b/cypress/integration/unit_tests/score_bounds_map_test.js
@@ -1,5 +1,6 @@
-import {addPolygonWithPath} from '../../../docs/basic_map.js';
+import {addPolygonWithPath, defaultMapCenter, defaultZoomLevel} from '../../../docs/basic_map.js';
 import {ScoreBoundsMap} from '../../../docs/import/score_bounds_map.js';
+import {getConvertEeObjectToPromiseRelease} from '../../support/import_test_util.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
 const scoreBoundsCoordinates = [
@@ -24,7 +25,7 @@ const newNe = {
 };
 
 describe('Unit tests for ScoreBoundsMap class', () => {
-  loadScriptsBeforeForUnitTests('jquery', 'maps');
+  loadScriptsBeforeForUnitTests('ee', 'jquery', 'maps');
 
   let underTest;
   const storedSaves = [];
@@ -49,50 +50,61 @@ describe('Unit tests for ScoreBoundsMap class', () => {
 
   it('tests ScoreBoundsMap class', () => {
     const deleteConfirmStub = cy.stub(window, 'confirm').returns(true);
-    underTest.initialize(scoreBoundsCoordinates);
+    underTest.initialize(scoreBoundsCoordinates, ['TX', 'LA']);
     expect(underTest.polygon).to.not.be.null;
     expect(underTest.polygon.getMap()).to.eql(underTest.map);
     expect(underTest.drawingManager.getMap()).to.be.null;
     expect(storedSaves).to.be.empty;
     cy.get('[title="Draw a shape"').should('not.exist');
-    cy.get('.score-bounds-delete-button').should('be.visible').then(() => {
-      // Bounds have not yet been set.
-      expect(underTest.map.getBounds().contains(scoreBoundsCoordinates[1]))
-          .to.be.false;
-      // Now they're set.
-      underTest.onShow();
-      // TODO(janakr): Bounds are not available immediately after map
-      //  initialization. Putting it here, after a few cy.get() operations,
-      //  appears to be enough, but might have to add a wait if flaky.
-      // Check that map bounds have adjusted to include the polygon we drew,
-      // which extends north of the US into Canada.
-      const bounds = underTest.map.getBounds();
-      scoreBoundsCoordinates.forEach(
-          (point) => expect(bounds.contains(point)).to.be.true);
-      // Now pan the map way over, just for fun.
-      expect(underTest.map.getBounds().contains(newSw)).to.be.false;
-      expect(underTest.map.getBounds().contains(newNe)).to.be.false;
-      underTest.map.fitBounds(new google.maps.LatLngBounds(newSw, newNe));
-      expect(underTest.map.getBounds().contains(newSw)).to.be.true;
-      expect(underTest.map.getBounds().contains(newNe)).to.be.true;
-      // Modify polygon, check that new path was saved.
-      underTest.polygon.getPath().setAt(
-          0, new google.maps.LatLng({lng: -100, lat: 30}));
-      expect(storedSaves).to.eql([[
-        {lng: -100, lat: 30},
-        ...scoreBoundsCoordinates.slice(1),
-      ]]);
-      storedSaves.length = 0;
-      // Switch to "new" disaster that has no polygon.
-      underTest.initialize(null);
-      expect(underTest.polygon).to.be.null;
-      expect(underTest.drawingManager.getMap()).to.eql(underTest.map);
-      expect(storedSaves).to.be.empty;
-      underTest.onShow();
-      // Bounds were reset.
-      expect(underTest.map.getBounds().contains(newSw)).to.be.false;
-      expect(underTest.map.getBounds().contains(newNe)).to.be.false;
-    });
+    cy.get('.score-bounds-delete-button')
+        .should('be.visible')
+        .then(() => {
+          // Bounds have not yet been set.
+          expect(underTest.map.getBounds().contains(scoreBoundsCoordinates[1]))
+              .to.be.false;
+          // Now they're set.
+          underTest.onShow();
+          // TODO(janakr): Bounds are not available immediately after map
+          //  initialization. Putting it here, after a few cy.get() operations,
+          //  appears to be enough, but might have to add a wait if flaky.
+          // Check that map bounds have adjusted to include the polygon we drew,
+          // which extends north of the US into Canada.
+          const bounds = underTest.map.getBounds();
+          scoreBoundsCoordinates.forEach(
+              (point) => expect(bounds.contains(point)).to.be.true);
+          // Now pan the map way over, just for fun.
+          expect(underTest.map.getBounds().contains(newSw)).to.be.false;
+          expect(underTest.map.getBounds().contains(newNe)).to.be.false;
+          underTest.map.fitBounds(new google.maps.LatLngBounds(newSw, newNe));
+          expect(underTest.map.getBounds().contains(newSw)).to.be.true;
+          expect(underTest.map.getBounds().contains(newNe)).to.be.true;
+          // Modify polygon, check that new path was saved.
+          underTest.polygon.getPath().setAt(
+              0, new google.maps.LatLng({lng: -100, lat: 30}));
+          expect(storedSaves).to.eql([[
+            {lng: -100, lat: 30},
+            ...scoreBoundsCoordinates.slice(1),
+          ]]);
+          storedSaves.length = 0;
+          // Switch to "new" disaster that has no polygon.
+          underTest.initialize(null, ['TX', 'LA']);
+          expect(underTest.polygon).to.be.null;
+          expect(underTest.drawingManager.getMap()).to.eql(underTest.map);
+          expect(storedSaves).to.be.empty;
+          return underTest.onShow();
+        })
+        .then(() => {
+          // Bounds were reset.
+          expect(underTest.map.getBounds().contains(newSw)).to.be.false;
+          expect(underTest.map.getBounds().contains(newNe)).to.be.false;
+          // We have a reasonably tight map around Texas and Louisiana
+          expect(underTest.map.getBounds().contains({lng: -100, lat: 32}))
+              .to.be.true;
+          expect(underTest.map.getBounds().contains({lng: -91, lat: 32}))
+              .to.be.true;
+          expect(underTest.map.getBounds().contains({lng: -100, lat: 41}))
+              .to.be.false;
+        });
 
     // No polygon, so no delete, and drawing manager visible.
     cy.get('.score-bounds-delete-button').should('not.be.visible');
@@ -118,8 +130,27 @@ describe('Unit tests for ScoreBoundsMap class', () => {
     });
   });
 
+  it('tests ScoreBoundsMap does not zoom to states if user zooms first', () => {
+    underTest.map.setCenter(defaultMapCenter);
+    underTest.map.setZoom(defaultZoomLevel);
+    const releasePromise = getConvertEeObjectToPromiseRelease();
+    underTest.initialize(null, ['TX', 'LA']);
+    const promise = underTest.onShow();
+    expect(promise).to.not.be.null;
+    cy.wait(50).then(
+        () => expect(underTest.map.getBounds().contains({lng: -100, lat: 41}))
+                  .to.be.true);
+    let zoomedBounds;
+    cy.get('[title="Zoom in"]').click().then(() => {
+      zoomedBounds = underTest.map.getBounds();
+      expect(zoomedBounds.contains({lng: -100, lat: 41})).to.be.false;
+      releasePromise();
+    });
+    cy.wrap(promise).then(() => expect(map.getBounds()).to.eql(zoomedBounds));
+  });
+
   it('Tests callbacks for ScoreBoundsMap after drag', () => {
-    underTest.initialize(scoreBoundsCoordinates);
+    underTest.initialize(scoreBoundsCoordinates, ['TX', 'LA']);
     underTest.onShow();
     google.maps.event.trigger(underTest.polygon, 'dragstart');
     google.maps.event.trigger(underTest.polygon, 'dragend');

--- a/cypress/integration/unit_tests/score_bounds_map_test.js
+++ b/cypress/integration/unit_tests/score_bounds_map_test.js
@@ -56,9 +56,7 @@ describe('Unit tests for ScoreBoundsMap class', () => {
     expect(underTest.drawingManager.getMap()).to.be.null;
     expect(storedSaves).to.be.empty;
     cy.get('[title="Draw a shape"').should('not.exist');
-    cy.get('.score-bounds-delete-button')
-        .should('be.visible')
-        .then(() => {
+    cy.get('.score-bounds-delete-button').should('be.visible').then(() => {
           // Bounds have not yet been set.
           expect(underTest.map.getBounds().contains(scoreBoundsCoordinates[1]))
               .to.be.false;

--- a/cypress/integration/unit_tests/score_bounds_map_test.js
+++ b/cypress/integration/unit_tests/score_bounds_map_test.js
@@ -146,6 +146,7 @@ describe('Unit tests for ScoreBoundsMap class', () => {
       expect(zoomedBounds.contains({lng: -100, lat: 41})).to.be.false;
       releasePromise();
     });
+    // We didn't zoom to selected states, because "user" already zoomed.
     cy.wrap(promise).then(() => expect(map.getBounds()).to.eql(zoomedBounds));
   });
 

--- a/cypress/integration/unit_tests/score_bounds_map_test.js
+++ b/cypress/integration/unit_tests/score_bounds_map_test.js
@@ -56,7 +56,9 @@ describe('Unit tests for ScoreBoundsMap class', () => {
     expect(underTest.drawingManager.getMap()).to.be.null;
     expect(storedSaves).to.be.empty;
     cy.get('[title="Draw a shape"').should('not.exist');
-    cy.get('.score-bounds-delete-button').should('be.visible').then(() => {
+    cy.get('.score-bounds-delete-button')
+        .should('be.visible')
+        .then(() => {
           // Bounds have not yet been set.
           expect(underTest.map.getBounds().contains(scoreBoundsCoordinates[1]))
               .to.be.false;

--- a/cypress/support/import_test_util.js
+++ b/cypress/support/import_test_util.js
@@ -1,9 +1,11 @@
 import {disasterData} from '../../docs/import/manage_layers_lib';
+import * as MapUtil from '../../docs/map_util.js';
 import * as Toast from '../../docs/toast.js';
 
 export {
   createAndAppend,
   createTrs,
+  getConvertEeObjectToPromiseRelease,
   setDisasterAndLayers,
   setUpSavingStubs,
   waitForPromiseAndAssertSaves,
@@ -79,4 +81,23 @@ function setUpSavingStubs() {
     cy.wrap(toastStub.withArgs('Saving...', -1)).as('savingStub');
     cy.wrap(toastStub.withArgs('Saved')).as('savedStub');
   });
+}
+
+/**
+ * A wrapper for {@link convertEeObjectToPromise} that returns a resolve
+ * function for releasing the result.
+ * @return {Function}
+ */
+function getConvertEeObjectToPromiseRelease() {
+  let resolveFunction = null;
+  const promise = new Promise((resolve) => resolveFunction = resolve);
+  const oldConvert = MapUtil.convertEeObjectToPromise;
+  MapUtil.convertEeObjectToPromise = (eeObject) => {
+    MapUtil.convertEeObjectToPromise = oldConvert;
+    return MapUtil.convertEeObjectToPromise(eeObject).then(async (result) => {
+      await promise;
+      return result;
+    });
+  };
+  return resolveFunction;
 }

--- a/cypress/support/script_loader.js
+++ b/cypress/support/script_loader.js
@@ -155,7 +155,7 @@ const testPrefix = new Date().getTime() + '-';
 function addFirebaseHooks() {
   before(() => {
     cy.task('initializeTestFirebase', null, {
-        timeout: 10000,
+        timeout: 20000,
       }).then((token) => global.firestoreCustomToken = token);
     // Write a copy of the data to backup documents in case of accidental
     // deletion. One backup per day.
@@ -177,7 +177,7 @@ function addFirebaseHooks() {
  * @return {Cypress.Chainable<any>}
  */
 function doServerEeSetup() {
-  return cy.task('getEarthEngineToken')
+  return cy.task('getEarthEngineToken', {timeout: 20000})
       .then((token) => earthEngineCustomToken = token);
 }
 

--- a/docs/basic_map.js
+++ b/docs/basic_map.js
@@ -4,9 +4,10 @@ export {
   addPolygonWithPath,
   applyMinimumBounds,
   createBasicMap,
-  defaultMapCenter,
-  defaultZoomLevel,
 };
+
+// For testing.
+export {defaultMapCenter, defaultZoomLevel};
 
 // Center of the contiguous United States (lower 48).
 const defaultMapCenter = {

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -191,9 +191,10 @@ function onSetDisaster() {
   processedCurrentDisasterStateAssets = false;
   processedCurrentDisasterSelfAssets = false;
   const scoreBoundsPath = getElementFromPath(scoreCoordinatesPath);
-  scoreBoundsMap.initialize(
-      scoreBoundsPath ? transformGeoPointArrayToLatLng(scoreBoundsPath) : null);
   const states = disasterData.get(currentDisaster).states;
+  scoreBoundsMap.initialize(
+      scoreBoundsPath ? transformGeoPointArrayToLatLng(scoreBoundsPath) : null,
+      states);
   const neededStates = [];
   for (const state of states) {
     if (!stateAssets.has(state)) {

--- a/docs/import/score_bounds_map.js
+++ b/docs/import/score_bounds_map.js
@@ -141,10 +141,12 @@ class ScoreBoundsMap {
         if (zoomChangedByUser) {
           return;
         }
-        const coordinates = resolvedBounds.coordinates[0];
-        bounds.extend(latLngLiteralFromArray(coordinates[0]));
-        bounds.extend(latLngLiteralFromArray(coordinates[2]));
-        console.log('changed bounds inside');
+        const rectangleCoordinates = resolvedBounds.coordinates[0];
+        const swCorner = rectangleCoordinates[0];
+        const neCorner = rectangleCoordinates[2];
+
+        bounds.extend(latLngLiteralFromArray(swCorner))
+            .extend(latLngLiteralFromArray(neCorner));
         applyMinimumBounds(bounds, this.map);
       });
     }

--- a/docs/import/score_bounds_map.js
+++ b/docs/import/score_bounds_map.js
@@ -144,6 +144,7 @@ class ScoreBoundsMap {
         const coordinates = resolvedBounds.coordinates[0];
         bounds.extend(latLngLiteralFromArray(coordinates[0]));
         bounds.extend(latLngLiteralFromArray(coordinates[2]));
+        console.log('changed bounds inside');
         applyMinimumBounds(bounds, this.map);
       });
     }


### PR DESCRIPTION
Use EE TIGER states resource. Not instant, so we don't zoom if user manages to beat us to a zoom.

It might have been nice to cancel our operation if user panned as well, but I don't know how to get that event: bounds_changed fires too often. Also, if the user is panning around the map but it's zoomed out, probably not much value in it.

There is a weird quirk right now: if you switch between two disasters, and the second one doesn't have a polygon, we won't re-center the map until the state ee processing is finished. Until then, the previous disaster's map will stay up (though without the polygon). We could re-center the map on the US until the ee promise finished, but that felt pretty manic.

#283