### PR TITLE
Make SVI/Income/Buildings optional when possible

### DIFF
--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -80,7 +80,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
       ', and must specify either damage asset or map bounds' +
       allOptionalMissing;
 
-  it.only('validates asset data', () => {
+  it('validates asset data', () => {
     const boundsChanged = new Promise((resolve) => {
       const listener = scoreBoundsMap.map.addListener('bounds_changed', () => {
         google.maps.event.removeListener(listener);
@@ -161,6 +161,14 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     cy.get('#process-button')
         .should('have.css', 'background-color')
         .and('eq', 'rgb(150, 150, 0)');
+    // Get rid of score asset.
+    setFirstSelectInScoreRow(0).select('').blur();
+    cy.get('#process-button')
+        .should('be.disabled')
+        .should('have.css', 'background-color')
+        .and('eq', 'rgb(128, 128, 128)');
+    // Put score asset back.
+    setFirstSelectInScoreRow(0);
     // Put income back.
     setFirstSelectInScoreRow(1);
     cy.get('#process-button')
@@ -176,7 +184,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
         .should('have.text', 'Must specify either damage asset or map bounds');
     cy.get('#process-button').should('be.disabled');
     // Get rid of score asset.
-    setFirstSelectInScoreRow(0).select('');
+    setFirstSelectInScoreRow(0).select('').blur();
     cy.get('#process-button')
         .should(
             'have.text',

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -147,10 +147,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     }
     // Yay! We're ready to go.
     cy.get('#process-button')
-        .should(
-            'have.text',
-            'Kick off Data Processing (will ' +
-                'take a while!)');
+        .should('have.text', 'Kick off Data Processing (will take a while!)');
     cy.get('#process-button')
         .should('be.enabled')
         .should('have.css', 'background-color')

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -80,7 +80,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
       ', and must specify either damage asset or map bounds' +
       allOptionalMissing;
 
-  it('validates asset data', () => {
+  it.only('validates asset data', () => {
     const boundsChanged = new Promise((resolve) => {
       const listener = scoreBoundsMap.map.addListener('bounds_changed', () => {
         google.maps.event.removeListener(listener);
@@ -149,7 +149,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     cy.get('#process-button')
         .should('be.enabled')
         .should('have.css', 'background-color')
-        .and('eq', 'rgb(255, 255, 255)');
+        .and('eq', 'rgb(0, 128, 0)');
     // Getting rid of income keeps enabled, but warns
     setFirstSelectInScoreRow(1).select('').blur();
     cy.get('#process-button')
@@ -168,7 +168,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     cy.get('#process-button')
         .should('be.enabled')
         .should('have.css', 'background-color')
-        .and('eq', 'rgb(255, 255, 255)');
+        .and('eq', 'rgb(0, 128, 0)');
     // Get rid of damage: not ready anymore.
     cy.get('#damage-asset-select').select('').blur();
     // Message is just about damage.
@@ -417,6 +417,9 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
   function preparePage() {
     cy.visit('test_utils/empty.html');
     return cy.document().then((doc) => {
+      const buttonCss = doc.createElement('style');
+      buttonCss.innerHTML = 'button {background-color: green;} ' + 'button:disabled {background-color: grey}';
+      doc.head.appendChild(buttonCss);
       const tbody = doc.createElement('tbody');
       tbody.id = 'asset-selection-table-body';
       doc.body.appendChild(tbody);

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -418,7 +418,8 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     cy.visit('test_utils/empty.html');
     return cy.document().then((doc) => {
       const buttonCss = doc.createElement('style');
-      buttonCss.innerHTML = 'button {background-color: green;} ' + 'button:disabled {background-color: grey}';
+      buttonCss.innerHTML = 'button {background-color: green;} ' +
+          'button:disabled {background-color: grey}';
       doc.head.appendChild(buttonCss);
       const tbody = doc.createElement('tbody');
       tbody.id = 'asset-selection-table-body';

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -206,11 +206,13 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
         .should('eq', 5)
         .then(validateUserFields);
     cy.get('#process-button').should('be.disabled');
-    const allStateAssetsMissingText = 'Missing asset(s): Poverty [NY, WY], ' +
-        'Census TIGER Shapefiles [NY, WY], and must specify either damage ' +
-        'asset or map bounds; warning: created asset will be missing Income ' +
-        '[NY, WY], SVI [NY, WY], Building counts [NY, WY]';
-    cy.get('#process-button').should('have.text', allStateAssetsMissingText);
+    cy.get('#process-button')
+        .should(
+            'have.text',
+            'Missing asset(s): Poverty [NY, WY], Census TIGER ' +
+                'Shapefiles [NY, WY], and must specify either damage asset ' +
+                'or map bounds; warning: created asset will be missing Income' +
+                ' [NY, WY], SVI [NY, WY], Building counts [NY, WY]');
     // Specifying one state has desired effect.
     setFirstSelectInScoreRow(0);
     cy.get('#process-button')

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -76,8 +76,6 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
   const allOptionalMissing = alwaysOptionalMissing + ', Building counts';
   const allStateAssetsMissingWithDamageAssetText = allMandatoryMissingText +
       ', Microsoft Building Shapefiles' + alwaysOptionalMissing;
-  const allStateAssetsMissingWithScoreBoundsText =
-      allMandatoryMissingText + allOptionalMissing;
   const allMissingText = allMandatoryMissingText +
       ', and must specify either damage asset or map bounds' +
       allOptionalMissing;
@@ -119,7 +117,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
                 scoreBoundsMap.drawingManager));
 
     cy.get('#process-button')
-        .should('have.text', allStateAssetsMissingWithScoreBoundsText);
+        .should('have.text', allMandatoryMissingText + allOptionalMissing);
     cy.get('.score-bounds-delete-button').click();
     cy.get('#process-button').should('have.text', allMissingText);
 

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -78,7 +78,13 @@ const optionalWarningPrefix = '; warning: created asset will be missing ';
  */
 function validateUserFields() {
   const states = disasterData.get(getDisaster()).states;
+  /**
+   * Holds missing assets, as arrays. Each array has the display name of the
+   * asset type, and, if this is a multistate disaster, a string indicating
+   * which states are missing for this type.
+   */
   const missingItems = [];
+  const multistate = states.length > 1;
   const damageAssetPresent = !!$('#damage-asset-select').val();
 
   for (const {idStem, displayName} of scoreAssetTypes) {
@@ -91,7 +97,7 @@ function validateUserFields() {
     }
     if (missingForType.length) {
       const missingItem = [displayName];
-      if (states.length > 1) {
+      if (multistate) {
         missingItem.push('[' + missingForType.join(', ') + ']');
       }
       missingItems.push(missingItem);
@@ -138,6 +144,7 @@ function validateUserFields() {
   if (message) {
     processButton.text(message);
     processButton.attr('disabled', true);
+    processButton.css('background-color', '');
   } else {
     processButton.text(
         kickOffText +

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -65,10 +65,16 @@ const kickOffText = 'Kick off Data Processing (will take a while!)';
 const optionalWarningPrefix = '; warning: created asset will be missing ';
 
 /**
- * Checks that all fields that can be entered by the user have a non-empty
- * value. Does not check that assets actually exist, are of valid type, etc. If
- * all validation succeeds, enables kick-off button, otherwise disables and
- * changes button text to say what is missing.
+ * Checks that all mandatory fields that can be entered by the user have
+ * non-empty values. Does not check that assets actually exist, are of valid
+ * type, etc. If all validation succeeds, enables kick-off button, otherwise
+ * disables and changes button text to say what is missing.
+ *
+ * Some fields (Income, SVI) are optional. If they are missing, a separate
+ * message is displayed on the button, but it can still be enabled. If it is
+ * enabled, it is yellowed a bit to indicate the missing optional assets.
+ * The buildings asset is optional if the damage asset is not present, but is
+ * required if the damage asset is present.
  */
 function validateUserFields() {
   const states = disasterData.get(getDisaster()).states;
@@ -102,6 +108,10 @@ function validateUserFields() {
           !damageAssetPresent;
       const optional = missingItem[0] === 'Income' ||
           missingItem[0] === 'SVI' || optionalBuildings;
+      // Construct string to append to message: display name + missing states,
+      // if any. Buildings is special because we don't actually display
+      // "Microsoft Building Shapefiles" on the map, only building counts, so we
+      // tell the user that's what they're missing.
       const itemString = optionalBuildings ?
           ('Building counts' +
            (missingItem.length > 1 ? ' ' + missingItem[1] : '')) :


### PR DESCRIPTION
SVI and Income are always optional, Buildings optional when damage asset not present. Messaging stays in the button. We change the button color to a grayish yellow when missing optional assets.