### PR TITLE
Back up previous version of score asset when creating new one

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "defaultCommandTimeout": 20000,
   "projectId": "jr8ks8",
   "nodeVersion": "system",
   "animationDistanceThreshold": 20,

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
-  "defaultCommandTimeout": 20000,
   "projectId": "jr8ks8",
   "nodeVersion": "system",
   "animationDistanceThreshold": 20,

--- a/cypress/integration/integration_tests/nav_test.js
+++ b/cypress/integration/integration_tests/nav_test.js
@@ -1,5 +1,5 @@
 describe('Integration test for the navbar', () => {
-  it('Switch disasters', () => {
+  it.only('Switch disasters', () => {
     cy.visit('');
 
     // Michael on top of Harvey.
@@ -13,6 +13,7 @@ describe('Integration test for the navbar', () => {
         .eq(0)
         .contains('2018-michael');
     cy.get('#disaster-dropdown').select('2018-michael');
+    cy.awaitLoad();
 
     // The page should now be switched to the Michael disaster.
     cy.get('.google-visualization-table-td').contains('Florida');

--- a/cypress/integration/integration_tests/nav_test.js
+++ b/cypress/integration/integration_tests/nav_test.js
@@ -1,5 +1,5 @@
 describe('Integration test for the navbar', () => {
-  it.only('Switch disasters', () => {
+  it('Switch disasters', () => {
     cy.visit('');
 
     // Michael on top of Harvey.

--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -82,7 +82,7 @@ describe('Unit tests for click_feature.js with map and table', () => {
       containerDiv.appendChild(tableDiv);
       drawTableAndSetUpHandlers(
           convertEeObjectToPromise(scoredFeatures).then((fc) => fc.features),
-          map, features);
+          map);
     });
     cy.wrap(loadingFinishedPromise);
     return assertNoSelection();

--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -57,7 +57,7 @@ describe('Unit tests for click_feature.js with map and table', () => {
   beforeEach(() => {
     currentFeatures.clear();
     setUpPage();
-    cy.stub(Resources, 'getScoreAsset').returns(features);
+    cy.stub(Resources, 'getScoreAssetPath').returns(features);
     const oldConvertToPromise = MapUtil.convertEeObjectToPromise;
     MapUtil.convertEeObjectToPromise = (eeObject) => {
       MapUtil.convertEeObjectToPromise = oldConvertToPromise;
@@ -102,7 +102,6 @@ describe('Unit tests for click_feature.js with map and table', () => {
   }
 
   it('clicks on a feature on the map, then unclicks it', () => {
-    console.log('got here');
     clickAndVerifyBlockGroup();
     cy.wait(waitBeforeClick);
     cy.get('#test-map-div').click(500, 100);

--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -5,7 +5,10 @@ import * as loading from '../../../docs/loading.js';
 import {convertEeObjectToPromise} from '../../../docs/map_util.js';
 import {blockGroupTag, geoidTag} from '../../../docs/property_names';
 import {scoreTag} from '../../../docs/property_names.js';
-import {drawTableAndSetUpHandlers} from '../../../docs/run.js';
+import {
+  createScorePromise,
+  drawTableAndSetUpHandlers,
+} from '../../../docs/run.js';
 import {cyQueue} from '../../support/commands.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
 import {convertPathToLatLng, createGoogleMap} from '../../support/test_map.js';
@@ -68,6 +71,8 @@ describe('Unit tests for click_feature.js with map and table', () => {
           if (id === tableContainerId) resolve();
         });
     createGoogleMap().then((mapResult) => map = mapResult);
+    // Make sure score asset name is known.
+    createScorePromise();
     cy.document().then((doc) => {
       // Lightly fake out prod document access.
       cy.stub(document, 'getElementById')

--- a/cypress/integration/unit_tests/create_score_asset_test.js
+++ b/cypress/integration/unit_tests/create_score_asset_test.js
@@ -1,6 +1,6 @@
 import {createScoreAsset} from '../../../docs/import/create_score_asset.js';
 import {convertEeObjectToPromise} from '../../../docs/map_util';
-import {getBackupScoreAsset, getScoreAsset} from '../../../docs/resources.js';
+import {getBackupScoreAssetPath, getScoreAssetPath} from '../../../docs/resources.js';
 import {assertFirestoreMapBounds} from '../../support/firestore_map_bounds';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
@@ -35,12 +35,12 @@ describe('Unit tests for create_score_asset.js', () => {
     // Stub out delete, rename, and export. We'll assert on what was exported
     // below.
     cy.stub(ee.data, 'deleteAsset').callsFake((oldAsset, callback) => {
-      expect(oldAsset).to.equal(getBackupScoreAsset());
+      expect(oldAsset).to.equal(getBackupScoreAssetPath());
       callback();
     });
     cy.stub(ee.data, 'renameAsset').callsFake((from, to, callback) => {
-      expect(from).to.equal(getScoreAsset());
-      expect(to).to.equal(getBackupScoreAsset());
+      expect(from).to.equal(getScoreAssetPath());
+      expect(to).to.equal(getBackupScoreAssetPath());
       callback();
     });
     exportStub = cy.stub(ee.batch.Export.table, 'toAsset')

--- a/cypress/integration/unit_tests/create_score_asset_test.js
+++ b/cypress/integration/unit_tests/create_score_asset_test.js
@@ -1,5 +1,6 @@
 import {createScoreAsset} from '../../../docs/import/create_score_asset.js';
 import {convertEeObjectToPromise} from '../../../docs/map_util';
+import {getBackupScoreAsset, getScoreAsset} from '../../../docs/resources.js';
 import {assertFirestoreMapBounds} from '../../support/firestore_map_bounds';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
 
@@ -31,8 +32,17 @@ describe('Unit tests for create_score_asset.js', () => {
       makePoint(1.4, 0.7),
       makePoint(1.5, 0.5),
     ]);
-    // Stub out delete and export. We'll assert on what was exported, below.
-    cy.stub(ee.data, 'deleteAsset').callsFake((_, callback) => callback());
+    // Stub out delete, rename, and export. We'll assert on what was exported
+    // below.
+    cy.stub(ee.data, 'deleteAsset').callsFake((oldAsset, callback) => {
+      expect(oldAsset).to.equal(getBackupScoreAsset());
+      callback();
+    });
+    cy.stub(ee.data, 'renameAsset').callsFake((from, to, callback) => {
+      expect(from).to.equal(getScoreAsset());
+      expect(to).to.equal(getBackupScoreAsset());
+      callback();
+    });
     exportStub = cy.stub(ee.batch.Export.table, 'toAsset')
                      .returns({start: () => {}, id: 'FAKE_ID'});
 

--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -79,7 +79,7 @@ describe('Unit test for ShapeData', () => {
       ee.Feature(ee.Geometry.Point([200, 200])),
     ]);
     // Use our custom EarthEngine FeatureCollections.
-    cy.stub(resourceGetter, 'getScoreAsset').returns(scoreCollection);
+    cy.stub(resourceGetter, 'getScoreAssetPath').returns(scoreCollection);
 
     setUpPage();
   });

--- a/cypress/integration/unit_tests/process_joined_data_test.js
+++ b/cypress/integration/unit_tests/process_joined_data_test.js
@@ -1,4 +1,4 @@
-import processJoinedData from '../../../docs/process_joined_data.js';
+import {processJoinedData} from '../../../docs/process_joined_data.js';
 
 const featureProperties = {
   'SNAP HOUSEHOLDS': 2,

--- a/cypress/integration/unit_tests/run_test.js
+++ b/cypress/integration/unit_tests/run_test.js
@@ -1,62 +1,41 @@
-import {mapContainerId, tableContainerId} from '../../../docs/dom_constants.js';
-import {createScorePromise, run} from '../../../docs/run.js';
-import * as Update from '../../../docs/update.js';
-import * as PolygonDraw from '../../../docs/polygon_draw.js';
-import * as LayerUtil from '../../../docs/layer_util.js';
-import * as ProcessJoinedData from '../../../docs/process_joined_data.js';
-import * as DrawTable from '../../../docs/draw_table.js';
-import * as Loading from '../../../docs/loading.js';
-import * as ClickFeature from '../../../docs/click_feature.js';
 import * as Resources from '../../../docs/resources.js';
+import {setScorePromiseAndReturnAssetName} from '../../../docs/run.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
-import SettablePromise from '../../../docs/settable_promise.js';
 
 describe('Unit test for run.js', () => {
-  loadScriptsBeforeForUnitTests('ee', 'deck', 'maps');
-  xit('Score asset not present, but backup is', () => {
-    cy.stub(Update, 'createToggles');
-    cy.stub(PolygonDraw, 'initializeAndProcessUserRegions');
-    cy.stub(LayerUtil, 'setMapToDrawLayersOn');
-    cy.stub(ProcessJoinedData, 'processJoinedData').
-        callsFake((promise) => promise);
-    cy.stub(LayerUtil, 'addScoreLayer');
-    const promiseGivenToDrawTable = new SettablePromise();
-    cy.stub(DrawTable, 'drawTable').callsFake((promise) => {
-      promiseGivenToDrawTable.setPromise(promise);
-      return promiseGivenToDrawTable;
-    });
-    cy.stub(Loading, 'addLoadingElement');
-    cy.stub(ClickFeature, 'selectHighlightedFeatures');
-    cy.stub(Resources, 'getScoreAsset').
-        returns('nonexistent/feature/collection');
-    cy.stub(Resources, 'getBackupScoreAsset').
-        returns(ee.FeatureCollection(
-            [ee.Feature(ee.Geometry.Point([0, 0]), {property: 'value'})]));
-    cy.stub(Loading, 'loadingElementFinished');
-    const fakeMap = {
-      addListener: () => {
-      }, data: {
-        addListener: () => {
-        }
-      }
-    };
-    run(null, null, new Promise(() => {
-    }));
-    cy.wrap(promiseGivenToDrawTable.getPromise()).then((result) => {
-      expect(result.features).to.have.length(1);
-      expect(result.features[0].properties).
-          to.
-          have.
-          property('property', 'value');
+  loadScriptsBeforeForUnitTests('ee');
+  it('Score asset present', () => {
+    const assetName = 'TIGER/2018/States';
+    cy.stub(Resources, 'getScoreAsset').returns(assetName);
+    const backupStub = cy.stub(Resources, 'getBackupScoreAsset');
+    cy.wrap(setScorePromiseAndReturnAssetName()).then((result) => {
+      expect(result).to.equal(assetName);
+      expect(backupStub).to.not.be.called;
     });
   });
 
   it('Score asset not present, but backup is', () => {
-    cy.stub(Resources, 'getScoreAsset').
-        returns('nonexistent/feature/collection');
-    cy.stub(Resources, 'getBackupScoreAsset').
-        returns(ee.FeatureCollection(
-            [ee.Feature(ee.Geometry.Point([0, 0]), {property: 'value'})]));
-    cy.wrap(createScorePromise()).then(console.log);
+    cy.stub(Resources, 'getScoreAsset')
+        .returns('nonexistent/feature/collection');
+    const backupName = 'TIGER/2018/States';
+    cy.stub(Resources, 'getBackupScoreAsset').returns(backupName);
+    cy.wrap(setScorePromiseAndReturnAssetName())
+        .then((result) => expect(result).to.equal(backupName));
+  });
+
+
+  it('Neither asset present', () => {
+    cy.stub(Resources, 'getScoreAsset')
+        .returns('nonexistent/feature/collection');
+    cy.stub(Resources, 'getBackupScoreAsset').returns('another/bad/asset');
+    const promise = setScorePromiseAndReturnAssetName().then(
+        (result) => {
+          throw new Error('unexpected: ' + result);
+        },
+        (err) => {
+          expect(err).to.contain('another/bad/asset');
+          expect(err).to.contain('not found.');
+        });
+    cy.wrap(promise);
   });
 });

--- a/cypress/integration/unit_tests/run_test.js
+++ b/cypress/integration/unit_tests/run_test.js
@@ -1,0 +1,44 @@
+import {mapContainerId, tableContainerId} from '../../../docs/dom_constants.js';
+import {createScorePromise, run} from '../../../docs/run.js';
+import * as Update from '../../../docs/update.js';
+import * as PolygonDraw from '../../../docs/polygon_draw.js';
+import * as LayerUtil from '../../../docs/layer_util.js';
+import * as ProcessJoinedData from '../../../docs/process_joined_data.js';
+import * as DrawTable from '../../../docs/draw_table.js';
+import * as Loading from '../../../docs/loading.js';
+import * as ClickFeature from '../../../docs/click_feature.js';
+import * as Resources from '../../../docs/resources.js';
+import {loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
+import SettablePromise from '../../../docs/settable_promise.js';
+
+describe('Unit test for run.js', () => {
+  loadScriptsBeforeForUnitTests('ee', 'deck', 'maps');
+  it('Score asset not present, but backup is', () => {
+    cy.stub(Update, 'createToggles');
+    cy.stub(PolygonDraw, 'initializeAndProcessUserRegions');
+    cy.stub(LayerUtil, 'setMapToDrawLayersOn');
+    cy.stub(ProcessJoinedData, 'processJoinedData').callsFake((promise) => promise);
+    cy.stub(LayerUtil, 'addScoreLayer');
+    const promiseGivenToDrawTable = new SettablePromise();
+    cy.stub(DrawTable, 'drawTable').callsFake((promise) => {
+      promiseGivenToDrawTable.setPromise(promise);
+      return promiseGivenToDrawTable;
+    });
+    cy.stub(Loading, 'addLoadingElement');
+    cy.stub(ClickFeature, 'selectHighlightedFeatures');
+    cy.stub(Resources, 'getScoreAsset').returns('nonexistent/feature/collection');
+    cy.stub(Resources, 'getBackupScoreAsset').returns(ee.FeatureCollection([ee.Feature(ee.Geometry.Point([0, 0]), {property: 'value'})]));
+    cy.stub(Loading, 'loadingElementFinished');
+    const fakeMap = {addListener: () => {}, data: {addListener: () => {}}};
+    run(null, null, new Promise(() => {}));
+    cy.wrap(promiseGivenToDrawTable.getPromise()).then((result) => {
+      expect(result.features).to.have.length(1);
+      expect(result.features[0].properties).to.have.property('property', 'value');
+    });
+  });
+
+  it('Score asset not present, but backup is', () => {
+    cy.stub(Resources, 'getScoreAsset').returns('nonexistent/feature/collection');
+    cy.stub(Resources, 'getBackupScoreAsset').returns(ee.FeatureCollection([ee.Feature(ee.Geometry.Point([0, 0]), {property: 'value'})]));
+    cy.wrap(createScorePromise()).then()
+  });

--- a/cypress/integration/unit_tests/run_test.js
+++ b/cypress/integration/unit_tests/run_test.js
@@ -6,7 +6,7 @@ import {loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
 describe('Unit test for run.js', () => {
   loadScriptsBeforeForUnitTests('ee');
   let errorStub;
-  beforeEach(() => errorStub = cy.stub(Snackbar, 'showError'));
+  beforeEach(() => errorStub = cy.stub(Error, 'showError'));
 
   it('Score asset present', () => {
     const assetName = 'TIGER/2018/States';

--- a/cypress/integration/unit_tests/run_test.js
+++ b/cypress/integration/unit_tests/run_test.js
@@ -1,9 +1,13 @@
+import * as Error from '../../../docs/error.js';
 import * as Resources from '../../../docs/resources.js';
 import {setScorePromiseAndReturnAssetName} from '../../../docs/run.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
 
 describe('Unit test for run.js', () => {
   loadScriptsBeforeForUnitTests('ee');
+  let errorStub;
+  beforeEach(() => errorStub = cy.stub(Snackbar, 'showError'));
+
   it('Score asset present', () => {
     const assetName = 'TIGER/2018/States';
     cy.stub(Resources, 'getScoreAsset').returns(assetName);
@@ -11,6 +15,7 @@ describe('Unit test for run.js', () => {
     cy.wrap(setScorePromiseAndReturnAssetName()).then((result) => {
       expect(result).to.equal(assetName);
       expect(backupStub).to.not.be.called;
+      expect(errorStub).to.not.be.called;
     });
   });
 
@@ -19,8 +24,10 @@ describe('Unit test for run.js', () => {
         .returns('nonexistent/feature/collection');
     const backupName = 'TIGER/2018/States';
     cy.stub(Resources, 'getBackupScoreAsset').returns(backupName);
-    cy.wrap(setScorePromiseAndReturnAssetName())
-        .then((result) => expect(result).to.equal(backupName));
+    cy.wrap(setScorePromiseAndReturnAssetName()).then((result) => {
+      expect(result).to.equal(backupName);
+      expect(errorStub).to.be.calledOnce;
+    });
   });
 
 
@@ -36,6 +43,6 @@ describe('Unit test for run.js', () => {
           expect(err).to.contain('another/bad/asset');
           expect(err).to.contain('not found.');
         });
-    cy.wrap(promise);
+    cy.wrap(promise).then(() => expect(errorStub).to.be.calledOnce);
   });
 });

--- a/cypress/integration/unit_tests/run_test.js
+++ b/cypress/integration/unit_tests/run_test.js
@@ -13,11 +13,12 @@ import SettablePromise from '../../../docs/settable_promise.js';
 
 describe('Unit test for run.js', () => {
   loadScriptsBeforeForUnitTests('ee', 'deck', 'maps');
-  it('Score asset not present, but backup is', () => {
+  xit('Score asset not present, but backup is', () => {
     cy.stub(Update, 'createToggles');
     cy.stub(PolygonDraw, 'initializeAndProcessUserRegions');
     cy.stub(LayerUtil, 'setMapToDrawLayersOn');
-    cy.stub(ProcessJoinedData, 'processJoinedData').callsFake((promise) => promise);
+    cy.stub(ProcessJoinedData, 'processJoinedData').
+        callsFake((promise) => promise);
     cy.stub(LayerUtil, 'addScoreLayer');
     const promiseGivenToDrawTable = new SettablePromise();
     cy.stub(DrawTable, 'drawTable').callsFake((promise) => {
@@ -26,19 +27,36 @@ describe('Unit test for run.js', () => {
     });
     cy.stub(Loading, 'addLoadingElement');
     cy.stub(ClickFeature, 'selectHighlightedFeatures');
-    cy.stub(Resources, 'getScoreAsset').returns('nonexistent/feature/collection');
-    cy.stub(Resources, 'getBackupScoreAsset').returns(ee.FeatureCollection([ee.Feature(ee.Geometry.Point([0, 0]), {property: 'value'})]));
+    cy.stub(Resources, 'getScoreAsset').
+        returns('nonexistent/feature/collection');
+    cy.stub(Resources, 'getBackupScoreAsset').
+        returns(ee.FeatureCollection(
+            [ee.Feature(ee.Geometry.Point([0, 0]), {property: 'value'})]));
     cy.stub(Loading, 'loadingElementFinished');
-    const fakeMap = {addListener: () => {}, data: {addListener: () => {}}};
-    run(null, null, new Promise(() => {}));
+    const fakeMap = {
+      addListener: () => {
+      }, data: {
+        addListener: () => {
+        }
+      }
+    };
+    run(null, null, new Promise(() => {
+    }));
     cy.wrap(promiseGivenToDrawTable.getPromise()).then((result) => {
       expect(result.features).to.have.length(1);
-      expect(result.features[0].properties).to.have.property('property', 'value');
+      expect(result.features[0].properties).
+          to.
+          have.
+          property('property', 'value');
     });
   });
 
   it('Score asset not present, but backup is', () => {
-    cy.stub(Resources, 'getScoreAsset').returns('nonexistent/feature/collection');
-    cy.stub(Resources, 'getBackupScoreAsset').returns(ee.FeatureCollection([ee.Feature(ee.Geometry.Point([0, 0]), {property: 'value'})]));
-    cy.wrap(createScorePromise()).then()
+    cy.stub(Resources, 'getScoreAsset').
+        returns('nonexistent/feature/collection');
+    cy.stub(Resources, 'getBackupScoreAsset').
+        returns(ee.FeatureCollection(
+            [ee.Feature(ee.Geometry.Point([0, 0]), {property: 'value'})]));
+    cy.wrap(createScorePromise()).then(console.log);
   });
+});

--- a/cypress/integration/unit_tests/run_test.js
+++ b/cypress/integration/unit_tests/run_test.js
@@ -42,8 +42,7 @@ describe('Unit test for run.js', () => {
         .returns('nonexistent/feature/collection');
     cy.stub(Resources, 'getBackupScoreAssetPath').returns('another/bad/asset');
     const promise = setScorePromises().then(
-        (result) => assert.fail(null, null, 'unexpected: ' + result),
-        (err) => {
+        (result) => assert.fail(null, null, 'unexpected: ' + result), (err) => {
           expect(err).to.contain('another/bad/asset');
           expect(err).to.contain('not found.');
         });

--- a/cypress/support/script_loader.js
+++ b/cypress/support/script_loader.js
@@ -177,7 +177,7 @@ function addFirebaseHooks() {
  * @return {Cypress.Chainable<any>}
  */
 function doServerEeSetup() {
-  return cy.task('getEarthEngineToken')
+  return cy.task('getEarthEngineToken', {timeout: 20000})
       .then((token) => earthEngineCustomToken = token);
 }
 

--- a/docs/import/create_score_asset.js
+++ b/docs/import/create_score_asset.js
@@ -1,5 +1,5 @@
 import {blockGroupTag, buildingCountTag, damageTag, geoidTag, incomeTag, snapPercentageTag, snapPopTag, sviTag, totalPopTag, tractTag} from '../property_names.js';
-import {getBackupScoreAsset, getScoreAsset} from '../resources.js';
+import {getBackupScoreAssetPath, getScoreAssetPath} from '../resources.js';
 import {computeAndSaveBounds} from './center.js';
 import {cdcGeoidKey, censusBlockGroupKey, censusGeoidKey, tigerGeoidKey} from './import_data_keys.js';
 
@@ -320,8 +320,8 @@ function createScoreAsset(
     allStatesProcessing = allStatesProcessing.merge(processing);
   }
 
-  const scoreAssetPath = getScoreAsset();
-  const oldScoreAssetPath = getBackupScoreAsset();
+  const scoreAssetPath = getScoreAssetPath();
+  const oldScoreAssetPath = getBackupScoreAssetPath();
   const task = ee.batch.Export.table.toAsset(
       allStatesProcessing,
       scoreAssetPath.substring(scoreAssetPath.lastIndexOf('/') + 1),

--- a/docs/import/create_score_asset.js
+++ b/docs/import/create_score_asset.js
@@ -343,7 +343,8 @@ function createScoreAsset(
         if (err) {
           if (err.includes('does not exist')) {
             // This check isn't perfect detection, but best we can do.
-            console.log('Old ' + scoreAssetPath + ' not found, did not move it');
+            console.log(
+                'Old ' + scoreAssetPath + ' not found, did not move it');
           } else {
             const message = 'Error backing up: ' + err;
             setStatus(message);

--- a/docs/polygon_draw.js
+++ b/docs/polygon_draw.js
@@ -5,7 +5,7 @@ import {addLoadingElement, loadingElementFinished} from './loading.js';
 import {latLngToGeoPoint, polygonToGeoPointArray, transformGeoPointArrayToLatLng} from './map_util.js';
 import {createPopup, isMarker, setUpPopup} from './popup.js';
 import {snapPopTag, totalPopTag} from './property_names.js';
-import {getScoreAsset} from './resources.js';
+import {getScoreAssetPath} from './resources.js';
 import {userRegionData} from './user_region_data.js';
 
 // StoredShapeData is only for testing.
@@ -258,7 +258,7 @@ StoredShapeData.prepareDamageCalculation = (polygon) => {
 };
 
 StoredShapeData.getIntersectingBlockGroups = (polygon) => {
-  return ee.FeatureCollection(getScoreAsset())
+  return ee.FeatureCollection(getScoreAssetPath())
       .filterBounds(polygon)
       .map((feature) => {
         const geometry = feature.geometry();

--- a/docs/process_joined_data.js
+++ b/docs/process_joined_data.js
@@ -1,6 +1,6 @@
 import {damageTag, scoreTag, snapPercentageTag} from './property_names.js';
 
-export {processJoinedData as default};
+export {processJoinedData};
 
 const scoreDisplayCap = 255;
 

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -14,12 +14,27 @@ function getDisaster() {
   return defaultDisaster;
 }
 
-/** @return {string} EE asset path for score asset for the current disaster */
+/**
+ * EarthEngine path to score asset.
+ *
+ * This asset may be absent while it is being created. If a previous version of
+ * the asset was created, it will be present under {@link getBackupScoreAsset}.
+ * Therefore, this function should only be called when creating the score asset
+ * and inside run.js when constructing the score asset promise. Naively calling
+ * it could result in errors during the time when the score asset is being
+ * updated.
+ * @return {string}
+ */
 function getScoreAsset() {
+  // TOOD(janakr): rename this path.
   return gdEePathPrefix + getDisaster() + '/data-ms-as-tot';
 }
 
-/** @return {string} EE asset path for previously created score asset */
+/**
+ * EarthEngine path to most recently created score asset before current one.
+ * Not needed unless there is no asset at the path of {@link getScoreAsset}.
+ * @return {string}
+ */
 function getBackupScoreAsset() {
   return gdEePathPrefix + getDisaster() + '/score-asset-previous-version';
 }

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -1,6 +1,6 @@
 import {gdEePathPrefix} from './ee_paths.js';
 
-export {getBackupScoreAsset, getDisaster, getScoreAsset};
+export {getBackupScoreAssetPath, getDisaster, getScoreAssetPath};
 
 /**
  * Determines and returns the current disaster.
@@ -18,24 +18,25 @@ function getDisaster() {
  * EarthEngine path to score asset.
  *
  * This asset may be absent while it is being created. If a previous version of
- * the asset was created, it will be present under {@link getBackupScoreAsset}.
+ * the asset was created, it will be present under {@link getBackupScoreAssetPath}.
  * Therefore, this function should only be called when creating the score asset
  * and inside run.js when constructing the score asset promise. Naively calling
  * it could result in errors during the time when the score asset is being
  * updated.
  * @return {string}
  */
-function getScoreAsset() {
-  // TOOD(janakr): rename this path.
+function getScoreAssetPath() {
+  // TODO(janakr): rename this path to something more intelligible, like
+  //  .../score-asset
   return gdEePathPrefix + getDisaster() + '/data-ms-as-tot';
 }
 
 /**
  * EarthEngine path to most recently created score asset before current one.
- * Not needed unless there is no asset at the path of {@link getScoreAsset}.
+ * Not needed unless there is no asset at the path of {@link getScoreAssetPath}.
  * @return {string}
  */
-function getBackupScoreAsset() {
+function getBackupScoreAssetPath() {
   return gdEePathPrefix + getDisaster() + '/score-asset-previous-version';
 }
 

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -1,6 +1,7 @@
 import {gdEePathPrefix} from './ee_paths.js';
 
-export {getDisaster, getScoreAsset, getBackupScoreAsset};
+export {getBackupScoreAsset, getDisaster, getScoreAsset};
+
 /**
  * Determines and returns the current disaster.
  * @return {string} current disaster
@@ -18,8 +19,9 @@ function getScoreAsset() {
   return gdEePathPrefix + getDisaster() + '/data-ms-as-tot';
 }
 
+/** @return {string} EE asset path for previously created score asset */
 function getBackupScoreAsset() {
-  return gdEePathPrefix + getDisaster() + '/score-asset-previous-version'
+  return gdEePathPrefix + getDisaster() + '/score-asset-previous-version';
 }
 
 /** The default disaster. */

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -18,11 +18,11 @@ function getDisaster() {
  * EarthEngine path to score asset.
  *
  * This asset may be absent while it is being created. If a previous version of
- * the asset was created, it will be present under {@link getBackupScoreAssetPath}.
- * Therefore, this function should only be called when creating the score asset
- * and inside run.js when constructing the score asset promise. Naively calling
- * it could result in errors during the time when the score asset is being
- * updated.
+ * the asset was created, it will be present under {@link
+ * getBackupScoreAssetPath}. Therefore, this function should only be called when
+ * creating the score asset and inside run.js when constructing the score asset
+ * promise. Naively calling it could result in errors during the time when the
+ * score asset is being updated.
  * @return {string}
  */
 function getScoreAssetPath() {

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -1,6 +1,6 @@
 import {gdEePathPrefix} from './ee_paths.js';
 
-export {getDisaster, getScoreAsset};
+export {getDisaster, getScoreAsset, getBackupScoreAsset};
 /**
  * Determines and returns the current disaster.
  * @return {string} current disaster
@@ -18,6 +18,9 @@ function getScoreAsset() {
   return gdEePathPrefix + getDisaster() + '/data-ms-as-tot';
 }
 
+function getBackupScoreAsset() {
+  return gdEePathPrefix + getDisaster() + '/score-asset-previous-version'
+}
 
 /** The default disaster. */
 const defaultDisaster = '2017-harvey';

--- a/docs/resources.js
+++ b/docs/resources.js
@@ -15,11 +15,9 @@ function getDisaster() {
 
 /** @return {string} EE asset path for score asset for the current disaster */
 function getScoreAsset() {
-  // TODO(janakr): Modify map to handle no-damage scenario more intuitively.
-  //  Should make damage threshold, weight 0, probably hide those toggles
-  //  completely. Other changes?
   return gdEePathPrefix + getDisaster() + '/data-ms-as-tot';
 }
+
 
 /** The default disaster. */
 const defaultDisaster = '2017-harvey';

--- a/docs/run.js
+++ b/docs/run.js
@@ -9,6 +9,7 @@ import {setUserFeatureVisibility} from './popup.js';
 import processJoinedData from './process_joined_data.js';
 import {getScoreAsset} from './resources.js';
 import {setUpToggles} from './update.js';
+import SettablePromise from './settable_promise.js';
 
 export {
   createAndDisplayJoinedData,
@@ -20,6 +21,8 @@ export {
 // it from EarthEngine again.
 let snapAndDamagePromise;
 const scalingFactor = 100;
+
+const resolvedScoreAsset = new SettablePromise();
 
 /**
  * Main function that processes the known layers (damage, SNAP) and
@@ -35,7 +38,12 @@ function run(map, firebaseAuthPromise, disasterMetadataPromise) {
   setMapToDrawLayersOn(map);
   const scoreAsset = getScoreAsset();
   snapAndDamagePromise =
-      convertEeObjectToPromise(ee.FeatureCollection(scoreAsset));
+      convertEeObjectToPromise(ee.FeatureCollection(scoreAsset))
+          .catch((err) => {
+            
+      });
+  resolvedScoreAsset.setPromise(
+      snapAndDamagePromise.then(() => scoreAsset);
   const initialTogglesValuesPromise =
       setUpToggles(disasterMetadataPromise, map);
   createAndDisplayJoinedData(map, initialTogglesValuesPromise, scoreAsset);

--- a/docs/run.js
+++ b/docs/run.js
@@ -54,7 +54,6 @@ function setScorePromises() {
               throw err;
             }
           });
-  console.log(scorePromise);
   resolvedScoreAsset = scorePromise.then((collection) => collection.id);
   return resolvedScoreAsset;
 }

--- a/docs/run.js
+++ b/docs/run.js
@@ -109,7 +109,7 @@ function createAndDisplayJoinedData(map, initialTogglesValuesPromise) {
  * @param {google.maps.Map} map
  */
 function drawTableAndSetUpHandlers(processedData, map) {
-  Promise.all([resolvedScoreAsset.getPromise(), drawTable(processedData, map)])
+  Promise.all([resolvedScoreAsset, drawTable(processedData, map)])
       .then(([scoreAsset, tableSelector]) => {
         loadingElementFinished(tableContainerId);
         // every time we get a new table and data, reselect elements in the

--- a/docs/run.js
+++ b/docs/run.js
@@ -1,6 +1,7 @@
 import {clickFeature, selectHighlightedFeatures} from './click_feature.js';
 import {sidebarDatasetsId, tableContainerId} from './dom_constants.js';
 import {drawTable} from './draw_table.js';
+import {showError} from './error.js';
 import {addLayer, addNullLayer, addScoreLayer, scoreLayerName, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from './layer_util.js';
 import {addLoadingElement, loadingElementFinished} from './loading.js';
 import {convertEeObjectToPromise} from './map_util.js';
@@ -46,6 +47,10 @@ function setScorePromiseAndReturnAssetName() {
       convertEeObjectToPromise(ee.FeatureCollection(getScoreAsset()))
           .catch((err) => {
             if (err.endsWith('not found.')) {
+              showError(
+                  'Primary score asset not found. Checking to see if ' +
+                      'backup exists',
+                  null);
               return convertEeObjectToPromise(
                   ee.FeatureCollection(getBackupScoreAsset()));
             } else {

--- a/docs/run.js
+++ b/docs/run.js
@@ -2,15 +2,7 @@ import {clickFeature, selectHighlightedFeatures} from './click_feature.js';
 import {sidebarDatasetsId, tableContainerId} from './dom_constants.js';
 import {drawTable} from './draw_table.js';
 import {showError} from './error.js';
-import {
-  addLayer,
-  addNullLayer,
-  addScoreLayer,
-  scoreLayerName,
-  setMapToDrawLayersOn,
-  toggleLayerOff,
-  toggleLayerOn,
-} from './layer_util.js';
+import {addLayer, addNullLayer, addScoreLayer, scoreLayerName, setMapToDrawLayersOn, toggleLayerOff, toggleLayerOn} from './layer_util.js';
 import {addLoadingElement, loadingElementFinished} from './loading.js';
 import {convertEeObjectToPromise} from './map_util.js';
 import {initializeAndProcessUserRegions} from './polygon_draw.js';

--- a/docs/run.js
+++ b/docs/run.js
@@ -66,7 +66,8 @@ function setScorePromiseAndReturnAssetName() {
  * in tests.
  */
 function setScorePromises() {
-  resolvedScoreAsset.setPromise(setScorePromiseAndReturnAssetName());
+  const scorePromiseAndReturnAssetName = setScorePromiseAndReturnAssetName();
+  resolvedScoreAsset.setPromise(scorePromiseAndReturnAssetName);
 }
 
 /**

--- a/docs/script.js
+++ b/docs/script.js
@@ -2,7 +2,7 @@ import {Authenticator} from './authenticate.js';
 import createMap from './create_map.js';
 import {readDisasterDocument} from './firestore_document.js';
 import {loadNavbarWithPicker} from './navbar.js';
-import run from './run.js';
+import {run} from './run.js';
 import SettablePromise from './settable_promise.js';
 import {initializeSidebar} from './sidebar.js';
 import TaskAccumulator from './task_accumulator.js';

--- a/docs/update.js
+++ b/docs/update.js
@@ -1,6 +1,5 @@
 import {showError} from './error.js';
 import {removeScoreLayer} from './layer_util.js';
-import {getScoreAsset} from './resources.js';
 import {createAndDisplayJoinedData} from './run.js';
 
 export {
@@ -37,8 +36,7 @@ function update(map) {
   }
 
   removeScoreLayer();
-  createAndDisplayJoinedData(
-      map, Promise.resolve(getToggleValues()), getScoreAsset());
+  createAndDisplayJoinedData(map, Promise.resolve(getToggleValues()));
   // clear old listeners
   google.maps.event.clearListeners(map, 'click');
   google.maps.event.clearListeners(map.data, 'click');


### PR DESCRIPTION
And use that backup if the new one is not found. We do this by catching a failure in our score promise and substituting the backup if the failure seems to be from a missing asset.

This works out because we don't do any processing of the score asset except via that promise. Stern comment added to that effect.

Test has a horrible wait because of an apparent Cypress bug (https://github.com/cypress-io/cypress/issues/5980).