### PR TITLE
Handle EE authentication error more gracefully

### DIFF
--- a/docs/authenticate.js
+++ b/docs/authenticate.js
@@ -43,7 +43,10 @@ const firebaseConfigTest = {
 const gdUserEmail = 'gd-earthengine-user@givedirectly.org';
 
 const eeErrorDialog =
-    '<div title="EarthEngine authentication error">You do not appear to be whitelisted for EarthEngine access. Please whitelist your account at <a href="https://signup.earthengine.google.com">https://signup.earthengine.google.com</a> or sign into a whitelisted account after closing this dialog</div>';
+    '<div title="EarthEngine authentication error">You do not appear to be ' +
+    'whitelisted for EarthEngine access. Please whitelist your account at ' +
+    '<a href="https://signup.earthengine.google.com">https://signup.earthengine.google.com</a>' +
+    'or sign into a whitelisted account after closing this dialog</div>';
 
 /**
  * Logs an error message to the console and shows a snackbar notification

--- a/docs/authenticate.js
+++ b/docs/authenticate.js
@@ -41,6 +41,10 @@ const firebaseConfigTest = {
 };
 
 const gdUserEmail = 'gd-earthengine-user@givedirectly.org';
+
+const eeErrorDialog =
+    '<div title="EarthEngine authentication error">You do not appear to be whitelisted for EarthEngine access. Please whitelist your account at <a href="https://signup.earthengine.google.com">https://signup.earthengine.google.com</a> or sign into a whitelisted account after closing this dialog</div>';
+
 /**
  * Logs an error message to the console and shows a snackbar notification
  * indicating an issue with authentication.
@@ -73,7 +77,7 @@ class Authenticator {
    *     is finished
    */
   start() {
-    this.eeAuthenticate(() => this.onSignInFailedFirstTime());
+    this.eeAuthenticate(() => this.navigateToSignInPage());
     const gapiSettings = Object.assign({}, gapiTemplate);
     gapiSettings.scope = '';
     gapi.load('auth2', () => {
@@ -86,7 +90,7 @@ class Authenticator {
               'You must be signed in as ' + gdUserEmail +
               ' to access this page. Please open in an incognito window or ' +
               'sign in as ' + gdUserEmail + ' here');
-          this.onSignInFailedFirstTime({prompt: 'select_account'});
+          this.requireSignIn();
         } else {
           this.onLoginTaskCompleted();
         }
@@ -108,20 +112,41 @@ class Authenticator {
   }
 
   /**
-   * Falls back to a page redirect so that user can log in, getting around
-   * pop-up-blocking functionality of browsers.
+   * Redirects page so that user can log in, getting around pop-up-blocking
+   * functionality of browsers.
    * @param {gapi.auth.SignInOptions} extraOptions Dictionary of sign-in options
    */
-  onSignInFailedFirstTime(extraOptions = {}) {
+  navigateToSignInPage(extraOptions = {}) {
     this.gapiInitDone.getPromise().then(
         () => gapi.auth2.getAuthInstance().signIn(
             {...{ux_mode: 'redirect'}, ...extraOptions}));
   }
 
+  /**
+   * Forces sign-in page to come up, even if user already signed into Google.
+   * Useful if user is not signed in to a required account.
+   */
+  requireSignIn() {
+    this.navigateToSignInPage({prompt: 'select_account'});
+  }
+
   /** Initializes EarthEngine. */
   internalInitializeEE() {
     this.onLoginTaskCompleted();
-    initializeEE(this.eeInitializeCallback);
+    initializeEE(this.eeInitializeCallback, (err) => {
+      if (err.message.includes('401')) {
+        // HTTP code 401 indicates "unauthorized".
+        // TODO(#340): Stand up a server that allows anonymous access in case of
+        //  failure here.
+        // TODO(#340): Maybe don't require EE failure every time, store
+        //  something in localStorage so that we know user needs token.
+        $(eeErrorDialog)
+            .dialog(
+                {modal: true, width: 600, close: () => this.requireSignIn()});
+      } else {
+        defaultErrorCallback(err);
+      }
+    });
   }
 
   /**
@@ -171,10 +196,14 @@ function trackEeAndFirebase(taskAccumulator, needsGdUser = false) {
         // Expires in 3600 is a lie, but no need to tell the truth.
         /* expiresIn */ 3600, /* extraScopes */[],
         /* callback */
-        () => initializeEE(() => {
-          ee.data.setCloudApiEnabled(true);
-          taskAccumulator.taskCompleted();
-        }),
+        () => initializeEE(
+            () => {
+              ee.data.setCloudApiEnabled(true);
+              taskAccumulator.taskCompleted();
+            },
+            (err) => {
+              throw new Error('EarthEngine init failure: ' + err);
+            }),
         /* updateAuthLibrary */ false);
     return firebase.auth().signInWithCustomToken(firebaseToken);
   }
@@ -186,13 +215,15 @@ function initializeFirebase() {
 }
 
 /**
- * Initializes EarthEngine. Exposed only for use in test codepaths.
+ * Initializes EarthEngine.
  * @param {Function} runCallback Called if initialization succeeds
+ * @param {Function} failureCallback Called if initialization fails, likely
+ *     because user not whitelisted for EarthEngine.
  */
-function initializeEE(runCallback) {
+function initializeEE(runCallback, failureCallback) {
   ee.initialize(
       /** opt_baseurl */ null, /** opt_tileurl */ null, runCallback,
-      (err) => defaultErrorCallback('Error initializing EarthEngine: ' + err));
+      failureCallback);
 }
 
 /**

--- a/docs/authenticate.js
+++ b/docs/authenticate.js
@@ -141,6 +141,9 @@ class Authenticator {
         //  failure here.
         // TODO(#340): Maybe don't require EE failure every time, store
         //  something in localStorage so that we know user needs token.
+        // Use a jQuery dialog because normal "alert" doesn't display hyperlinks
+        // as clickable. Inferior, though, because it does allow page to
+        // continue to load behind the dialog. Not too big a deal.
         $(eeErrorDialog)
             .dialog(
                 {modal: true, width: 600, close: () => this.requireSignIn()});

--- a/docs/import/manage_disaster.html
+++ b/docs/import/manage_disaster.html
@@ -11,6 +11,8 @@
   <!-- Load jQuery, a 3rd-party library. -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.js"></script>
+  <link href = "https://code.jquery.com/ui/1.10.4/themes/ui-lightness/jquery-ui.css"
+        rel = "stylesheet">
 
   <!-- Load debug Earth Engine JavaScript client library. -->
   <!-- TODO(janakr): Switch back to compiled version in production. -->

--- a/docs/import/manage_disaster.html
+++ b/docs/import/manage_disaster.html
@@ -10,6 +10,7 @@
 
   <!-- Load jQuery, a 3rd-party library. -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.js"></script>
 
   <!-- Load debug Earth Engine JavaScript client library. -->
   <!-- TODO(janakr): Switch back to compiled version in production. -->

--- a/docs/import/manage_layers.html
+++ b/docs/import/manage_layers.html
@@ -16,6 +16,8 @@
   <!-- Load jQuery, a 3rd-party library. -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.js"></script>
+  <link href = "https://code.jquery.com/ui/1.10.4/themes/ui-lightness/jquery-ui.css"
+        rel = "stylesheet">
 
   <script src="https://apis.google.com/js/api.js"></script>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,6 +13,9 @@
 
   <!-- Load jQuery, a 3rd-party library. -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.js"></script>
+  <link href = "https://code.jquery.com/ui/1.10.4/themes/ui-lightness/jquery-ui.css"
+        rel = "stylesheet">
   <script src="https://apis.google.com/js/api.js"></script>
 
   <!-- Load debug Earth Engine JavaScript client library. -->

--- a/docs/style.css
+++ b/docs/style.css
@@ -727,5 +727,7 @@ table, th, td {
   background-color: transparent;
 }
 
-/* Override jquery ui's default weird gradient. */
+/* Override jquery ui's default weird gradient in dialog boxes. */
 .ui-widget-content {background: #eeeeee;}
+
+/* TODO: style jQuery dialog to fit in more with our theme. */

--- a/docs/style.css
+++ b/docs/style.css
@@ -724,5 +724,8 @@ table, th, td {
 
 .header-cell {
   background-image: none;
-  background-color: none;
+  background-color: transparent;
 }
+
+/* Override jquery ui's default weird gradient. */
+.ui-widget-content {background: #eeeeee;}


### PR DESCRIPTION
Show a dialog telling them how to whitelist themselves for EarthEngine, and send them to sign in again, hopefully this time as a whitelisted user. This provides a good hook for future work to catch errors and get a token from a server.

We use jQuery for this dialog because it offers clickable hyperlinks. There's some visual inconsistency because the other alert (for not being the gd user) is a standard html alert. I like the standard one better because we don't actually want the page to be usable/continue loading while it is up, but what to do.

Can be manually tested by going to our map page as a non-EE-whitelisted user.

Drive-by fix suggested by IntelliJ for the background-color attribute of .header-cell.

![ee-error](https://user-images.githubusercontent.com/10134896/71132272-00910780-21c5-11ea-969f-1e4fffbaf457.png)

#340
