### PR TITLE
Surface color editor immediately on layer add

### DIFF
--- a/cypress/integration/unit_tests/add_layer_test.js
+++ b/cypress/integration/unit_tests/add_layer_test.js
@@ -12,14 +12,14 @@ describe('Unit tests for adding layers', () => {
   setUpSavingStubs();
   beforeEach(() => disasterData.clear());
 
-  afterEach(() => disasterData.clear());
-
-  it('processes a new feature layer with <= 25 vals', () => {
+  it.only('processes a new feature layer with <= 25 vals', () => {
     stubFeatureCollection(5);
     setDisasterAndLayers([{}, {}]);
     const rows = createTrs(2);
     const tbody = createAndAppend('tbody', 'tbody');
     tbody.append(rows);
+    createAndAppend('div', 'color-fxn-editor').hide();
+    expect($('#color-fxn-editor').prop('style').display).to.equal('none');
 
     waitForPromiseAndAssertSaves(
         processNewEeLayer(mockAsset, LayerType.FEATURE_COLLECTION))
@@ -39,6 +39,7 @@ describe('Unit tests for adding layers', () => {
           expect(scoopsColumn['min']).to.equal(0);
           expect(scoopsColumn['values']).to.eql(['0', '1', '2', '3', '4']);
           expect($('#tbody').children('tr').length).to.equal(3);
+          expect($('#color-fxn-editor').prop('style').display).to.equal('block');
         });
   });
 

--- a/cypress/integration/unit_tests/add_layer_test.js
+++ b/cypress/integration/unit_tests/add_layer_test.js
@@ -12,7 +12,7 @@ describe('Unit tests for adding layers', () => {
   setUpSavingStubs();
   beforeEach(() => disasterData.clear());
 
-  it.only('processes a new feature layer with <= 25 vals', () => {
+  it('processes a new feature layer with <= 25 vals', () => {
     stubFeatureCollection(5);
     setDisasterAndLayers([{}, {}]);
     const rows = createTrs(2);

--- a/cypress/integration/unit_tests/add_layer_test.js
+++ b/cypress/integration/unit_tests/add_layer_test.js
@@ -39,7 +39,8 @@ describe('Unit tests for adding layers', () => {
           expect(scoopsColumn['min']).to.equal(0);
           expect(scoopsColumn['values']).to.eql(['0', '1', '2', '3', '4']);
           expect($('#tbody').children('tr').length).to.equal(3);
-          expect($('#color-fxn-editor').prop('style').display).to.equal('block');
+          expect($('#color-fxn-editor').prop('style').display)
+              .to.equal('block');
         });
   });
 

--- a/docs/import/add_layer.js
+++ b/docs/import/add_layer.js
@@ -68,7 +68,9 @@ function processNewEeLayer(asset, type) {
 function prependToTable(layer) {
   const index = getCurrentLayers().length;
   getCurrentLayers().push(layer);
-  $('#tbody').prepend(createLayerRow(layer, index));
+  const newRow = createLayerRow(layer, index);
+  $('#tbody').prepend(newRow);
+  newRow.children('.color-td').trigger('click');
   return updateLayersInFirestore();
 }
 

--- a/docs/import/color_function_util.js
+++ b/docs/import/color_function_util.js
@@ -280,7 +280,7 @@ function withColor(td, layer, property) {
     default:
       setStatus(ILLEGAL_STATE_ERR + 'unrecognized color function: ' + layer);
   }
-  td.addClass('editable')
+  td.addClass('editable color-td')
       .on('click', () => onClick(td, colorFunction['current-style']));
   return td;
 }


### PR DESCRIPTION
#334

Test is sort of sad because jquery .hide() and .show() don't just toggle the hidden attr as I had expected. 
The matched elements will be hidden immediately, with no animation. This is roughly equivalent to calling .css( "display", "none" ), except that the value of the display property is saved in jQuery's data cache so that display can later be restored to its initial value. If an element has a display value of inline and is hidden then shown, it will once again be displayed inline.
https://api.jquery.com/hide/
