### PR TITLE
Revamp update_test

### DIFF
--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -84,7 +84,7 @@ describe('Unit test for toggleLayerOn', () => {
     deckGlArray[0] = new deck.GeoJsonLayer({});
     deckGlArray[1] = new deck.GeoJsonLayer({});
   });
- 
+
   it('tests adding kml urls', () => {
     createGoogleMap().then((map) => {
       const promise = addLayer(mockFirebaseLayers[5], map);

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -84,7 +84,7 @@ describe('Unit test for toggleLayerOn', () => {
     deckGlArray[0] = new deck.GeoJsonLayer({});
     deckGlArray[1] = new deck.GeoJsonLayer({});
   });
-
+ 
   it('tests adding kml urls', () => {
     createGoogleMap().then((map) => {
       const promise = addLayer(mockFirebaseLayers[5], map);

--- a/cypress/integration/unit_tests/update_test.js
+++ b/cypress/integration/unit_tests/update_test.js
@@ -76,6 +76,10 @@ describe('Unit test for updates.js', () => {
             'have.text',
             'ERROR: poverty threshold must be between 0.00 and 1.00')
         .then(() => expect(errorStub).to.be.calledOnce);
+    cy.get('[id="poverty threshold"]').clear().type('0.0').blur();
+    cy.get('#update').click().then(
+        () => assertDisplayCalledWith(0.5, 0.0, 0.5));
+    cy.get('#error').should('have.text', '');
   });
 
   /**

--- a/cypress/integration/unit_tests/update_test.js
+++ b/cypress/integration/unit_tests/update_test.js
@@ -1,52 +1,28 @@
+import * as ErrorLib from '../../../docs/error.js';
 import {disasterData, getCurrentData} from '../../../docs/import/manage_layers_lib.js';
 import * as LayerUtil from '../../../docs/layer_util.js';
 import * as Run from '../../../docs/run.js';
-import {setUpToggles, toggles} from '../../../docs/update.js';
+import {setUpToggles} from '../../../docs/update.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
-
-let lastPassedPovertyThreshold;
-let lastPassedDamageThreshold;
-let lastPassedPovertyWeight;
-let createAndDisplayJoinedDataStub;
-let createAndDisplayJoinedDataPromise;
 
 describe('Unit test for updates.js', () => {
   loadScriptsBeforeForUnitTests('firebase', 'jquery');
 
-  before(() => {
-    global.google = {maps: {event: {clearListeners: () => {}}}};
-
-    const snackbarDiv = document.createElement('div');
-    snackbarDiv.id = 'snackbar';
-    const snackbarText = document.createElement('span');
-    snackbarText.id = 'snackbar-text';
-    snackbarDiv.appendChild(snackbarText);
-    document.body.appendChild(snackbarDiv);
-  });
+  before(() => global.google = {maps: {event: {clearListeners: () => {}}}});
 
   // creates the form div and stubs the relevant document methods.
   beforeEach(() => {
-    createAndDisplayJoinedDataStub =
-        cy.stub(Run, 'createAndDisplayJoinedData')
-            .callsFake((_, valuesPromise) => {
-              valuesPromise.then((toggles) => {
-                lastPassedPovertyThreshold = toggles.povertyThreshold;
-                lastPassedDamageThreshold = toggles.damageThreshold;
-                lastPassedPovertyWeight = toggles.povertyWeight;
-              });
-            });
-    cy.stub(LayerUtil, 'removeScoreLayer');
+    cy.wrap(cy.stub(Run, 'createAndDisplayJoinedData')).as(
+        'createAndDisplayJoinedDataStub');
+    cy.wrap(cy.stub(LayerUtil, 'removeScoreLayer')).as('removeScoreLayerStub');
 
-    lastPassedDamageThreshold = null;
-    lastPassedPovertyThreshold = null;
-    lastPassedPovertyWeight = null;
     cy.visit('test_utils/empty.html');
     cy.document().then((doc) => {
       const formDiv = doc.createElement('div');
       formDiv.id = 'form-div';
       doc.body.appendChild(formDiv);
-      cy.stub(document, 'getElementById').callsFake(
-          (id) => doc.getElementById(id));
+      cy.stub(document, 'getElementById')
+          .callsFake((id) => doc.getElementById(id));
     });
   });
 
@@ -55,15 +31,9 @@ describe('Unit test for updates.js', () => {
     cy.wrap(setUpToggles(Promise.resolve({data: () => nullData}), {}));
     cy.get('input').should('have.length', 2);
     cy.get('[id="poverty threshold"]').clear().type('0.05');
-    cy.get('#update').click().then(() => {
-      expect(createAndDisplayJoinedDataStub).to.be.calledOnce;
-      expect(toggles.get('poverty weight')).to.equals(1);
-    });
-    cy.get('#error').should('have.text', '').then(() => {
-        expect(lastPassedPovertyWeight).to.equals(1);
-        expect(lastPassedDamageThreshold).to.equals(0.0);
-      });
-    });
+    cy.get('#update').click().then(() => assertDisplayCalledWith(1, 0.3, 0));
+    cy.get('#error').should('have.text', '');
+  });
 
   it('does have a damage asset', () => {
     setUpDamageAsset();
@@ -81,26 +51,55 @@ describe('Unit test for updates.js', () => {
     setUpDamageAsset();
     cy.get('[id="poverty weight"]').invoke('val', 0.01).trigger('input');
     cy.get('[id="damage threshold"]').invoke('val', 0.24).trigger('input');
-    cy.get('#update').click().then(() => {
-      expect(createAndDisplayJoinedDataStub).to.be.calledOnce;
-      expect(toggles.get('poverty weight')).to.equals(0.01);
-      expect(toggles.get('damage threshold')).to.equals(0.24);
-    });
+    cy.get('#update').click().then(
+        () => assertDisplayCalledWith(0.01, 0.3, 0.24));
     cy.get('#error').should('have.text', '');
-      cy.wrap(createAndDisplayJoinedDataPromise).then(() => {
-        expect(lastPassedPovertyWeight).to.equals(0.01);
-        expect(lastPassedDamageThreshold).to.equals(0.24);
-      });
-    });
-
-  it.only('updates toggles with errors', () => {
-    setUpDamageAsset();
-    cy.get('[id="poverty weight"]').invoke('val', -0.01).trigger('input');
-    cy.get('#update').click().then(() => expect(
-        lastPassedPovertyThreshold).to.be.null);
-    cy.get('#snackbar-text').should('have.text', 'poverty threshold must be between 0.00 and 1.00');
-    cy.get('#error').should('have.text', 'ERROR: poverty threshold must be between 0.00 and 1.00');
   });
+
+  it('updates toggles with errors', () => {
+    const errorStub =
+        cy.stub(ErrorLib, 'showError')
+            .withArgs('poverty threshold must be between 0.00 and 1.00');
+    setUpDamageAsset();
+    cy.get('[id="poverty threshold"]').clear().type('-0.01').blur();
+    cy.get('#update').click();
+    cy.get('@createAndDisplayJoinedDataStub')
+        .then(
+            (createAndDisplayJoinedDataStub) =>
+                expect(createAndDisplayJoinedDataStub).to.not.be.called);
+    cy.get('@removeScoreLayerStub')
+        .then(
+            (removeScoreLayerStub) =>
+                expect(removeScoreLayerStub).to.not.be.called);
+    cy.get('#error')
+        .should(
+            'have.text',
+            'ERROR: poverty threshold must be between 0.00 and 1.00')
+        .then(() => expect(errorStub).to.be.calledOnce);
+  });
+
+  /**
+   * Checks that stub was called with the expected toggles values.
+   * @param {number} povertyWeight
+   * @param {number} povertyThreshold
+   * @param {number} damageThreshold
+   */
+  function assertDisplayCalledWith(
+      povertyWeight, povertyThreshold, damageThreshold) {
+    cy.get('@createAndDisplayJoinedDataStub')
+        .then((createAndDisplayJoinedDataStub) => {
+          expect(createAndDisplayJoinedDataStub).to.be.calledOnce;
+          expect(createAndDisplayJoinedDataStub)
+              .to.be.calledWith(
+                  {},
+                  Promise.resolve(
+                      {povertyWeight, povertyThreshold, damageThreshold}));
+        });
+    cy.get('@removeScoreLayerStub')
+        .then(
+            (removeScoreLayerStub) =>
+                expect(removeScoreLayerStub).to.be.calledOnce);
+  }
 });
 
 /**

--- a/cypress/integration/unit_tests/update_test.js
+++ b/cypress/integration/unit_tests/update_test.js
@@ -26,10 +26,6 @@ describe('Unit test for updates.js', () => {
 
   // creates the form div and stubs the relevant document methods.
   beforeEach(() => {
-    // function that resolves the createAndDisplayJoinedDataPromise
-    let resolvePromise;
-    createAndDisplayJoinedDataPromise =
-        new Promise((resolve) => resolvePromise = resolve);
     createAndDisplayJoinedDataStub =
         cy.stub(Run, 'createAndDisplayJoinedData')
             .callsFake((_, valuesPromise) => {
@@ -37,7 +33,6 @@ describe('Unit test for updates.js', () => {
                 lastPassedPovertyThreshold = toggles.povertyThreshold;
                 lastPassedDamageThreshold = toggles.damageThreshold;
                 lastPassedPovertyWeight = toggles.povertyWeight;
-                resolvePromise();
               });
             });
     cy.stub(LayerUtil, 'removeScoreLayer');
@@ -64,8 +59,7 @@ describe('Unit test for updates.js', () => {
       expect(createAndDisplayJoinedDataStub).to.be.calledOnce;
       expect(toggles.get('poverty weight')).to.equals(1);
     });
-    cy.get('#error').should('have.text', '');
-      cy.wrap(createAndDisplayJoinedDataPromise).then(() => {
+    cy.get('#error').should('have.text', '').then(() => {
         expect(lastPassedPovertyWeight).to.equals(1);
         expect(lastPassedDamageThreshold).to.equals(0.0);
       });

--- a/cypress/support/script_loader.js
+++ b/cypress/support/script_loader.js
@@ -23,7 +23,7 @@ const scriptMap = new Map([
   [
     'deck',
     {
-      script: 'https://unpkg.com/deck.gl@latest/dist.min.js',
+      script: 'https://unpkg.com/deck.gl@7.3.11/dist.min.js',
       callback: () => typeof (deck) !== 'undefined',
     },
   ],

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
   <script
       src="https://maps.google.com/maps/api/js?libraries=drawing,places&key=AIzaSyBAQkh-kRrYitkPafxVLoZx3E5aYM-auXM"></script>
 
-  <script src="https://unpkg.com/deck.gl@latest/dist.min.js"></script>
+  <script src="https://unpkg.com/deck.gl@7.3.11/dist.min.js"></script>
 
   <!-- Load jQuery, a 3rd-party library. -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,7 @@
   <script
       src="https://maps.google.com/maps/api/js?libraries=drawing,places&key=AIzaSyBAQkh-kRrYitkPafxVLoZx3E5aYM-auXM"></script>
 
+  <!-- TODO(janakr): Download locally. -->
   <script src="https://unpkg.com/deck.gl@7.3.11/dist.min.js"></script>
 
   <!-- Load jQuery, a 3rd-party library. -->

--- a/docs/update.js
+++ b/docs/update.js
@@ -33,7 +33,8 @@ function update(map) {
     return;
   }
   if (hasDamageAsset) {
-    if (!getUpdatedValue(damageThresholdKey) || !getUpdatedValue(povertyWeightKey)) {
+    if (!getUpdatedValue(damageThresholdKey) ||
+        !getUpdatedValue(povertyWeightKey)) {
       return;
     }
   }
@@ -52,7 +53,7 @@ function update(map) {
  */
 function getUpdatedValue(toggle) {
   const newValue = Number(getValue(toggle));
-  if (!hasErrors(newValue, toggle)) {
+  if (validate(newValue, toggle)) {
     toggles.set(toggle, newValue);
     return true;
   }
@@ -231,14 +232,14 @@ function updateWeights() {
  * TODO: implement ability to show multiple errors at once?
  * @param {Number} threshold
  * @param {string} toggle
- * @return {boolean} true if there are any errors parsing the new threshold.
+ * @return {boolean} true if there are no errors parsing the new threshold.
  */
-function hasErrors(threshold, toggle) {
+function validate(threshold, toggle) {
   if (Number.isNaN(threshold) || threshold < 0.0 || threshold > 1.0) {
     setErrorMessage(toggle + ' must be between 0.00 and 1.00');
-    return true;
+    return false;
   }
-  return false;
+  return true;
 }
 
 /**

--- a/docs/update.js
+++ b/docs/update.js
@@ -29,11 +29,13 @@ const damageWeightValueId = 'damage-weight-value';
  * @param {google.map.Maps} map
  */
 function update(map) {
-  debugger;
-  getUpdatedValue(povertyThresholdKey);
+  if (!getUpdatedValue(povertyThresholdKey)) {
+    return;
+  }
   if (hasDamageAsset) {
-    getUpdatedValue(damageThresholdKey);
-    getUpdatedValue(povertyWeightKey);
+    if (!getUpdatedValue(damageThresholdKey) || !getUpdatedValue(povertyWeightKey)) {
+      return;
+    }
   }
 
   removeScoreLayer();
@@ -46,12 +48,15 @@ function update(map) {
 /**
  * Pulls value from input box and
  * @param {string} toggle
+ * @return {boolean} True if successful, false if there was an error
  */
 function getUpdatedValue(toggle) {
   const newValue = Number(getValue(toggle));
   if (!hasErrors(newValue, toggle)) {
     toggles.set(toggle, newValue);
+    return true;
   }
+  return false;
 }
 
 // Set in setUpInitialToggleValues.

--- a/docs/update.js
+++ b/docs/update.js
@@ -29,6 +29,7 @@ const damageWeightValueId = 'damage-weight-value';
  * @param {google.map.Maps} map
  */
 function update(map) {
+  debugger;
   getUpdatedValue(povertyThresholdKey);
   if (hasDamageAsset) {
     getUpdatedValue(damageThresholdKey);

--- a/docs/update.js
+++ b/docs/update.js
@@ -29,6 +29,7 @@ const damageWeightValueId = 'damage-weight-value';
  * @param {google.map.Maps} map
  */
 function update(map) {
+  setInnerHtml('error', '');
   if (!getUpdatedValue(povertyThresholdKey)) {
     return;
   }


### PR DESCRIPTION
update_test was using Promises but not actually waiting on them. This means it wasn't testing anything. In fact, there were three different failures visible in the console: 
![update-errors](https://user-images.githubusercontent.com/10134896/71391475-39b8e580-25d2-11ea-92a1-ea1d36bb323a.png)

I redid it as follows:
* Used cy.document(), which allows you to actually see the form being created. Also enables us to interact in the typical Cypress way with the elements.
* Simplified the assertions about the arguments to createAndDisplayJoinedData.
* Stubbed out showError, so we could directly assert on it rather than trying to fake the page out.

I found a real bug while doing this: we were calling createAndDisplayJoinedData even if there was an error validating the arguments. I also noticed that we didn't clear the error div. We should probably just get rid of that div and rely on the snackbar, but leaving that alone for now.

There were also two errors in the tests, both asserting there were more inputs than there really were. Fixed those too.