### PR TITLE
Handle EE folder creation errors and Firestore errors in disaster creation

### DIFF
--- a/cypress/integration/unit_tests/manage_disaster_add_delete_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_add_delete_test.js
@@ -3,11 +3,7 @@ import * as FirestoreDocument from '../../../docs/firestore_document.js';
 import {getFirestoreRoot} from '../../../docs/firestore_document.js';
 import {assetDataTemplate} from '../../../docs/import/create_disaster_lib.js';
 import {disasterData} from '../../../docs/import/manage_disaster';
-import {
-  addDisaster,
-  deleteDisaster,
-  writeNewDisaster,
-} from '../../../docs/import/manage_disaster.js';
+import {addDisaster, deleteDisaster, writeNewDisaster} from '../../../docs/import/manage_disaster.js';
 import {createOptionFrom} from '../../../docs/import/manage_layers.js';
 import {createAndAppend} from '../../support/import_test_util.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
@@ -28,8 +24,11 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
   let setAclsStub;
   beforeEach(() => {
     disasterData.clear();
-    createFolderStub = cy.stub(ee.data, 'createFolder').callsFake((dir, force, callback) => callback());
-    setAclsStub = cy.stub(ee.data, 'setAssetAcl').callsFake((id, acl, callback) => callback());
+    createFolderStub =
+        cy.stub(ee.data, 'createFolder')
+            .callsFake((asset, overwrite, callback) => callback());
+    setAclsStub = cy.stub(ee.data, 'setAssetAcl')
+                      .callsFake((asset, acls, callback) => callback());
   });
 
   it('writes a new disaster to firestore', () => {

--- a/cypress/integration/unit_tests/manage_disaster_add_delete_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_add_delete_test.js
@@ -175,8 +175,8 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
     const id = '2005-summer';
     const states = [KNOWN_STATE];
     const errorStub = cy.stub(ErrorLib, 'showError');
-    // Tests don't have permission to create folders, so this will exercise EE
-    // failure mode better than we could fake it.
+    // Restore actual ee.createFolder. Tests don't have permission to create
+    // folders, so this exercises EE failure mode better than we could fake it.
     createFolderStub.restore();
     const firestoreStub =
         cy.stub(FirestoreDocument, 'disasterCollectionReference');

--- a/cypress/integration/unit_tests/manage_disaster_add_delete_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_add_delete_test.js
@@ -1,7 +1,13 @@
+import * as ErrorLib from '../../../docs/error.js';
+import * as FirestoreDocument from '../../../docs/firestore_document.js';
 import {getFirestoreRoot} from '../../../docs/firestore_document.js';
 import {assetDataTemplate} from '../../../docs/import/create_disaster_lib.js';
 import {disasterData} from '../../../docs/import/manage_disaster';
-import {addDisaster, deleteDisaster, writeNewDisaster} from '../../../docs/import/manage_disaster.js';
+import {
+  addDisaster,
+  deleteDisaster,
+  writeNewDisaster,
+} from '../../../docs/import/manage_disaster.js';
 import {createOptionFrom} from '../../../docs/import/manage_layers.js';
 import {createAndAppend} from '../../support/import_test_util.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader';
@@ -22,11 +28,8 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
   let setAclsStub;
   beforeEach(() => {
     disasterData.clear();
-    createFolderStub =
-        cy.stub(ee.data, 'createFolder')
-            .callsFake((asset, overwrite, callback) => callback());
-    setAclsStub = cy.stub(ee.data, 'setAssetAcl')
-                      .callsFake((asset, acls, callback) => callback());
+    createFolderStub = cy.stub(ee.data, 'createFolder').callsFake((dir, force, callback) => callback());
+    setAclsStub = cy.stub(ee.data, 'setAssetAcl').callsFake((id, acl, callback) => callback());
   });
 
   it('writes a new disaster to firestore', () => {
@@ -88,10 +91,16 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
     cy.wrap(writeNewDisaster(id, states))
         .then((success) => {
           expect(success).to.be.true;
+          expect(createFolderStub).to.be.calledTwice;
+          expect(setAclsStub).to.be.calledTwice;
+          createFolderStub.resetHistory();
+          setAclsStub.resetHistory();
           return writeNewDisaster(id, states);
         })
         .then((success) => {
           expect(success).to.be.false;
+          expect(createFolderStub).to.not.be.called;
+          expect(setAclsStub).to.not.be.called;
           const status = $('#compute-status');
           expect(status.is(':visible')).to.be.true;
           expect(status.text())
@@ -103,7 +112,10 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
   it('tries to write a disaster with bad info, then fixes it', () => {
     const year = createAndAppend('input', 'year');
     const name = createAndAppend('input', 'name');
-    const states = createAndAppend('input', 'states');
+    const states = createAndAppend('select', 'states');
+    states.prop('multiple', 'multiple')
+        .append(createSelectedOption('IG'))
+        .append(createSelectedOption('MY'));
     const status = $('#compute-status');
 
     cy.wrap(addDisaster())
@@ -112,6 +124,8 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
           expect(status.is(':visible')).to.be.true;
           expect(status.text())
               .to.eql('Error: Disaster name, year, and states are required.');
+          expect(createFolderStub).to.not.be.called;
+          expect(setAclsStub).to.not.be.called;
 
           year.val('hello');
           name.val('my name is');
@@ -125,6 +139,10 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
 
           year.val('2000');
           name.val('HARVEY');
+          states.val(['IG', 'MY']);
+          expect(createFolderStub).to.not.be.called;
+          expect(setAclsStub).to.not.be.called;
+
           return addDisaster();
         })
         .then((success) => {
@@ -135,10 +153,64 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
                   'Error: disaster name must be comprised of only ' +
                   'lowercase letters');
 
+          expect(createFolderStub).to.not.be.called;
+          expect(setAclsStub).to.not.be.called;
           name.val('harvey');
           return addDisaster();
         })
-        .then((success) => expect(success).to.be.true);
+        .then((success) => {
+          expect(success).to.be.true;
+          expect(createFolderStub).to.be.calledThrice;
+          expect(setAclsStub).to.be.calledThrice;
+        });
+  });
+
+  /**
+   * Creates an option with the given text, already selected.
+   * @param {string} text
+   * @return {JQuery<HTMLOptionElement>}
+   */
+  function createSelectedOption(text) {
+    return $(document.createElement('option')).val(text).prop('selected', true);
+  }
+
+  it('Error creating EE folder', () => {
+    const id = '2005-summer';
+    const states = [KNOWN_STATE];
+    const errorStub = cy.stub(ErrorLib, 'showError');
+    // Tests don't have permission to create folders, so this will exercise EE
+    // failure mode better than we could fake it.
+    createFolderStub.restore();
+    const firestoreStub =
+        cy.stub(FirestoreDocument, 'disasterCollectionReference');
+    cy.wrap(writeNewDisaster(id, states)).then((success) => {
+      expect(success).to.be.false;
+      expect(firestoreStub).to.not.be.called;
+      expect(disasterData).to.be.empty;
+      expect(errorStub).to.be.calledOnce;
+      expect(errorStub).to.be.calledWith(
+          'Error creating EarthEngine folders: "Asset ' +
+          '\'projects/earthengine-legacy/assets/users/gd\' does not exist or ' +
+          'doesn\'t allow this operation." You can try refreshing the page');
+    });
+  });
+
+  it('Error writing to Firestore', () => {
+    const id = '2005-summer';
+    const states = [KNOWN_STATE];
+    const errorStub = cy.stub(ErrorLib, 'showError');
+    // Tests don't have permission to write to root Firestore, so this will
+    // exercise Firestore functionality better than we could fake it.
+    cy.stub(FirestoreDocument, 'disasterCollectionReference')
+        .returns(firebase.firestore().collection('disaster-metadata'));
+    cy.wrap(writeNewDisaster(id, states)).then((success) => {
+      expect(success).to.be.false;
+      expect(disasterData).to.be.empty;
+      expect(errorStub).to.be.calledOnce;
+      expect(errorStub).to.be.calledWith(
+          'Error writing to Firestore: "Missing or insufficient ' +
+          'permissions." You can try refreshing the page');
+    });
   });
 
   it('deletes a disaster', () => {

--- a/cypress/integration/unit_tests/manage_disaster_add_delete_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_add_delete_test.js
@@ -128,7 +128,6 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
 
           year.val('hello');
           name.val('my name is');
-          states.val(['IG', 'MY']);
           return addDisaster();
         })
         .then((success) => {
@@ -138,7 +137,6 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
 
           year.val('2000');
           name.val('HARVEY');
-          states.val(['IG', 'MY']);
           expect(createFolderStub).to.not.be.called;
           expect(setAclsStub).to.not.be.called;
 

--- a/docs/error.js
+++ b/docs/error.js
@@ -17,10 +17,10 @@ function createError(msg) {
  * Logs an error message to the console and shows a snackbar notification.
  *
  * @param {string} msg the message to be logged
- * @param {string} snackbarMsg the message to be shown in the notification (this
- *     can be omitted if the message should just be the logged message).
+ * @param {?string} snackbarMsg the message to be shown in the notification
+ *     (this can be omitted if the message should just be the logged message).
  */
-function showError(msg, snackbarMsg) {
+function showError(msg, snackbarMsg = null) {
   if (snackbarMsg == null) snackbarMsg = msg;
   console.error(msg);
   showSnackbar(

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -373,7 +373,7 @@ function addDisaster() {
  * @param {string} disasterId of the form <year>-<name>
  * @param {Array<string>} states array of state (abbreviations)
  * @return {Promise<boolean>} Returns true if EarthEngine folders created
- *     successfully and successful write to Firestore
+ *     successfully and Firestore write was successful
  */
 async function writeNewDisaster(disasterId, states) {
   if (disasterData.has(disasterId)) {
@@ -431,6 +431,7 @@ async function writeNewDisaster(disasterId, states) {
 
 /**
  * Returns a promise that resolves on the creation of the given folder.
+ * TODO: add status bar for when this is finished.
  *
  * @param {string} dir asset path of folder to create
  * @return {Promise<void>} resolves when after the directory is created and


### PR DESCRIPTION
We just show a snackbar error. Not sure there's more we can do, because it's unexpected.

This will slightly slow down creation, because it's EE then Firestore, but worth it.

Also fix slightly broken test: under the covers we were creating states for the letters in 'IG, MY' because inputs can't have array values.

Closes #331
