### PR TITLE
Rename score asset to poverty-damage-score

### DIFF
--- a/docs/resources.js
+++ b/docs/resources.js
@@ -28,7 +28,7 @@ function getDisaster() {
 function getScoreAssetPath() {
   // TODO(janakr): rename this path to something more intelligible, like
   //  .../score-asset
-  return gdEePathPrefix + getDisaster() + '/data-ms-as-tot';
+  return gdEePathPrefix + getDisaster() + '/poverty-damage-score';
 }
 
 /**


### PR DESCRIPTION
Don't rename backup: if anything, we should make backup less attractive, so people don't try to create assets from it. Leaving that for another day. For now, it's alphabetically not that close to poverty-damage-score, so that's something.

I've already copied data-ms-as-tot over to poverty-damage-score for all of our disasters.

#335