### PR TITLE
Get properties of features dynamically, don't hard-code them

### DIFF
--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -2,10 +2,7 @@ import {tableContainerId} from '../../../docs/dom_constants.js';
 import {convertEeObjectToPromise} from '../../../docs/ee_promise_cache.js';
 import {currentFeatures} from '../../../docs/highlight_features';
 import * as loading from '../../../docs/loading.js';
-import {
-  blockGroupTag,
-  geoidTag
-} from '../../../docs/property_names';
+import {blockGroupTag, geoidTag} from '../../../docs/property_names';
 import {scoreTag} from '../../../docs/property_names.js';
 import * as Resources from '../../../docs/resources.js';
 import {drawTableAndSetUpHandlers, resolveScoreAsset} from '../../../docs/run.js';
@@ -85,8 +82,17 @@ describe('Unit tests for click_feature.js with map and table', () => {
       tableDiv.id = 'table';
       containerDiv.appendChild(tableDiv);
       drawTableAndSetUpHandlers(
-          convertEeObjectToPromise(scoredFeatures).then((fc) => (
-              {featuresList: fc.features, columnsFound: [geoidTag, blockGroupTag, scoreTag, 'OTHER PERCENTAGE', 'SOME PROPERTY']})),
+          convertEeObjectToPromise(scoredFeatures).then((fc) => ({
+                                                          featuresList:
+                                                              fc.features,
+                                                          columnsFound: [
+                                                            geoidTag,
+                                                            blockGroupTag,
+                                                            scoreTag,
+                                                            'OTHER PERCENTAGE',
+                                                            'SOME PROPERTY',
+                                                          ],
+                                                        })),
           map);
     });
     cy.wrap(loadingFinishedPromise);

--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -179,7 +179,7 @@ describe('Unit tests for click_feature.js with map and table', () => {
     cy.get('#test-map-div').should('contain', 'SCORE: 1');
     cy.get('#test-map-div').should('contain', 'my block group');
     // Rounded because property name ends with 'PERCENTAGE'.
-    cy.get('#test-map-div').should('contain', 'OTHER PERCENTAGE: 4.232');
+    cy.get('#test-map-div').should('contain', 'OTHER PERCENTAGE: 4.233');
     cy.get('#test-map-div').should('contain', 'SOME PROPERTY: 100');
     cy.get('.google-visualization-table-tr-sel')
         .find('[class="google-visualization-table-td"]')
@@ -252,6 +252,6 @@ function createFeatureWithOnlyGeoid(west, south, east, north) {
 function createFeatureFromCorners(west, south, east, north) {
   let result = createFeatureWithOnlyGeoid(west, south, east, north);
   result = result.set('SOME PROPERTY', 100);
-  result = result.set('OTHER PERCENTAGE', 4.23223434);
+  result = result.set('OTHER PERCENTAGE', 4.23293434);
   return result;
 }

--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -152,9 +152,6 @@ describe('Unit tests for click_feature.js with map and table', () => {
     assertFeatureShownOnMap(missingPropertiesCorners);
     cy.get('#test-map-div').should('contain', 'SCORE: 4');
     cy.get('#test-map-div').should('contain', 'missing properties group');
-    cy.get('#test-map-div').should('contain', 'SVI: undefined');
-    cy.get('#test-map-div').should('contain', 'MEDIAN INCOME: undefined');
-    cy.get('#test-map-div').should('contain', 'BUILDING COUNT: undefined');
   });
 
   /**
@@ -258,8 +255,8 @@ function createFeatureWithOnlyGeoid(west, south, east, north) {
  */
 function createFeatureFromCorners(west, south, east, north) {
   let result = createFeatureWithOnlyGeoid(west, south, east, north);
-  for (let i = 1; i < tableHeadings.length; i++) {
-    result = result.set(tableHeadings[i], 100 * i);
-  }
+  // for (let i = 1; i < tableHeadings.length; i++) {
+  //   result = result.set(tableHeadings[i], 100 * i);
+  // }
   return result;
 }

--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -1,9 +1,12 @@
 import {tableContainerId} from '../../../docs/dom_constants.js';
-import {tableHeadings} from '../../../docs/draw_table.js';
 import {convertEeObjectToPromise} from '../../../docs/ee_promise_cache.js';
 import {currentFeatures} from '../../../docs/highlight_features';
 import * as loading from '../../../docs/loading.js';
-import {blockGroupTag, geoidTag} from '../../../docs/property_names';
+import {
+  blockGroupTag, buildingCountTag, damageTag,
+  geoidTag, incomeTag,
+  snapPercentageTag, sviTag, totalPopTag,
+} from '../../../docs/property_names';
 import {scoreTag} from '../../../docs/property_names.js';
 import * as Resources from '../../../docs/resources.js';
 import {drawTableAndSetUpHandlers, resolveScoreAsset} from '../../../docs/run.js';
@@ -18,6 +21,18 @@ const feature2Corners = [0.75, 0.25, 1.5, 0.75];
 const zeroScoreCorners = [0, 0, 0.25, 0.25];
 const missingPropertiesCorners = [-0.25, -0.25, 0, 0];
 
+
+const tableHeadings = [
+  geoidTag,
+  blockGroupTag,
+  scoreTag,
+  snapPercentageTag,
+  damageTag,
+  buildingCountTag,
+  totalPopTag,
+  sviTag,
+  incomeTag,
+];
 
 describe('Unit tests for click_feature.js with map and table', () => {
   loadScriptsBeforeForUnitTests('ee', 'charts', 'maps');

--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -178,6 +178,9 @@ describe('Unit tests for click_feature.js with map and table', () => {
     cy.get('#test-map-div').click(0, 0);
     cy.get('#test-map-div').should('contain', 'SCORE: 1');
     cy.get('#test-map-div').should('contain', 'my block group');
+    // Rounded because property name ends with 'PERCENTAGE'.
+    cy.get('#test-map-div').should('contain', 'OTHER PERCENTAGE: 4.232');
+    cy.get('#test-map-div').should('contain', 'SOME PROPERTY: 100');
     cy.get('.google-visualization-table-tr-sel')
         .find('[class="google-visualization-table-td"]')
         .should('have.text', 'my block group');

--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -3,9 +3,8 @@ import {convertEeObjectToPromise} from '../../../docs/ee_promise_cache.js';
 import {currentFeatures} from '../../../docs/highlight_features';
 import * as loading from '../../../docs/loading.js';
 import {
-  blockGroupTag, buildingCountTag, damageTag,
-  geoidTag, incomeTag,
-  snapPercentageTag, sviTag, totalPopTag,
+  blockGroupTag,
+  geoidTag
 } from '../../../docs/property_names';
 import {scoreTag} from '../../../docs/property_names.js';
 import * as Resources from '../../../docs/resources.js';
@@ -20,19 +19,6 @@ const feature1Corners = [0.25, 0.25, 0.75, 1];
 const feature2Corners = [0.75, 0.25, 1.5, 0.75];
 const zeroScoreCorners = [0, 0, 0.25, 0.25];
 const missingPropertiesCorners = [-0.25, -0.25, 0, 0];
-
-
-const tableHeadings = [
-  geoidTag,
-  blockGroupTag,
-  scoreTag,
-  snapPercentageTag,
-  damageTag,
-  buildingCountTag,
-  totalPopTag,
-  sviTag,
-  incomeTag,
-];
 
 describe('Unit tests for click_feature.js with map and table', () => {
   loadScriptsBeforeForUnitTests('ee', 'charts', 'maps');
@@ -99,7 +85,8 @@ describe('Unit tests for click_feature.js with map and table', () => {
       tableDiv.id = 'table';
       containerDiv.appendChild(tableDiv);
       drawTableAndSetUpHandlers(
-          convertEeObjectToPromise(scoredFeatures).then((fc) => fc.features),
+          convertEeObjectToPromise(scoredFeatures).then((fc) => (
+              {featuresList: fc.features, columnsFound: [geoidTag, blockGroupTag, scoreTag, 'OTHER PERCENTAGE', 'SOME PROPERTY']})),
           map);
     });
     cy.wrap(loadingFinishedPromise);
@@ -255,8 +242,7 @@ function createFeatureWithOnlyGeoid(west, south, east, north) {
  */
 function createFeatureFromCorners(west, south, east, north) {
   let result = createFeatureWithOnlyGeoid(west, south, east, north);
-  // for (let i = 1; i < tableHeadings.length; i++) {
-  //   result = result.set(tableHeadings[i], 100 * i);
-  // }
+  result = result.set('SOME PROPERTY', 100);
+  result = result.set('OTHER PERCENTAGE', 4.23223434);
   return result;
 }

--- a/docs/click_feature.js
+++ b/docs/click_feature.js
@@ -46,7 +46,8 @@ function clickFeature(lng, lat, map, featuresAsset, tableSelector) {
   });
 }
 
-const HIDDEN_PROPERTIES = Object.freeze(new Set([  geoidTag,
+const HIDDEN_PROPERTIES = Object.freeze(new Set([
+  geoidTag,
   blockGroupTag,
   scoreTag,
 ]));

--- a/docs/click_feature.js
+++ b/docs/click_feature.js
@@ -1,6 +1,5 @@
-import {tableHeadings} from './draw_table.js';
 import {currentFeatures, highlightFeatures} from './highlight_features.js';
-import {blockGroupTag, geoidTag} from './property_names.js';
+import {blockGroupTag, geoidTag, scoreTag} from './property_names.js';
 
 export {clickFeature, selectHighlightedFeatures};
 
@@ -47,6 +46,11 @@ function clickFeature(lng, lat, map, featuresAsset, tableSelector) {
   });
 }
 
+const HIDDEN_PROPERTIES = Object.freeze(new Set([  geoidTag,
+  blockGroupTag,
+  scoreTag,
+]));
+
 /**
  * Puts the information for a blockgroup into a div.
  * @param {Feature} feature post-evaluate JSON feature
@@ -70,10 +74,11 @@ function createHtmlForPopup(feature, rowData) {
     property.innerText = 'SCORE: ' + rowData[2];
     properties.appendChild(property);
   }
-  for (let col = 3; col < tableHeadings.length; col++) {
-    const heading = tableHeadings[col];
+  for (let [heading, value] of Object.entries(feature.properties)) {
+    if (HIDDEN_PROPERTIES.has(heading)) {
+      continue;
+    }
     const property = document.createElement('li');
-    let value = feature.properties[heading];
     if (heading.endsWith(' PERCENTAGE')) {
       value = parseFloat(value).toFixed(3);
     }

--- a/docs/import/create_score_asset.js
+++ b/docs/import/create_score_asset.js
@@ -10,8 +10,7 @@ export {backUpAssetAndStartTask};
 
 const TRACT_TAG = 'TRACT';
 const SVI_TAG = 'SVI';
-// Median household income in the past 12 months (in 2016 inflation-adjusted
-// dollars)
+// Median household income in the past 12 months.
 const INCOME_TAG = 'MEDIAN INCOME';
 
 /**

--- a/docs/import/create_score_asset.js
+++ b/docs/import/create_score_asset.js
@@ -1,10 +1,10 @@
-import {blockGroupTag, damageTag, geoidTag, povertyPercentageTag, povertyHouseholdsTag, totalHouseholdsTag} from '../property_names.js';
+import {blockGroupTag, damageTag, geoidTag, povertyHouseholdsTag, povertyPercentageTag, totalHouseholdsTag} from '../property_names.js';
 import {getBackupScoreAssetPath, getScoreAssetPath} from '../resources.js';
+
 import {computeAndSaveBounds} from './center.js';
 import {cdcGeoidKey, censusBlockGroupKey, censusGeoidKey, tigerGeoidKey} from './import_data_keys.js';
 
 export {createScoreAsset, setStatus};
-
 // For testing.
 export {backUpAssetAndStartTask};
 

--- a/docs/polygon_draw.js
+++ b/docs/polygon_draw.js
@@ -109,7 +109,8 @@ class StoredShapeData {
     const numDamagePoints = StoredShapeData.prepareDamageCalculation(polygon);
     const intersectingBlockGroups =
         StoredShapeData.getIntersectingBlockGroups(polygon);
-    // TODO(janakr): we should have poor/total
+    // TODO(janakr): with arbitrary data, only a "poverty percentage" may be
+    //  available, as opposed to underlying totals. This won't work then.
     const weightedSnapHouseholds = StoredShapeData.calculateWeightedTotal(
         intersectingBlockGroups, povertyHouseholdsTag);
     const weightedTotalHouseholds = StoredShapeData.calculateWeightedTotal(

--- a/docs/polygon_draw.js
+++ b/docs/polygon_draw.js
@@ -7,7 +7,7 @@ import {POLYGON_HELP_URL} from './help.js';
 import {addLoadingElement, loadingElementFinished} from './loading.js';
 import {latLngToGeoPoint, polygonToGeoPointArray, transformGeoPointArrayToLatLng} from './map_util.js';
 import {createPopup, isMarker, setUpPopup} from './popup.js';
-import {snapPopTag, totalPopTag} from './property_names.js';
+import {povertyHouseholdsTag, totalHouseholdsTag} from './property_names.js';
 import {getScoreAssetPath} from './resources.js';
 import {userRegionData} from './user_region_data.js';
 
@@ -109,10 +109,11 @@ class StoredShapeData {
     const numDamagePoints = StoredShapeData.prepareDamageCalculation(polygon);
     const intersectingBlockGroups =
         StoredShapeData.getIntersectingBlockGroups(polygon);
+    // TODO(janakr): we should have poor/total
     const weightedSnapHouseholds = StoredShapeData.calculateWeightedTotal(
-        intersectingBlockGroups, snapPopTag);
+        intersectingBlockGroups, povertyHouseholdsTag);
     const weightedTotalHouseholds = StoredShapeData.calculateWeightedTotal(
-        intersectingBlockGroups, totalPopTag);
+        intersectingBlockGroups, totalHouseholdsTag);
     return new Promise(((resolve, reject) => {
       ee.List([
           numDamagePoints,

--- a/docs/process_joined_data.js
+++ b/docs/process_joined_data.js
@@ -2,7 +2,7 @@ import {
   blockGroupTag,
   damageTag, geoidTag,
   scoreTag,
-  snapPercentageTag,
+  povertyPercentageTag,
 } from './property_names.js';
 
 export {processJoinedData};
@@ -27,7 +27,7 @@ const scoreDisplayCap = 255;
  */
 function colorAndRate(
     feature, scalingFactor, povertyThreshold, damageThreshold, povertyWeight) {
-  const povertyRatio = feature.properties[snapPercentageTag];
+  const povertyRatio = feature.properties[povertyPercentageTag];
   const ratioBuildingsDamaged = feature.properties[damageTag] || 0;
   let score = 0;
   if (povertyRatio >= povertyThreshold &&

--- a/docs/process_joined_data.js
+++ b/docs/process_joined_data.js
@@ -1,4 +1,9 @@
-import {damageTag, scoreTag, snapPercentageTag} from './property_names.js';
+import {
+  blockGroupTag,
+  damageTag, geoidTag,
+  scoreTag,
+  snapPercentageTag,
+} from './property_names.js';
 
 export {processJoinedData};
 
@@ -42,7 +47,9 @@ function colorAndRate(
 }
 
 const KEY_BLACKLIST = Object.freeze(new Set(['system:index', 'color']));
-const ALWAYS_PRESENT_KEYS = 
+// We put these keys here because adding them to the set first guarantees they
+// will be the first three columns in the table.
+const ALWAYS_PRESENT_KEYS = Object.freeze([geoidTag, blockGroupTag, scoreTag]);
 
 /**
  * Processes the provided Promise. The returned Promise has the same underlying
@@ -68,12 +75,11 @@ function processJoinedData(
     damageThreshold,
     povertyWeight,
   }]) => {
-        const columnsFound = new Set();
+        const columnsFound = new Set(ALWAYS_PRESENT_KEYS);
         for (const feature of featuresList) {
           colorAndRate(
               feature, scalingFactor, povertyThreshold, damageThreshold,
               povertyWeight);
-          console.log(feature.properties);
           for (const key of Object.keys(feature.properties)) {
             if (!columnsFound.has(key) && !KEY_BLACKLIST.has(key)) {
               columnsFound.add(key);

--- a/docs/process_joined_data.js
+++ b/docs/process_joined_data.js
@@ -23,6 +23,7 @@ const scoreDisplayCap = 255;
 function colorAndRate(
     feature, scalingFactor, povertyThreshold, damageThreshold, povertyWeight) {
   const povertyRatio = feature.properties[povertyPercentageTag];
+  // If damage tag is absent, treat as 0.
   const ratioBuildingsDamaged = feature.properties[damageTag] || 0;
   let score = 0;
   if (povertyRatio >= povertyThreshold &&

--- a/docs/process_joined_data.js
+++ b/docs/process_joined_data.js
@@ -1,9 +1,4 @@
-import {
-  blockGroupTag,
-  damageTag, geoidTag,
-  scoreTag,
-  povertyPercentageTag,
-} from './property_names.js';
+import {blockGroupTag, damageTag, geoidTag, povertyPercentageTag, scoreTag} from './property_names.js';
 
 export {processJoinedData};
 
@@ -70,11 +65,14 @@ const ALWAYS_PRESENT_KEYS = Object.freeze([geoidTag, blockGroupTag, scoreTag]);
 function processJoinedData(
     dataPromise, scalingFactor, initialTogglesValuesPromise) {
   return Promise.all([dataPromise, initialTogglesValuesPromise])
-      .then(([featuresList, {
-    povertyThreshold,
-    damageThreshold,
-    povertyWeight,
-  }]) => {
+      .then(([
+              featuresList,
+              {
+                povertyThreshold,
+                damageThreshold,
+                povertyWeight,
+              },
+            ]) => {
         const columnsFound = new Set(ALWAYS_PRESENT_KEYS);
         for (const feature of featuresList) {
           colorAndRate(
@@ -87,6 +85,8 @@ function processJoinedData(
           }
         }
         return {
-          featuresList, columnsFound: Object.freeze(Array.from(columnsFound))};
+          featuresList,
+          columnsFound: Object.freeze(Array.from(columnsFound)),
+        };
       });
 }

--- a/docs/property_names.js
+++ b/docs/property_names.js
@@ -1,28 +1,22 @@
 export {
   blockGroupTag,
-  buildingCountTag,
   damageTag,
   geoidTag,
-  incomeTag,
   scoreTag,
-  snapPercentageTag,
-  snapPopTag,
-  sviTag,
-  totalPopTag,
-  tractTag,
+  povertyPercentageTag,
+  povertyHouseholdsTag,
+  totalHouseholdsTag,
 };
 
 const blockGroupTag = 'BLOCK GROUP';
-const tractTag = 'TRACT';
 const damageTag = 'DAMAGE PERCENTAGE';
 const geoidTag = 'GEOID';
 const scoreTag = 'SCORE';
-const snapPercentageTag = 'SNAP PERCENTAGE';
+// TODO(janakr): Allow user to set the column names for the score ingredient
+//  (currently always 'SNAP PERCENTAGE') and population properties (for use with
+//  drawing polygons, currently always 'SNAP HOUSEHOLDS' and
+//  'TOTAL HOUSEHOLDS'). Then can read these in from Firestore.
+const povertyPercentageTag = 'SNAP PERCENTAGE';
 // TODO(ruthtalbot): Does GD actually want these totals surfaced?
-const snapPopTag = 'SNAP HOUSEHOLDS';
-const totalPopTag = 'TOTAL HOUSEHOLDS';
-const buildingCountTag = 'BUILDING COUNT';
-// Median household income in the past 12 months (in 2016 inflation-adjusted
-// dollars)
-const incomeTag = 'MEDIAN INCOME';
-const sviTag = 'SVI';
+const povertyHouseholdsTag = 'SNAP HOUSEHOLDS';
+const totalHouseholdsTag = 'TOTAL HOUSEHOLDS';

--- a/docs/property_names.js
+++ b/docs/property_names.js
@@ -2,9 +2,9 @@ export {
   blockGroupTag,
   damageTag,
   geoidTag,
-  scoreTag,
-  povertyPercentageTag,
   povertyHouseholdsTag,
+  povertyPercentageTag,
+  scoreTag,
   totalHouseholdsTag,
 };
 

--- a/docs/property_names.js
+++ b/docs/property_names.js
@@ -16,6 +16,10 @@ const scoreTag = 'SCORE';
 //  (currently always 'SNAP PERCENTAGE') and population properties (for use with
 //  drawing polygons, currently always 'SNAP HOUSEHOLDS' and
 //  'TOTAL HOUSEHOLDS'). Then can read these in from Firestore.
+//  Alternately, change these names to be a bit more generic:
+//  'POVERTY PERCENTAGE' and similar. Then GD can just transform their asset to
+//  have these properties. That does make table a bit generic, though: helpful
+//  to have some indication where percentage comes from.
 const povertyPercentageTag = 'SNAP PERCENTAGE';
 // TODO(ruthtalbot): Does GD actually want these totals surfaced?
 const povertyHouseholdsTag = 'SNAP HOUSEHOLDS';

--- a/docs/run.js
+++ b/docs/run.js
@@ -103,7 +103,7 @@ function createAndDisplayJoinedData(map, initialTogglesValuesPromise) {
   const processedData = processJoinedData(
       resolvedScoreAsset.then(getEePromiseForFeatureCollection), scalingFactor,
       initialTogglesValuesPromise);
-  addScoreLayer(processedData);
+  addScoreLayer(processedData.then(({featuresList}) => featuresList));
   maybeCheckScoreCheckbox();
   drawTableAndSetUpHandlers(processedData, map);
 }

--- a/docs/run.js
+++ b/docs/run.js
@@ -111,7 +111,7 @@ function createAndDisplayJoinedData(map, initialTogglesValuesPromise) {
 /**
  * Invokes {@link drawTable} with the appropriate callbacks to set up click
  * handlers for the map.
- * @param {Promise<Array<GeoJson.Feature>>} processedData
+ * @param {Promise<Array<GeoJsonFeature>>} processedData
  * @param {google.maps.Map} map
  */
 function drawTableAndSetUpHandlers(processedData, map) {


### PR DESCRIPTION
Start to make map much more flexible. Instead of a hard-coded list of properties, since we're looping over the features anyway, keep track of their properties and display the ones we found. This will allow us to create a very generic score asset, with new properties we may never have considered, and display them on the map. In the limit, GD should be able to run score asset creation with a very general poverty asset.

Don't display absent properties in pop-up ("absent" now means, "absent from this feature, but present in other features"). I can't remember if we decided this was the preferred way to go, but I think it was. If we want to display '-', can modify to do that as well.

Make subtle change so that if damage tag is absent, will still do calculation properly. Can take advantage of that in a follow-up in create_score_asset.js to not set the damage tag when damage not present.

Big downside of this PR is that property names are sorted alphabetically (except for some manually curated ones). I think the trade-off is worth it. If we really want to preserve ordering of currently known columns, we could do that (keep known columns sorted, if they're present, and add unknown ones at the end).

Closes #304
#322, #17 