### PR TITLE
Add support to token server for AWS Elastic Beanstalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ https://dashboard.cypress.io in the "Runs" tab under "Settings".
     clang-format -i --style=Google $SOURCE_FILES
     yarn run eslint $SOURCE_FILES
     ```
- 
 ## License
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](/LICENSE)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ https://dashboard.cypress.io in the "Runs" tab under "Settings".
     clang-format -i --style=Google $SOURCE_FILES
     yarn run eslint $SOURCE_FILES
     ```
-
+ 
 ## License
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](/LICENSE)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ https://dashboard.cypress.io in the "Runs" tab under "Settings".
     clang-format -i --style=Google $SOURCE_FILES
     yarn run eslint $SOURCE_FILES
     ```
+  
 ## License
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](/LICENSE)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ https://dashboard.cypress.io in the "Runs" tab under "Settings".
     clang-format -i --style=Google $SOURCE_FILES
     yarn run eslint $SOURCE_FILES
     ```
-  
+
 ## License
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](/LICENSE)

--- a/token_server/.elasticbeanstalk/config.yml
+++ b/token_server/.elasticbeanstalk/config.yml
@@ -1,0 +1,22 @@
+branch-defaults:
+  default:
+    environment: mapping-crisis-2-dev
+    group_suffix: null
+environment-defaults:
+  mapping-crisis-dev:
+    branch: null
+    repository: null
+global:
+  application_name: mapping-crisis-2
+  branch: null
+  default_ec2_keyname: null
+  default_platform: Node.js
+  default_region: us-east-1
+  include_git_submodules: true
+  instance_profile: null
+  platform_name: null
+  platform_version: null
+  profile: null
+  repository: null
+  sc: null
+  workspace_type: Application

--- a/token_server/README.md
+++ b/token_server/README.md
@@ -34,7 +34,7 @@ unless it is getting traffic.
 [Dashboard](https://console.cloud.google.com/appengine?folder=&organizationId=838088520005&project=mapping-crisis).
 You must be logged in as `gd-earthengine-user@givedirectly.org` to access it.
 
-### Set up Google Cloud instance
+### Set up new Google Cloud instance
 * Most of the necessary work needs to be done to set up the mapping page to work
 properly in the first place. The only additional work is to create a service
 account that is whitelisted for EarthEngine access (currently
@@ -60,7 +60,7 @@ run `eb deploy` after running `eb init` in order to log in.
 are using Elastic Beanstalk.
 
 ### Set up new Amazon Elastic Beanstalk instance
-* See the [Google Cloud instructions](#set-up-google-cloud-instance) if that is
+* See the [Google Cloud instructions](#set-up-new-google-cloud-instance) if that is
 also changing.
 * Delete the `.elasticbeanstalk` subdirectory of this directory, and follow the
 instructions [here]((https://aws.amazon.com/getting-started/tutorials/deploy-app-command-line-elastic-beanstalk/)

--- a/token_server/README.md
+++ b/token_server/README.md
@@ -34,9 +34,44 @@ unless it is getting traffic.
 [Dashboard](https://console.cloud.google.com/appengine?folder=&organizationId=838088520005&project=mapping-crisis).
 You must be logged in as `gd-earthengine-user@givedirectly.org` to access it.
 
-## Run server on Amazon EC2
+### Set up Google Cloud instance
+* Most of the work needs to be done to set up the mapping page to work properly
+in the first place. The only additional work is to create a service account that
 
-`¯\_(ツ)_/¯`
+## Run server on Amazon Elastic Beanstalk
+
+* Deploy using [these instructions](https://aws.amazon.com/getting-started/tutorials/deploy-app-command-line-elastic-beanstalk/).
+Since the project already exists on Amazon Elastic Beanstalk, you just need to
+run `eb deploy` after running `eb init` in order to log in. TODO(janakr): check this
+
+### Set up Amazon Elastic Beanstalk instance
+* See the [Google Cloud instructions](#set-up-google-cloud-instance) if that is
+also changing.
+* Delete the `.elasticbeanstalk` subdirectory of this directory, and follow the
+instructions [here]((https://aws.amazon.com/getting-started/tutorials/deploy-app-command-line-elastic-beanstalk/)
+to set up from scratch.
+* Delete the `.gitignore` file that setup creates, and add `.elasticbeanstalk/*`
+to git.
+* Add Google service account credentials to
+[Amazon Secrets Manager](https://aws.amazon.com/secrets-manager/getting-started/).
+Remember that you need to be logged into Google as
+`gd-earthengine-user@givedirectly.org`.
+   * The Google service account is currently
+`earthengine-token-provider@mapping-crisis.iam.gserviceaccount.com` (specified
+in `ee_token_creator.js`).
+   * Download private key JSON for the Google service account via the
+   [Credentials page](https://console.developers.google.com/apis/credentials?project=mapping-crisis).
+   * Upload to the [Amazon Secrets Manager](https://aws.amazon.com/secrets-manager/getting-started/)
+   using the provvided instructions.
+To make the secret readable by the server, you will have to have the server run
+as a user with permissions to read the secret:
+  * [Instructions for creating the user](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html#iam-instanceprofile-create).
+  * [Give access only to this secret](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_identity-based-policies.html#permissions_grant-limited-resources)
+  * After deploying the app, in the Elastic Beanstalk console, go to
+  Configuration > Security > Modify and choose the IAM instance profile you
+  created above.
+  * Make sure the region you created the secret in matches the region specified
+  in `token_server.js`! 
 
 ## Start locally, for testing only
 

--- a/token_server/README.md
+++ b/token_server/README.md
@@ -62,7 +62,7 @@ are using Elastic Beanstalk.
 ### Set up new Amazon Elastic Beanstalk instance
 * See the [Google Cloud instructions](#set-up-new-google-cloud-instance) if that is
 also changing.
-* Delete the `.elasticbeanstalk` subdirectory of this directory, and follow the
+* Delete the [.elasticbeanstalk](./.elasticbeanstalk) subdirectory of this directory, and follow the
 instructions [here]((https://aws.amazon.com/getting-started/tutorials/deploy-app-command-line-elastic-beanstalk/)
 to set up from scratch.
 * Delete the `.gitignore` file that setup creates, and add `.elasticbeanstalk/*`

--- a/token_server/README.md
+++ b/token_server/README.md
@@ -81,12 +81,12 @@ in [ee_token_creator.js](./ee_token_creator.js).
 To make the secret readable by the server, you will have to have the server run
 as a user with permissions to read the secret:
   * [Instructions for creating the user](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html#iam-instanceprofile-create).
-  * [Give access only to this secret](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_identity-based-policies.html#permissions_grant-limited-resources)
+  * [Give access only to this secret](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_identity-based-policies.html#permissions_grant-limited-resources).
   * After deploying the app, in the Elastic Beanstalk console, go to
   Configuration > Security > Modify and choose the IAM instance profile you
   created above.
   * Make sure the region you created the secret in matches the region specified
-  in [token_server.js](./token_server.js)! 
+  in [aws_get_credentials.js](./aws_get_credentials.js)! 
 
 ## Start locally, for testing only
 

--- a/token_server/README.md
+++ b/token_server/README.md
@@ -12,9 +12,9 @@ change the hosting location for this server, just update that variable.
 
 ## Run server on Google App Engine
 
-* One-time only: [install `gcloud`](https://cloud.google.com/sdk/docs/).
+*  One-time only: [install `gcloud`](https://cloud.google.com/sdk/docs/).
 
-* Run `gcloud app deploy --project mapping-crisis` from this directory
+*  Run `gcloud app deploy --project mapping-crisis` from this directory
 (`token_server/`). If you are not already authenticated in gcloud, it will give
 you a command to run, probably `gcloud auth login`. Run it, logging in as
 `gd-earthengine-user@givedirectly.org` and try again.
@@ -24,69 +24,81 @@ you a command to run, probably `gcloud auth login`. Run it, logging in as
   not expected to work, since appropriate headers have to be attached to the
   request).
 
-* The server should continue running forever, but will use few/no resources
+*  The server should continue running forever, but will use few/no resources
 unless it is getting traffic.
 
-* The app was initially set up using the features described at
+*  The app was initially set up using the features described at
 [NodeJS Runtime](https://cloud.google.com/appengine/docs/standard/nodejs/runtime).
 
-* Billing and usage is available at the
+*  Billing and usage is available at the
 [Dashboard](https://console.cloud.google.com/appengine?folder=&organizationId=838088520005&project=mapping-crisis).
 You must be logged in as `gd-earthengine-user@givedirectly.org` to access it.
 
 ### Set up new Google Cloud instance
-* Most of the necessary work needs to be done to set up the mapping page to work
-properly in the first place. The only additional work is to create a service
-account that is whitelisted for EarthEngine access (currently
-`earthengine-token-provider`) and give it the "Service Account Token Creator" role
-in the
-[IAM page](https://console.developers.google.com/iam-admin/iam?project=mapping-crisis).
 
-* If you are serving tokens from Google App Engine, and not from Amazon, then
-you should also give the default AppEngine service account
-(currently `mapping-crisis@appspot.gserviceaccount.com`) the "Service Account
-Token Creator" role, so that it can create tokens for the service account you
-created above.
+*  You should not normally need to do this unless you had to switch Google
+   accounts, as described in [INITIAL_SETUP.md](../docs/INITIAL_SETUP.md).
+*  If you have already followed the instructions at
+   [INITIAL_SETUP.md](../docs/INITIAL_SETUP.md) to set up the mapping page in
+   the first place, most of the work needed here is already done. The only
+   additional work is to create a service account that is whitelisted for
+   EarthEngine access (currently `earthengine-token-provider`) and give it the
+   "Service Account Token Creator" role in the
+   [IAM page](https://console.developers.google.com/iam-admin/iam?project=mapping-crisis).
+
+*  If you are serving tokens from Google App Engine, and not from Amazon, then
+   you should also give the default AppEngine service account (currently
+   `mapping-crisis@appspot.gserviceaccount.com`) the "Service Account Token
+   Creator" role, so that it can create tokens for the service account you
+   created above.
 
 ## Run server on Amazon Elastic Beanstalk
 
-* Deploy using [these instructions](https://aws.amazon.com/getting-started/tutorials/deploy-app-command-line-elastic-beanstalk/).
-Since the project already exists on Amazon Elastic Beanstalk, you just need to
-run `eb deploy` after running `eb init` in order to log in.
+*  Deploy using
+   [these instructions](https://aws.amazon.com/getting-started/tutorials/deploy-app-command-line-elastic-beanstalk/).
+   Since the project already exists on Amazon Elastic Beanstalk, you just need
+   to run `eb deploy` after running `eb init` in order to log in.
 
-* The server URL will be entered here once we have GiveDirectly's account.
+*  The server URL will be entered here once we have GiveDirectly's account.
 
-* See the [console](https://console.aws.amazon.com/) for more information. We
-are using Elastic Beanstalk.
+*  See the [console](https://console.aws.amazon.com/) for more information. We
+   are using Elastic Beanstalk.
 
 ### Set up new Amazon Elastic Beanstalk instance
-* See the [Google Cloud instructions](#set-up-new-google-cloud-instance) if that is
-also changing.
-* Delete the [.elasticbeanstalk](./.elasticbeanstalk) subdirectory of this directory, and follow the
-instructions [here]((https://aws.amazon.com/getting-started/tutorials/deploy-app-command-line-elastic-beanstalk/)
-to set up from scratch.
-* Delete the `.gitignore` file that setup creates, and add `.elasticbeanstalk/*`
-to git.
-* Add Google service account credentials to
-[Amazon Secrets Manager](https://aws.amazon.com/secrets-manager/getting-started/).
-Remember that you need to be logged into Google as
-`gd-earthengine-user@givedirectly.org`.
-   * The Google service account is currently
-`earthengine-token-provider@mapping-crisis.iam.gserviceaccount.com` (specified
-in [ee_token_creator.js](./ee_token_creator.js).
-   * Download private key JSON for the Google service account via the
-   [Credentials page](https://console.developers.google.com/apis/credentials?project=mapping-crisis).
-   * Upload to the [Amazon Secrets Manager](https://aws.amazon.com/secrets-manager/getting-started/)
-   using the provided instructions.
-To make the secret readable by the server, you will have to have the server run
-as a user with permissions to read the secret:
-  * [Instructions for creating the user](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html#iam-instanceprofile-create).
-  * [Give access only to this secret](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_identity-based-policies.html#permissions_grant-limited-resources).
-  * After deploying the app, in the Elastic Beanstalk console, go to
-  Configuration > Security > Modify and choose the IAM instance profile you
-  created above.
-  * Make sure the region you created the secret in matches the region specified
-  in [aws_get_credentials.js](./aws_get_credentials.js)! 
+
+*  You should not normally need to do this if you already have a running server.
+*  See the [Google Cloud instructions](#set-up-new-google-cloud-instance) if
+   that is also changing.
+*  Delete the [.elasticbeanstalk](./.elasticbeanstalk) subdirectory of this
+   directory, and follow the  instructions
+   [here]((https://aws.amazon.com/getting-started/tutorials/deploy-app-command-line-elastic-beanstalk/)
+   to set up from scratch.
+*  Delete the `.gitignore` file that setup creates, and add
+   `.elasticbeanstalk/*` to git.
+*  Add Google service account credentials to
+   [Amazon Secrets Manager](https://aws.amazon.com/secrets-manager/getting-started/).
+   Remember that you need to be logged into Google as
+   `gd-earthengine-user@givedirectly.org`.
+     -  The Google service account is currently
+        `earthengine-token-provider@mapping-crisis.iam.gserviceaccount.com`
+        (specified in [ee_token_creator.js](./ee_token_creator.js)).
+     -  Download private key JSON for the Google service account via the
+        [Credentials page](https://console.developers.google.com/apis/credentials?project=mapping-crisis).
+     -  Upload to the [Amazon Secrets Manager](https://aws.amazon.com/secrets-manager/getting-started/)
+        using the provided instructions.
+     -  Take the "Secret ARN"'" (starting with `arn:aws:secretsmanager`) and put
+        it into the `SECRET_ID` field in
+        [aws_get_credentials.js](./aws_get_credentials.js).
+     - Make sure the region you created the secret in matches the region
+       specified in `AWS_REGION` in
+       [aws_get_credentials.js](./aws_get_credentials.js)! 
+   To make the secret readable by the server, you will have to have the server
+   run as a user with permissions to read the secret:
+     -  [Instructions for creating the user](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html#iam-instanceprofile-create).
+     -  [Give access only to this secret](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_identity-based-policies.html#permissions_grant-limited-resources).
+     -  After deploying the app, in the Elastic Beanstalk console, go to
+        Configuration > Security > Modify and choose the IAM instance profile
+        you created above.
 
 ## Start locally, for testing only
 

--- a/token_server/README.md
+++ b/token_server/README.md
@@ -7,7 +7,7 @@ should follow the instructions below, and they should only need to be done once.
 This server's location is unrelated to the mapping page's hosted location (The
 mapping page's hosted location is
 https://givedirectly.github.io/Google-Partnership as of January 2020). This
-server is pointed to by the `TOKEN_SERVER_URL` of `docs/authenticate.js`. If you
+server is pointed to by the `TOKEN_SERVER_URL` of [authenticate.js](../docs/authenticate.js). If you
 change the hosting location for this server, just update that variable.
 
 ## Run server on Google App Engine
@@ -73,7 +73,7 @@ Remember that you need to be logged into Google as
 `gd-earthengine-user@givedirectly.org`.
    * The Google service account is currently
 `earthengine-token-provider@mapping-crisis.iam.gserviceaccount.com` (specified
-in `ee_token_creator.js`).
+in [ee_token_creator.js](./ee_token_creator.js).
    * Download private key JSON for the Google service account via the
    [Credentials page](https://console.developers.google.com/apis/credentials?project=mapping-crisis).
    * Upload to the [Amazon Secrets Manager](https://aws.amazon.com/secrets-manager/getting-started/)
@@ -86,7 +86,7 @@ as a user with permissions to read the secret:
   Configuration > Security > Modify and choose the IAM instance profile you
   created above.
   * Make sure the region you created the secret in matches the region specified
-  in `token_server.js`! 
+  in [token_server.js](./token_server.js)! 
 
 ## Start locally, for testing only
 

--- a/token_server/README.md
+++ b/token_server/README.md
@@ -35,16 +35,31 @@ unless it is getting traffic.
 You must be logged in as `gd-earthengine-user@givedirectly.org` to access it.
 
 ### Set up Google Cloud instance
-* Most of the work needs to be done to set up the mapping page to work properly
-in the first place. The only additional work is to create a service account that
+* Most of the necessary work needs to be done to set up the mapping page to work
+properly in the first place. The only additional work is to create a service
+account that is whitelisted for EarthEngine access (currently
+`earthengine-token-provider`) and give it the "Service Account Token Creator" role
+in the
+[IAM page](https://console.developers.google.com/iam-admin/iam?project=mapping-crisis).
+
+* If you are serving tokens from Google App Engine, and not from Amazon, then
+you should also give the default AppEngine service account
+(currently `mapping-crisis@appspot.gserviceaccount.com`) the "Service Account
+Token Creator" role, so that it can create tokens for the service account you
+created above.
 
 ## Run server on Amazon Elastic Beanstalk
 
 * Deploy using [these instructions](https://aws.amazon.com/getting-started/tutorials/deploy-app-command-line-elastic-beanstalk/).
 Since the project already exists on Amazon Elastic Beanstalk, you just need to
-run `eb deploy` after running `eb init` in order to log in. TODO(janakr): check this
+run `eb deploy` after running `eb init` in order to log in.
 
-### Set up Amazon Elastic Beanstalk instance
+* The server URL will be entered here once we have GiveDirectly's account.
+
+* See the [console](https://console.aws.amazon.com/) for more information. We
+are using Elastic Beanstalk.
+
+### Set up new Amazon Elastic Beanstalk instance
 * See the [Google Cloud instructions](#set-up-google-cloud-instance) if that is
 also changing.
 * Delete the `.elasticbeanstalk` subdirectory of this directory, and follow the
@@ -62,7 +77,7 @@ in `ee_token_creator.js`).
    * Download private key JSON for the Google service account via the
    [Credentials page](https://console.developers.google.com/apis/credentials?project=mapping-crisis).
    * Upload to the [Amazon Secrets Manager](https://aws.amazon.com/secrets-manager/getting-started/)
-   using the provvided instructions.
+   using the provided instructions.
 To make the secret readable by the server, you will have to have the server run
 as a user with permissions to read the secret:
   * [Instructions for creating the user](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html#iam-instanceprofile-create).

--- a/token_server/README.md
+++ b/token_server/README.md
@@ -91,7 +91,8 @@ You must be logged in as `gd-earthengine-user@givedirectly.org` to access it.
         [aws_get_credentials.js](./aws_get_credentials.js).
      - Make sure the region you created the secret in matches the region
        specified in `AWS_REGION` in
-       [aws_get_credentials.js](./aws_get_credentials.js)! 
+       [aws_get_credentials.js](./aws_get_credentials.js)!
+
    To make the secret readable by the server, you will have to have the server
    run as a user with permissions to read the secret:
      -  [Instructions for creating the user](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html#iam-instanceprofile-create).

--- a/token_server/README.md
+++ b/token_server/README.md
@@ -86,7 +86,7 @@ You must be logged in as `gd-earthengine-user@givedirectly.org` to access it.
         [Credentials page](https://console.developers.google.com/apis/credentials?project=mapping-crisis).
      -  Upload to the [Amazon Secrets Manager](https://aws.amazon.com/secrets-manager/getting-started/)
         using the provided instructions.
-     -  Take the "Secret ARN"'" (starting with `arn:aws:secretsmanager`) and put
+     -  Take the "Secret ARN" (starting with `arn:aws:secretsmanager`) and put
         it into the `SECRET_ID` field in
         [aws_get_credentials.js](./aws_get_credentials.js).
      - Make sure the region you created the secret in matches the region

--- a/token_server/app.yaml
+++ b/token_server/app.yaml
@@ -1,1 +1,1 @@
-runtime: nodejs12
+runtime: nodejs10

--- a/token_server/app.yaml
+++ b/token_server/app.yaml
@@ -1,1 +1,2 @@
+# TODO(janakr): update to 12 when Amazon supports (and change package.json).
 runtime: nodejs10

--- a/token_server/aws_get_credentials.js
+++ b/token_server/aws_get_credentials.js
@@ -1,0 +1,46 @@
+import AWS from 'aws-sdk';
+import fs from 'fs';
+import tmp from 'tmp';
+
+export {storeGoogleCredentials};
+
+const AWS_REGION = 'us-east-1';
+const SECRET_ID = 'arn:aws:secretsmanager:us-east-1:560508828482:secret:' +
+    'GoogleServiceAccountJson-EXtSJ9';
+
+const client = new AWS.SecretsManager({region: AWS_REGION});
+
+/**
+ * Loads credentials from AWS Secrets Manager and write them to a temp file,
+ * then sets `GOOGLE_APPLICATION_CREDENTIALS` environment variable to that file
+ * so Google libraries will pick it up.
+ *
+ * Secrets Manager code this is based on:
+ * https://docs.aws.amazon.com/code-samples/latest/catalog/javascript-secrets-secrets_getsecretvalue.js.html
+ * @return {Promise<void>} Promise that is done when environment variable is set
+ *     to temp file
+ */
+function storeGoogleCredentials() {
+  return new Promise(
+      (resolve, reject) =>
+          client.getSecretValue({SecretId: SECRET_ID}, (err, data) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            tmp.file((err, path) => {
+              if (err) {
+                reject(err);
+                return;
+              }
+              fs.writeFile(path, data.SecretString, (err) => {
+                if (err) {
+                  reject(err);
+                  return;
+                }
+                process.env.GOOGLE_APPLICATION_CREDENTIALS = path;
+                resolve();
+              });
+            });
+          }));
+}

--- a/token_server/aws_get_credentials.js
+++ b/token_server/aws_get_credentials.js
@@ -5,6 +5,8 @@ import tmp from 'tmp';
 export {storeGoogleCredentials};
 
 const AWS_REGION = 'us-east-1';
+
+// See instructions in README.md for where this comes from.
 const SECRET_ID = 'arn:aws:secretsmanager:us-east-1:560508828482:secret:' +
     'GoogleServiceAccountJson-EXtSJ9';
 

--- a/token_server/ee_token_creator.js
+++ b/token_server/ee_token_creator.js
@@ -8,6 +8,8 @@ export {generateEarthEngineToken};
 // Cope with slight differences between Babel/Node transpilation of googleapis.
 const google = googleapis.google || googleapis.default.google;
 
+let authAndClientPromise;
+
 /**
  * Produces an EarthEngine token that can be used by production code. We use
  * the somewhat legacy and very poorly documented but still supported
@@ -18,14 +20,18 @@ const google = googleapis.google || googleapis.default.google;
  * Using our service account, we request an access token with the
  * `earthengine.readonly` scope.
  *
- * @return {Promise<string>}
+ * @return {Promise<{accessToken: string, expireTime: string}>}
  */
 function generateEarthEngineToken() {
-  // This is the scope needed to use iamcredentials:
-  // https://developers.google.com/identity/protocols/googlescopes#iamcredentialsv1
-  const auth = new google.auth.GoogleAuth(
-      {scopes: ['https://www.googleapis.com/auth/cloud-platform']});
-  return auth.getClient().then((client) => createTokenPromise(auth, client));
+  if (!authAndClientPromise) {
+    // This is the scope needed to use iamcredentials:
+    // https://developers.google.com/identity/protocols/googlescopes#iamcredentialsv1
+    const auth = new google.auth.GoogleAuth(
+        {scopes: ['https://www.googleapis.com/auth/cloud-platform']});
+    authAndClientPromise = {auth, client: auth.getClient()};
+  }
+  return authAndClientPromise.client.then(
+      (client) => createTokenPromise(authAndClientPromise.auth, client));
 }
 
 /**
@@ -73,6 +79,7 @@ function requestToken(auth, client, callback) {
   // which is not desirable.
   const serviceAccount = client.email ?
       client.email :
+      // If this changes, change the README as well.
       'earthengine-token-provider@mapping-crisis.iam.gserviceaccount.com';
   google.iamcredentials({version: 'v1', auth})
       .projects.serviceAccounts.generateAccessToken(

--- a/token_server/package.json
+++ b/token_server/package.json
@@ -4,15 +4,20 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "start": "node --experimental_modules token_server.js"
+    "start": "node -r esm token_server.js",
+    "start-12": "node --experimental_modules token_server.js"
   },
   "engines": {
-    "node": "12.x.x"
+    "node": ">=10"
   },
   "dependencies": {
+    "aws-sdk": "^2.596.0",
+    "esm": "^3.2.25",
+    "fs": "^0.0.1-security",
     "google-auth-library": "^5.7.0",
+    "googleapis": "^46.0.0",
     "http": "^0.0.0",
-    "urlencoded-body-parser": "^3.0.0",
-    "googleapis": "^46.0.0"
+    "tmp": "^0.1.0",
+    "urlencoded-body-parser": "^3.0.0"
   }
 }

--- a/token_server/token_server.js
+++ b/token_server/token_server.js
@@ -2,8 +2,13 @@ import * as GoogleAuth from 'google-auth-library';
 import {createServer} from 'http';
 // TODO(janakr): this is a pretty random package. Maybe find a more popular one.
 import parseBody from 'urlencoded-body-parser';
-
+import {storeGoogleCredentials} from './aws_get_credentials.js';
 import {generateEarthEngineToken} from './ee_token_creator.js';
+
+// TODO(janakr): Elastic Beanstalk doesn't seem to support https without jumping
+//  through additional hoops. Sending tokens in the clear seems like a bad idea,
+//  although there's nothing obviously terrible you could do with an id token or
+//  the returned EE-enabled token.
 
 // TODO(janakr): Seems impossible to deploy to Google App Engine with
 //  a package that is in a sibling directory. That prevents us from sharing this
@@ -28,29 +33,38 @@ const TIME_BEFORE_REGENERATION = 40 * ONE_MINUTE_IN_MILLISECONDS;
 
 const allowedOrigins = new Set(['https://givedirectly.github.io']);
 
-if (!process.env.GAE_APPLICATION) {
+// AWS does not provide any pre-set environment variables, but we can assume
+// that local runs have GOOGLE_APPLICATION_CREDENTIALS and AWS doesn't, while
+// GAE has GAE_APPLICATION.
+if (!process.env.GAE_APPLICATION &&
+    process.env.GOOGLE_APPLICATION_CREDENTIALS) {
   // When running locally, allow requests from localhost.
   allowedOrigins.add('http://localhost:8080');
 }
 
-// Google App Engine tells us the port to listen to.
+// AWS Elastic Beanstalk/Google App Engine tells us the port to listen to.
 const port = process.env.PORT || 9080;
+
+// Promise that resolves immediately if credentials are present, and resolves
+// once secret is retrieved, written to file, and variable set to file location
+// if credentials not present (meaning we're on AWS).
+const googleCredentialsPresent = process.env.GOOGLE_APPLICATION_CREDENTIALS ?
+    Promise.resolve() :
+    storeGoogleCredentials();
 
 /**
  * Result of most recent call to {@link generateEarthEngineToken}. Because there
  * is no requirement that tokens be unique per user, we re-use tokens for almost
  * their full lifetime of 1 hour, minimizing work.
  *
- * After the initial {@link Promise} returned by
+ * After the initial {@link Promise} returned below by
  * {@link generateEarthEngineToken} resolves, this will always have a resolved
  * {@link Promise}, because {@link generateTokenPeriodically} only sets it when
  * further calls to {@link generateEarthEngineToken} have resolved.
  *
  * @type {Promise<{accessToken: string, expireTime: string}>}
  */
-let currentTokenPromise = generateEarthEngineToken();
-
-setTimeout(generateTokenPeriodically, TIME_BEFORE_REGENERATION);
+let currentTokenPromise;
 
 /**
  * Pre-fetches token and periodically gets a new one (every 40 minutes, leaving
@@ -61,43 +75,50 @@ setTimeout(generateTokenPeriodically, TIME_BEFORE_REGENERATION);
  * to wait, they can just use the old token.
  */
 function generateTokenPeriodically() {
-  generateEarthEngineToken().then(
-      (token) => currentTokenPromise = Promise.resolve(token));
+  googleCredentialsPresent.then(generateEarthEngineToken)
+      .then((token) => currentTokenPromise = Promise.resolve(token));
   setTimeout(generateTokenPeriodically, TIME_BEFORE_REGENERATION);
 }
 
-generateTokenPeriodically();
+// Cope with slight differences between ESM/Node transpilation of googleapis.
+const googleAuth = GoogleAuth.default || GoogleAuth;
 
-const client = new GoogleAuth.default.OAuth2Client(CLIENT_ID);
+// Can't do anything more without credentials being present.
+googleCredentialsPresent.then(() => {
+  setTimeout(generateTokenPeriodically, TIME_BEFORE_REGENERATION);
 
-/**
- * See
- * https://nodejs.org/api/http.html#http_http_createserver_options_requestlistener
- * or https://www.w3schools.com/nodejs/nodejs_http.asp for a gentle intro.
- */
-createServer(async (req, res) => {
-  const origin = req.headers['origin'];
-  if (!allowedOrigins.has(origin)) {
-    fail(res);
-    return;
-  }
+  currentTokenPromise = generateEarthEngineToken();
 
-  try {
-    const {idToken} = await parseBody(req);
-    await client.verifyIdToken({idToken: idToken, audience: CLIENT_ID});
-  } catch (err) {
-    console.log(err);
-    fail(res);
-    return;
-  }
-  const data = await currentTokenPromise;
-  const headers = Object.assign({}, RESPONSE_HEADERS);
-  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
-  headers['Access-Control-Allow-Origin'] = origin;
-  res.writeHead(200, headers);
-  res.write(JSON.stringify(data));
-  res.end();
-}).listen(port);
+  const client = new googleAuth.OAuth2Client(CLIENT_ID);
+
+  /**
+   * See
+   * https://nodejs.org/api/http.html#http_http_createserver_options_requestlistener
+   * or https://www.w3schools.com/nodejs/nodejs_http.asp for a gentle intro.
+   */
+  createServer(async (req, res) => {
+    const origin = req.headers['origin'];
+    if (!allowedOrigins.has(origin)) {
+      fail(res);
+      return;
+    }
+
+    try {
+      const {idToken} = await parseBody(req);
+      await client.verifyIdToken({idToken: idToken, audience: CLIENT_ID});
+    } catch (err) {
+      fail(res);
+      return;
+    }
+    const data = await currentTokenPromise;
+    const headers = Object.assign({}, RESPONSE_HEADERS);
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+    headers['Access-Control-Allow-Origin'] = origin;
+    res.writeHead(200, headers);
+    res.write(JSON.stringify(data));
+    res.end();
+  }).listen(port);
+});
 
 /**
  * Returns a generic failure to the client.

--- a/token_server/token_server.js
+++ b/token_server/token_server.js
@@ -75,8 +75,8 @@ let currentTokenPromise;
  * to wait, they can just use the old token.
  */
 function generateTokenPeriodically() {
-  googleCredentialsPresent.then(generateEarthEngineToken)
-      .then((token) => currentTokenPromise = Promise.resolve(token));
+  generateEarthEngineToken().then(
+      (token) => currentTokenPromise = Promise.resolve(token));
   setTimeout(generateTokenPeriodically, TIME_BEFORE_REGENERATION);
 }
 

--- a/token_server/yarn.lock
+++ b/token_server/yarn.lock
@@ -21,10 +21,27 @@ arrify@^2.0.0:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-"auth_utils@file:auth_utils":
-  version "1.0.0"
+aws-sdk@^2.596.0:
+  version "2.596.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.596.0.tgz#1a4af0609e174a50ffb8ed8981981e6d77a614fb"
+  integrity sha512-Bp+gyqhLw8tK4sgM1v1PDSw26H1mSXs6yhQInmGzDKqXJor6UyUb9JskFv0zC/bA84XizlshN1BBIgINqk6pNg==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
 
-base64-js@^1.3.0:
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base64-js@^1.0.2, base64-js@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
@@ -34,15 +51,37 @@ bignumber.js@^7.0.0:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
   integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
 
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
 
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
+
 bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 debug@^3.1.0:
   version "3.2.6"
@@ -75,10 +114,20 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 extend@^3.0.2:
   version "3.0.2"
@@ -90,7 +139,17 @@ fast-text-encoding@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz#3e5ce8293409cfaa7177a71b9ca84e1b1e6f25ef"
   integrity sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ==
 
-gaxios@^2.1.0:
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+fs@^0.0.1-security:
+  version "0.0.1-security"
+  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
+  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
+
+gaxios@^2.0.1, gaxios@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-2.2.0.tgz#7c51653c224415ac9218416cb94ff48610b816bc"
   integrity sha512-54Y7s3yvtEO9CZ0yBVQHI5fzS7TzkjlnuLdDEkeyL1SNYMv877VofvA56E/C3dvj3rS7GFiyMWl833Qrr+nrkg==
@@ -109,7 +168,19 @@ gcp-metadata@^3.2.0:
     gaxios "^2.1.0"
     json-bigint "^0.3.0"
 
-google-auth-library@^5.7.0:
+glob@^7.1.3:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+google-auth-library@^5.6.1, google-auth-library@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-5.7.0.tgz#2d8273793a9177f9f37f3920861f4256419c77ae"
   integrity sha512-uclMldsQNf64Qr67O8TINdnqbU/Ixv81WryX+sF9g7uP0igJ98aCR/uU399u1ABLa53LNsyji+bo+bP8/iL9dA==
@@ -129,6 +200,26 @@ google-p12-pem@^2.0.0:
   integrity sha512-Tq2kBCANxYYPxaBpTgCpRfdoPs9+/lNzc/Iaee4kuMVW5ascD+HwhpBsTLwH85C9Ev4qfB8KKHmpPQYyD2vg2w==
   dependencies:
     node-forge "^0.9.0"
+
+googleapis-common@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/googleapis-common/-/googleapis-common-3.2.0.tgz#80e706405065a0fe897b6d15bb2824f8a18e1776"
+  integrity sha512-ARTbCRgge1jnPJhXBJbxboofWF0cCYlktEhsc9tQzTDCTIjf8SiQkGmhyakitP4c9lBQAtOX4vYOJQE0En4CGw==
+  dependencies:
+    extend "^3.0.2"
+    gaxios "^2.0.1"
+    google-auth-library "^5.6.1"
+    qs "^6.7.0"
+    url-template "^2.0.8"
+    uuid "^3.3.2"
+
+googleapis@^46.0.0:
+  version "46.0.0"
+  resolved "https://registry.yarnpkg.com/googleapis/-/googleapis-46.0.0.tgz#ca261c6e2484adab1accdefb859fb31980e4f1b7"
+  integrity sha512-MOA6Qpu0jQfdnWZEyoAfW6duhWZxZxgrIzOtxNmsSj0WgLfot2s0vcAAq7MtCo1OX+/SduCsdJjCzq2tmhuxFw==
+  dependencies:
+    google-auth-library "^5.6.1"
+    googleapis-common "^3.2.0"
 
 gtoken@^4.1.0:
   version "4.1.3"
@@ -171,7 +262,20 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-inherits@2.0.4:
+ieee754@1.1.13, ieee754@^1.1.4:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2, inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -180,6 +284,16 @@ is-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
+isarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 json-bigint@^0.3.0:
   version "0.3.0"
@@ -222,6 +336,13 @@ mime@^2.2.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -237,10 +358,32 @@ node-forge@^0.9.0:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.1.tgz#775368e6846558ab6676858a4d8c6e8d16c677b5"
   integrity sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==
 
-qs@^6.2.1:
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  dependencies:
+    wrappy "1"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
+qs@^6.2.1, qs@^6.7.0:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
   integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 raw-body@^2.1.7:
   version "2.4.1"
@@ -252,6 +395,13 @@ raw-body@^2.1.7:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 safe-buffer@^5.0.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
@@ -261,6 +411,16 @@ safe-buffer@^5.0.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 setprototypeof@1.1.1:
   version "1.1.1"
@@ -272,6 +432,13 @@ setprototypeof@1.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+tmp@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
+  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+  dependencies:
+    rimraf "^2.6.3"
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -282,6 +449,19 @@ unpipe@1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
+  integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
+
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 urlencoded-body-parser@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/urlencoded-body-parser/-/urlencoded-body-parser-3.0.0.tgz#e55329c6feccb2ede0fd0c027d8c105c063ba5e0"
@@ -290,6 +470,34 @@ urlencoded-body-parser@^3.0.0:
     media-typer "^0.3.0"
     qs "^6.2.1"
     raw-body "^2.1.7"
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@^3.3.2:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
Main code change is that, because we're no longer running as a user that we can just give Google permissions to (the Google App Engine user), we have to store and load the credentials ourselves. The server can't do anything until that happens, so we wrap everything in the promise for that.

Other changes:
* AWS only supports Node 10 (boo) so had to drop down. Maybe they'll offer Node 12 soon: they offered 10 on [11/19/18](https://aws.amazon.com/about-aws/whats-new/2018/11/aws-elastic-beanstalk-adds-support-for-nodejs-10/), 20 days after Node 10 became the ["active" version](https://nodejs.org/en/about/releases/). Node 12 became the active version 10/21/19.
* Realized we were unnecessarily re-initializing auth and client objects inside ee_token_creator.js. Keep them around forever now.
* Was double-initializing currentTokenPromise, both directly and via generateTokenPeriodically. No longer.

#340