### PR TITLE
Don't set damage tag if missing

### DIFF
--- a/cypress/integration/unit_tests/create_score_asset_test.js
+++ b/cypress/integration/unit_tests/create_score_asset_test.js
@@ -137,7 +137,6 @@ describe('Unit tests for create_score_asset.js', () => {
           expect(feature.properties).to.eql({
             'BLOCK GROUP': 'Some state, group 361',
             'BUILDING COUNT': 3,
-            'DAMAGE PERCENTAGE': 0,
             'GEOID': '361',
             'MEDIAN INCOME': 37,
             'SNAP HOUSEHOLDS': 10,

--- a/docs/import/create_score_asset.js
+++ b/docs/import/create_score_asset.js
@@ -43,8 +43,6 @@ function countDamageAndBuildings(feature, damage, buildings, additionalTags) {
         ee.Algorithms.If(
             totalBuildings, ee.Number(damagedBuildings).divide(totalBuildings),
             0));
-  } else {
-    properties = properties.set(damageTag, 0);
   }
   const snapPop = feature.get(snapPopTag);
   const totalPop = feature.get(totalPopTag);


### PR DESCRIPTION
Depends on change in #370 to treat missing damage tag as 0.

Manually tested by generating asset and seeing that with dynamic-columns PR everything works.

Closes #322 although by making damage completely omitted.