### PR TITLE
Fix parameter headings to be content-title class

### DIFF
--- a/docs/update.js
+++ b/docs/update.js
@@ -114,7 +114,7 @@ function createToggles(map) {
 
   // threshold toggles
   const thresholdTitle = document.createElement('div');
-  thresholdTitle.className = 'form-title';
+  thresholdTitle.className = 'content-title';
   thresholdTitle.innerText = 'thresholds';
   form.appendChild(thresholdTitle);
   form.appendChild(createInput(povertyThresholdKey));
@@ -126,7 +126,7 @@ function createToggles(map) {
     const weightInputDiv = document.createElement('div');
     weightInputDiv.className = 'input-container';
     const weightTitle = document.createElement('div');
-    weightTitle.className = 'form-title';
+    weightTitle.className = 'content-title';
     weightTitle.innerText = 'weights';
     weightInputDiv.appendChild(weightTitle);
 


### PR DESCRIPTION
Forgot to update the headers to be 'content-title' class, not form-title after making css changes to the mange pages, so the styling on the headers is gone. 

Screenshot with styling back on the first header, but not on the second:
<img width="295" alt="Screen Shot 2020-01-02 at 12 11 30 PM" src="https://user-images.githubusercontent.com/53911188/71690315-27b90e80-2d59-11ea-810d-286c820a3935.png">

