### PR TITLE
Lint before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
 before_script:
 - yarn run ws --directory docs --port 8080 &
 script:
+- ./lint.sh
 - yarn run cypress run --env ON_TRAVIS=1 --record --browser=electron --group Unit --spec 'cypress/integration/unit_tests/*.js'
 # Chrome/Chromium video recording not working on xvfb with gpu acceleration
 - yarn run cypress run --env ON_TRAVIS=1 --record --browser=chrome --group Integration --config video=false --spec 'cypress/integration/integration_tests/*.js'
-- ./lint.sh


### PR DESCRIPTION
I think I originally thought the first unsuccessful command would terminate Travis, and it would be annoying to not have the tests run because of a lint error. But apparently everything always runs, so faster commands should go first.