### PR TITLE
Remove redundant disasterAssets map

### DIFF
--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -2,7 +2,7 @@ import {addPolygonWithPath} from '../../../docs/basic_map.js';
 import {readDisasterDocument} from '../../../docs/firestore_document.js';
 import {createDisasterData} from '../../../docs/import/create_disaster_lib.js';
 import * as ListEeAssets from '../../../docs/import/list_ee_assets.js';
-import {assetSelectionRowPrefix, disasterAssets, disasterData, scoreAssetTypes, scoreBoundsMap, setUpScoreBoundsMap, setUpScoreSelectorTable, validateUserFields} from '../../../docs/import/manage_disaster';
+import {assetSelectionRowPrefix, disasterData, scoreAssetTypes, scoreBoundsMap, setUpScoreBoundsMap, setUpScoreSelectorTable, validateUserFields} from '../../../docs/import/manage_disaster';
 import {enableWhenFirestoreReady} from '../../../docs/import/manage_disaster.js';
 import {getDisaster} from '../../../docs/resources.js';
 import {cyQueue} from '../../support/commands.js';
@@ -49,7 +49,6 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
                        ])));
 
     disasterData.clear();
-    disasterAssets.clear();
   });
 
   it('damage asset/map-bounds elements', () => {

--- a/cypress/integration/unit_tests/manage_layers_test.js
+++ b/cypress/integration/unit_tests/manage_layers_test.js
@@ -1,7 +1,7 @@
 import {eeLegacyPathPrefix} from '../../../docs/ee_paths.js';
 import {getFirestoreRoot} from '../../../docs/firestore_document.js';
 import {withColor} from '../../../docs/import/color_function_util.js';
-import {createOptionFrom, createTd, disasterAssets, getAssetsAndPopulateDisasterPicker, onCheck, onDelete, onInputBlur, onListBlur, updateAfterSort, withCheckbox, withInput, withList, withType} from '../../../docs/import/manage_layers.js';
+import {createOptionFrom, createTd, getAssetsAndPopulateDisasterPicker, onCheck, onDelete, onInputBlur, onListBlur, updateAfterSort, withCheckbox, withInput, withList, withType} from '../../../docs/import/manage_layers.js';
 import {setCurrentDisaster} from '../../../docs/import/manage_layers_lib';
 import {disasterData, getCurrentLayers} from '../../../docs/import/manage_layers_lib.js';
 import {getDisaster} from '../../../docs/resources';
@@ -26,7 +26,6 @@ describe('Unit tests for manage_layers page', () => {
     listAssetsStub = cy.stub(ee.data, 'listAssets');
     cy.stub(ee.data, 'createFolder');
 
-    disasterAssets.clear();
     // In prod this would happen in enableWhenReady which would read from
     // firestore.
     disasterData.clear();
@@ -58,15 +57,20 @@ describe('Unit tests for manage_layers page', () => {
         .returns(withNullGeometry);
     featureCollectionStub.withArgs('asset/with/empty/geometry')
         .returns(withEmptyGeometry);
-    cy.wrap(getAssetsAndPopulateDisasterPicker(disaster)).then(() => {
-      const assets = disasterAssets.get(disaster);
-      expect(assets.get('asset/with/geometry').disabled).to.be.false;
-      expect(assets.get('asset/with/null/geometry').disabled).to.be.true;
-      expect(assets.get('asset/with/empty/geometry').disabled).to.be.true;
+    cy.document().then((doc) => {
+      const damageDiv = document.createElement('div');
+      damageDiv.id = 'disaster-asset-picker';
+      doc.body.appendChild(damageDiv);
+      cy.stub(document, 'getElementById')
+          .callsFake((id) => doc.getElementById(id));
     });
+    cy.wrap(getAssetsAndPopulateDisasterPicker(disaster));
+    cy.get('[id="asset/with/geometry"]').should('not.be.disabled');
+    cy.get('[id="asset/with/null/geometry"]').should('be.disabled');
+    cy.get('[id="asset/with/empty/geometry"]').should('be.disabled');
   });
 
-  it('has racing disaster asset populates', () => {
+  it.only('has racing disaster asset populates', () => {
     const disaster = 'disaster';
     const otherDisaster = 'other';
     const fc =

--- a/cypress/integration/unit_tests/manage_layers_test.js
+++ b/cypress/integration/unit_tests/manage_layers_test.js
@@ -70,7 +70,7 @@ describe('Unit tests for manage_layers page', () => {
     cy.get('[id="asset/with/empty/geometry"]').should('be.disabled');
   });
 
-  it.only('has racing disaster asset populates', () => {
+  it('has racing disaster asset populates', () => {
     const disaster = 'disaster';
     const otherDisaster = 'other';
     const fc =

--- a/docs/import/manage_disaster.js
+++ b/docs/import/manage_disaster.js
@@ -4,27 +4,10 @@ import {showError} from '../error.js';
 import {disasterCollectionReference} from '../firestore_document.js';
 import {latLngToGeoPoint, transformGeoPointArrayToLatLng} from '../map_util.js';
 import {getDisaster} from '../resources.js';
-import {
-  createDisasterData,
-  incomeKey,
-  snapKey,
-  sviKey,
-  totalKey
-} from './create_disaster_lib.js';
-import {
-  createScoreAssetForStateBasedDisaster,
-  setStatus
-} from './create_score_asset.js';
-import {
-  cdcGeoidKey,
-  censusBlockGroupKey,
-  censusGeoidKey,
-  tigerGeoidKey
-} from './import_data_keys.js';
-import {
-  getDisasterAssetsFromEe,
-  getStateAssetsFromEe
-} from './list_ee_assets.js';
+import {createDisasterData, incomeKey, snapKey, sviKey, totalKey} from './create_disaster_lib.js';
+import {createScoreAssetForStateBasedDisaster, setStatus} from './create_score_asset.js';
+import {cdcGeoidKey, censusBlockGroupKey, censusGeoidKey, tigerGeoidKey} from './import_data_keys.js';
+import {getDisasterAssetsFromEe, getStateAssetsFromEe} from './list_ee_assets.js';
 import {clearStatus} from './manage_layers_lib.js';
 import {ScoreBoundsMap} from './score_bounds_map.js';
 import {scoreCoordinatesAttribute} from './score_path_lib.js';

--- a/docs/import/manage_layers.js
+++ b/docs/import/manage_layers.js
@@ -11,7 +11,6 @@ export {
   createLayerRow,
   createOptionFrom,
   createTd,
-  disasterAssets,
   getAssetsAndPopulateDisasterPicker,
   onCheck,
   onDelete,
@@ -28,12 +27,6 @@ export {
 // TODO(juliexxia): consolidate asset picker logic and storage structure between
 // manage_layers.js and manage_disaster.js
 // TODO: refactor to avoid as much jumpiness as possible.
-
-// A map of maps of the form:
-// {'disaster-2017' => {'asset/path' => {type: LayerType, disabled: boolean}}
-// The disabled boolean refers to whether the option should be disabled in the
-// disaster asset picker (see {@link getDisasterAssetsFromEe}).
-const disasterAssets = new Map();
 
 // TODO: general reminder to add loading indicators for things like creating
 // new state asset folders, etc.
@@ -311,22 +304,12 @@ let processedCurrentDisasterSelfAssets = false;
  */
 function getAssetsAndPopulateDisasterPicker(disaster) {
   processedCurrentDisasterSelfAssets = false;
-  const disasterLambda = (disaster) => {
-    if ((disaster) === getDisaster() && !processedCurrentDisasterSelfAssets) {
-      populateDisasterAssetPicker(disaster);
+  return getDisasterAssetsFromEe(disaster).then((assets) => {
+    if (disaster === getDisaster() && !processedCurrentDisasterSelfAssets) {
+      populateDisasterAssetPicker(disaster, assets);
       processedCurrentDisasterSelfAssets = true;
     }
-  };
-  if (disasterAssets.has(disaster)) {
-    disasterLambda(disaster);
-    return Promise.resolve();
-  } else {
-    setUpDisasterPicker(disaster);
-    return getDisasterAssetsFromEe(disaster).then((assets) => {
-      disasterAssets.set(disaster, assets);
-      disasterLambda(disaster);
-    });
-  }
+  });
 }
 
 /**
@@ -350,8 +333,9 @@ function setUpDisasterPicker(disaster) {
  * Displays disaster assets in a select underneath the #disaster-adder-label
  * label and adds an add button which adds a layer.
  * @param {string} disaster
+ * @param {Map<string, {type: LayerType, disabled: boolean}>} assets
  */
-function populateDisasterAssetPicker(disaster) {
+function populateDisasterAssetPicker(disaster, assets) {
   const div = $('#disaster-asset-picker').empty();
   const assetPickerLabel = $(document.createElement('label'))
                                .text('Add layer from ' + disaster + ': ')
@@ -359,20 +343,17 @@ function populateDisasterAssetPicker(disaster) {
   const assetPicker = $(document.createElement('select'))
                           .attr('id', disaster + '-adder')
                           .width(200);
-  if (disasterAssets.get(disaster)) {
-    for (const asset of disasterAssets.get(disaster)) {
-      const assetInfo = asset[1];
-      const type = layerTypeStrings.get(assetInfo.type);
-      assetPicker.append(createOptionFrom(asset[0])
-                             .text(asset[0] + '-' + type)
-                             .attr('disabled', assetInfo.disabled));
-    }
+  for (const [name, assetInfo] of assets) {
+    const type = layerTypeStrings.get(assetInfo.type);
+    assetPicker.append(createOptionFrom(name)
+                           .text(name + '-' + type)
+                           .attr('disabled', assetInfo.disabled));
   }
   const addButton =
       $(document.createElement('button')).prop('type', 'button').text('add');
   addButton.on('click', () => {
     const asset = assetPicker.val();
-    const type = disasterAssets.get(disaster).get(asset).type;
+    const type = assets.get(asset).type;
     processNewEeLayer(asset, type);
   });
   assetPickerLabel.append(assetPicker);

--- a/docs/import/manage_layers.js
+++ b/docs/import/manage_layers.js
@@ -304,6 +304,8 @@ let processedCurrentDisasterSelfAssets = false;
  */
 function getAssetsAndPopulateDisasterPicker(disaster) {
   processedCurrentDisasterSelfAssets = false;
+  // This will be immediately overwritten if promise below is already done.
+  setUpDisasterPicker(disaster);
   return getDisasterAssetsFromEe(disaster).then((assets) => {
     if (disaster === getDisaster() && !processedCurrentDisasterSelfAssets) {
       populateDisasterAssetPicker(disaster, assets);


### PR DESCRIPTION
In both manage_disaster and manage_layers it was doing a little bit, but not enough to justify keeping it: in manage_disaster, it helped us avoid a likely empty listing of the folder after creating a disaster, but actually in the edge case where a folder already existed, it could be incorrect. In manage_layers, it avoids creating a "pending" select that is immediately replaced by a real select, but the user doesn't actually see it, so it doesn't matter.

Fulfills https://github.com/givedirectly/Google-Partnership/pull/363#discussion_r361725663