### PR TITLE
Remove income string from expectation

### DIFF
--- a/cypress/integration/integration_tests/click_feature_test.js
+++ b/cypress/integration/integration_tests/click_feature_test.js
@@ -17,7 +17,7 @@ describe('Integration test for clicking feature', () => {
         .find('[class="google-visualization-table-td"]')
         .should(
             'have.text',
-            'Block Group 4, Census Tract 2415, Harris County, Texas21681');
+            'Block Group 4, Census Tract 2415, Harris County, Texas');
   });
 });
 
@@ -31,6 +31,6 @@ function clickBlockGroup() {
       .find('[class="google-visualization-table-td"]')
       .should(
           'have.text',
-          'Block Group 4, Census Tract 2415, Harris County, Texas21681');
+          'Block Group 4, Census Tract 2415, Harris County, Texas');
   cy.get('.map').should('contain', 'SCORE: 72');
 }

--- a/cypress/integration/integration_tests/click_feature_test.js
+++ b/cypress/integration/integration_tests/click_feature_test.js
@@ -32,5 +32,5 @@ function clickBlockGroup() {
       .should(
           'have.text',
           'Block Group 4, Census Tract 2415, Harris County, Texas');
-  cy.get('.map').should('contain', 'SCORE: 72');
+  cy.get('.map').should('contain', 'SCORE: 71');
 }


### PR DESCRIPTION
Income is now a number, so Cypress doesn't weirdly include it in text.

Also changed score expectation, since that changed slightly.