### PR TITLE
Convert all layer-related hyphenated vars to camelCase

### DIFF
--- a/cypress/integration/unit_tests/add_layer_test.js
+++ b/cypress/integration/unit_tests/add_layer_test.js
@@ -32,12 +32,12 @@ describe('Unit tests for adding layers', () => {
           const layers = getCurrentLayers();
           expect(layers.length).to.equal(3);
           const layer = layers[2];
-          expect(layer['asset-type']).to.equal(LayerType.FEATURE_COLLECTION);
-          expect(layer['ee-name']).to.equal(mockAsset);
-          expect(layer['display-name']).to.be.empty;
-          expect(layer['display-on-load']).to.be.false;
-          const colorFunction = layer['color-function'];
-          expect(colorFunction['current-style']).to.equal(ColorStyle.SINGLE);
+          expect(layer.assetType).to.equal(LayerType.FEATURE_COLLECTION);
+          expect(layer.eeName).to.equal(mockAsset);
+          expect(layer.displayName).to.be.empty;
+          expect(layer.displayOnLoad).to.be.false;
+          const colorFunction = layer.colorFunction;
+          expect(colorFunction.currentStyle).to.equal(ColorStyle.SINGLE);
           expect(colorFunction['colors']).to.be.empty;
           const scoopsColumn = colorFunction['columns']['scoops'];
           expect(scoopsColumn['max']).to.equal(4);
@@ -60,7 +60,7 @@ describe('Unit tests for adding layers', () => {
           const layers = getCurrentLayers();
           expect(layers.length).to.equal(1);
           const layer = layers[0];
-          const colorFunction = layer['color-function'];
+          const colorFunction = layer.colorFunction;
           const scoopsColumn = colorFunction['columns']['scoops'];
           expect(scoopsColumn['max']).to.equal(29);
           expect(scoopsColumn['min']).to.equal(0);
@@ -83,7 +83,7 @@ describe('Unit tests for adding layers', () => {
         .then(() => {
           expect(setAclStub).to.be.calledOnce;
           const layer = getCurrentLayers()[0];
-          expect(layer['color-function']['columns']['flavor']['values'])
+          expect(layer.colorFunction['columns']['flavor']['values'])
               .to.eql(['vanilla']);
         });
   });
@@ -99,8 +99,8 @@ describe('Unit tests for adding layers', () => {
           const layers = getCurrentLayers();
           expect(layers.length).to.equal(1);
           const layer = layers[0];
-          expect(layer['asset-type']).to.equal(LayerType.IMAGE_COLLECTION);
-          expect(layer['color-function']).to.be.undefined;
+          expect(layer.assetType).to.equal(LayerType.IMAGE_COLLECTION);
+          expect(layer.colorFunction).to.be.undefined;
         });
   });
 
@@ -115,8 +115,8 @@ describe('Unit tests for adding layers', () => {
       const layers = getCurrentLayers();
       expect(layers.length).to.equal(1);
       const layer = layers[0];
-      expect(layer['asset-type']).to.equal(LayerType.KML);
-      expect(layer['color-function']).to.be.undefined;
+      expect(layer.assetType).to.equal(LayerType.KML);
+      expect(layer.colorFunction).to.be.undefined;
       expect(layer['urls'].length).to.equal(2);
     });
   });

--- a/cypress/integration/unit_tests/add_layer_test.js
+++ b/cypress/integration/unit_tests/add_layer_test.js
@@ -31,12 +31,12 @@ describe('Unit tests for adding layers', () => {
           expect(setAclStub).to.be.calledOnce;
           const layers = getCurrentLayers();
           expect(layers.length).to.equal(3);
-          const layer = layers[2];
-          expect(layer.assetType).to.equal(LayerType.FEATURE_COLLECTION);
-          expect(layer.eeName).to.equal(mockAsset);
-          expect(layer.displayName).to.be.empty;
-          expect(layer.displayOnLoad).to.be.false;
-          const colorFunction = layer.colorFunction;
+          const {assetType, eeName, displayName, displayOnLoad, colorFunction} =
+              layers[2];
+          expect(assetType).to.equal(LayerType.FEATURE_COLLECTION);
+          expect(eeName).to.equal(mockAsset);
+          expect(displayName).to.be.empty;
+          expect(displayOnLoad).to.be.false;
           expect(colorFunction.currentStyle).to.equal(ColorStyle.SINGLE);
           expect(colorFunction.colors).to.be.empty;
           const scoopsColumn = colorFunction.columns.scoops;
@@ -60,7 +60,7 @@ describe('Unit tests for adding layers', () => {
           const layers = getCurrentLayers();
           expect(layers.length).to.equal(1);
           const layer = layers[0];
-          const colorFunction = layer.colorFunction;
+          const {colorFunction} = layer;
           const scoopsColumn = colorFunction.columns.scoops;
           expect(scoopsColumn.max).to.equal(29);
           expect(scoopsColumn.min).to.equal(0);
@@ -82,10 +82,10 @@ describe('Unit tests for adding layers', () => {
         processNewEeLayer(mockAsset, LayerType.FEATURE_COLLECTION))
         .then(() => {
           expect(setAclStub).to.be.calledOnce;
-          const layer = getCurrentLayers()[0];
-          expect(layer.colorFunction.columns.flavor.values).to.eql([
-            'vanilla',
-          ]);
+          expect(getCurrentLayers()[0].colorFunction.columns.flavor.values)
+              .to.eql([
+                'vanilla',
+              ]);
         });
   });
 
@@ -99,9 +99,9 @@ describe('Unit tests for adding layers', () => {
           expect(setAclStub).to.be.calledOnce;
           const layers = getCurrentLayers();
           expect(layers.length).to.equal(1);
-          const layer = layers[0];
-          expect(layer.assetType).to.equal(LayerType.IMAGE_COLLECTION);
-          expect(layer.colorFunction).to.be.undefined;
+          const {assetType, colorFunction} = layers[0];
+          expect(assetType).to.equal(LayerType.IMAGE_COLLECTION);
+          expect(colorFunction).to.be.undefined;
         });
   });
 
@@ -115,10 +115,10 @@ describe('Unit tests for adding layers', () => {
     ])).then(() => {
       const layers = getCurrentLayers();
       expect(layers.length).to.equal(1);
-      const layer = layers[0];
-      expect(layer.assetType).to.equal(LayerType.KML);
-      expect(layer.colorFunction).to.be.undefined;
-      expect(layer.urls.length).to.equal(2);
+      const {assetType, colorFunction, urls} = layers[0];
+      expect(assetType).to.equal(LayerType.KML);
+      expect(colorFunction).to.be.undefined;
+      expect(urls.length).to.equal(2);
     });
   });
 });

--- a/cypress/integration/unit_tests/add_layer_test.js
+++ b/cypress/integration/unit_tests/add_layer_test.js
@@ -38,11 +38,11 @@ describe('Unit tests for adding layers', () => {
           expect(layer.displayOnLoad).to.be.false;
           const colorFunction = layer.colorFunction;
           expect(colorFunction.currentStyle).to.equal(ColorStyle.SINGLE);
-          expect(colorFunction['colors']).to.be.empty;
-          const scoopsColumn = colorFunction['columns']['scoops'];
-          expect(scoopsColumn['max']).to.equal(4);
-          expect(scoopsColumn['min']).to.equal(0);
-          expect(scoopsColumn['values']).to.eql(['0', '1', '2', '3', '4']);
+          expect(colorFunction.colors).to.be.empty;
+          const scoopsColumn = colorFunction.columns.scoops;
+          expect(scoopsColumn.max).to.equal(4);
+          expect(scoopsColumn.min).to.equal(0);
+          expect(scoopsColumn.values).to.eql(['0', '1', '2', '3', '4']);
           expect($('#tbody').children('tr').length).to.equal(3);
           expect($('#color-fxn-editor').css('display')).to.equal('block');
         });
@@ -61,10 +61,10 @@ describe('Unit tests for adding layers', () => {
           expect(layers.length).to.equal(1);
           const layer = layers[0];
           const colorFunction = layer.colorFunction;
-          const scoopsColumn = colorFunction['columns']['scoops'];
-          expect(scoopsColumn['max']).to.equal(29);
-          expect(scoopsColumn['min']).to.equal(0);
-          expect(scoopsColumn['values']).to.eql([]);
+          const scoopsColumn = colorFunction.columns.scoops;
+          expect(scoopsColumn.max).to.equal(29);
+          expect(scoopsColumn.min).to.equal(0);
+          expect(scoopsColumn.values).to.eql([]);
         });
   });
 
@@ -83,8 +83,8 @@ describe('Unit tests for adding layers', () => {
         .then(() => {
           expect(setAclStub).to.be.calledOnce;
           const layer = getCurrentLayers()[0];
-          expect(layer.colorFunction['columns']['flavor']['values']).to.eql([
-            'vanilla'
+          expect(layer.colorFunction.columns.flavor.values).to.eql([
+            'vanilla',
           ]);
         });
   });
@@ -118,7 +118,7 @@ describe('Unit tests for adding layers', () => {
       const layer = layers[0];
       expect(layer.assetType).to.equal(LayerType.KML);
       expect(layer.colorFunction).to.be.undefined;
-      expect(layer['urls'].length).to.equal(2);
+      expect(layer.urls.length).to.equal(2);
     });
   });
 });

--- a/cypress/integration/unit_tests/add_layer_test.js
+++ b/cypress/integration/unit_tests/add_layer_test.js
@@ -83,8 +83,9 @@ describe('Unit tests for adding layers', () => {
         .then(() => {
           expect(setAclStub).to.be.calledOnce;
           const layer = getCurrentLayers()[0];
-          expect(layer.colorFunction['columns']['flavor']['values'])
-              .to.eql(['vanilla']);
+          expect(layer.colorFunction['columns']['flavor']['values']).to.eql([
+            'vanilla'
+          ]);
         });
   });
 

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -11,57 +11,57 @@ import {createGoogleMap} from '../../support/test_map';
 const mockData = [{geometry: {type: 'Nonsense'}}];
 
 const colorProperties = {
-  'color': 'yellow',
+  color: 'yellow',
 };
 const mockFirebaseLayers = [
   {
-    'eeName': 'asset0',
-    'assetType': LayerType.FEATURE_COLLECTION,
-    'displayName': 'asset0',
-    'displayOnLoad': true,
-    'colorFunction': colorProperties,
-    'index': 0,
+    eeName: 'asset0',
+    assetType: LayerType.FEATURE_COLLECTION,
+    displayName: 'asset0',
+    displayOnLoad: true,
+    colorFunction: colorProperties,
+    index: 0,
   },
   {
-    'eeName': 'asset1',
-    'assetType': LayerType.FEATURE_COLLECTION,
-    'displayName': 'asset1',
-    'displayOnLoad': false,
-    'colorFunction': colorProperties,
-    'index': 1,
+    eeName: 'asset1',
+    assetType: LayerType.FEATURE_COLLECTION,
+    displayName: 'asset1',
+    displayOnLoad: false,
+    colorFunction: colorProperties,
+    index: 1,
   },
   {
-    'eeName': 'asset2',
-    'assetType': LayerType.FEATURE_COLLECTION,
-    'displayName': 'asset2',
-    'displayOnLoad': false,
-    'colorFunction': colorProperties,
-    'index': 2,
+    eeName: 'asset2',
+    assetType: LayerType.FEATURE_COLLECTION,
+    displayName: 'asset2',
+    displayOnLoad: false,
+    colorFunction: colorProperties,
+    index: 2,
   },
   {
-    'eeName': 'image_asset',
-    'assetType': LayerType.IMAGE,
-    'displayName': 'image',
-    'displayOnLoad': true,
-    'index': 3,
+    eeName: 'image_asset',
+    assetType: LayerType.IMAGE,
+    displayName: 'image',
+    displayOnLoad: true,
+    index: 3,
   },
   {
-    'eeName': 'tile_asset',
-    'assetType': LayerType.MAP_TILES,
-    'urls': ['tile-url1/{X}/{Y}/{Z}', 'tile-url2/{X}/{Y}/{Z}'],
-    'displayName': 'tiles',
-    'displayOnLoad': true,
-    'index': 4,
+    eeName: 'tile_asset',
+    assetType: LayerType.MAP_TILES,
+    urls: ['tile-url1/{X}/{Y}/{Z}', 'tile-url2/{X}/{Y}/{Z}'],
+    displayName: 'tiles',
+    displayOnLoad: true,
+    index: 4,
   },
   {
-    'eeName': 'kml_urls',
-    'assetType': LayerType.KML,
-    'urls': [
+    eeName: 'kml_urls',
+    assetType: LayerType.KML,
+    urls: [
       'https://www.nhc.noaa.gov/storm_graphics/api/AL092017_043adv_CONE.kmz',
     ],
-    'displayName': 'tiles',
-    'displayOnLoad': false,
-    'index': 5,
+    displayName: 'tiles',
+    displayOnLoad: false,
+    index: 5,
   },
 ];
 
@@ -184,12 +184,12 @@ describe('Unit test for toggleLayerOn', () => {
     setUpLayerFailure().then(
         () => addLayer(
             {
-              'eeName': 'asset/does/not/exist',
-              'assetType': LayerType.FEATURE_COLLECTION,
-              'displayName': 'asset1',
-              'displayOnLoad': false,
-              'colorFunction': colorProperties,
-              'index': 3,
+              eeName: 'asset/does/not/exist',
+              assetType: LayerType.FEATURE_COLLECTION,
+              displayName: 'asset1',
+              displayOnLoad: false,
+              colorFunction: colorProperties,
+              index: 3,
             },
             null));
     assertLayerFailure();
@@ -197,23 +197,23 @@ describe('Unit test for toggleLayerOn', () => {
 
   it('fails to toggle on a layer', () => {
     const layer = {
-      'eeName': 'asset/does/not/exist',
-      'assetType': LayerType.FEATURE_COLLECTION,
-      'displayName': 'asset1',
-      'displayOnLoad': false,
-      'colorFunction': colorProperties,
-      'index': failureLayerIndex,
+      eeName: 'asset/does/not/exist',
+      assetType: LayerType.FEATURE_COLLECTION,
+      displayName: 'asset1',
+      displayOnLoad: false,
+      colorFunction: colorProperties,
+      index: failureLayerIndex,
     };
     addNullLayer(layer);
     setUpLayerFailure().then(
         () => toggleLayerOn(
             {
-              'eeName': 'asset/does/not/exist',
-              'assetType': LayerType.FEATURE_COLLECTION,
-              'displayName': 'asset1',
-              'displayOnLoad': false,
-              'colorFunction': colorProperties,
-              'index': failureLayerIndex,
+              eeName: 'asset/does/not/exist',
+              assetType: LayerType.FEATURE_COLLECTION,
+              displayName: 'asset1',
+              displayOnLoad: false,
+              colorFunction: colorProperties,
+              index: failureLayerIndex,
             },
             null));
     assertLayerFailure();
@@ -223,12 +223,12 @@ describe('Unit test for toggleLayerOn', () => {
     setUpLayerFailure().then(
         () => addLayer(
             {
-              'eeName': 'asset/does/not/exist',
-              'assetType': LayerType.IMAGE,
-              'displayName': 'asset1',
-              'displayOnLoad': false,
-              'colorFunction': colorProperties,
-              'index': failureLayerIndex,
+              eeName: 'asset/does/not/exist',
+              assetType: LayerType.IMAGE,
+              displayName: 'asset1',
+              displayOnLoad: false,
+              colorFunction: colorProperties,
+              index: failureLayerIndex,
             },
             null));
     assertLayerFailure();
@@ -579,14 +579,14 @@ describe('Unit test for toggleLayerOn', () => {
     expectNoBlobImages().then(
         () => addLayer(
             {
-              'eeName': 'tile_asset',
-              'assetType': LayerType.MAP_TILES,
-              'urls': [
+              eeName: 'tile_asset',
+              assetType: LayerType.MAP_TILES,
+              urls: [
                 'https://storms.ngs.noaa.gov/storms/tilesd/services/tileserver.php?/20170827-rgb.json',
               ],
-              'displayName': 'tiles',
-              'displayOnLoad': true,
-              'index': 4,
+              displayName: 'tiles',
+              displayOnLoad: true,
+              index: 4,
             },
             map));
     // Experimentally found.
@@ -606,12 +606,12 @@ describe('Unit test for toggleLayerOn', () => {
     cy.stub($, 'getJSON').returns(promise);
     let addLayerPromise = null;
     const layer = {
-      'eeName': 'tile_asset',
-      'assetType': LayerType.MAP_TILES,
-      'urls': ['dummy_url'],
-      'displayName': 'tiles',
-      'displayOnLoad': true,
-      'index': 4,
+      eeName: 'tile_asset',
+      assetType: LayerType.MAP_TILES,
+      urls: ['dummy_url'],
+      displayName: 'tiles',
+      displayOnLoad: true,
+      index: 4,
     };
     expectNoBlobImages().then(() => {
       addLayerPromise = addLayer(layer, map);

--- a/cypress/integration/unit_tests/checkbox_test.js
+++ b/cypress/integration/unit_tests/checkbox_test.js
@@ -15,52 +15,52 @@ const colorProperties = {
 };
 const mockFirebaseLayers = [
   {
-    'ee-name': 'asset0',
-    'asset-type': LayerType.FEATURE_COLLECTION,
-    'display-name': 'asset0',
-    'display-on-load': true,
-    'color-function': colorProperties,
+    'eeName': 'asset0',
+    'assetType': LayerType.FEATURE_COLLECTION,
+    'displayName': 'asset0',
+    'displayOnLoad': true,
+    'colorFunction': colorProperties,
     'index': 0,
   },
   {
-    'ee-name': 'asset1',
-    'asset-type': LayerType.FEATURE_COLLECTION,
-    'display-name': 'asset1',
-    'display-on-load': false,
-    'color-function': colorProperties,
+    'eeName': 'asset1',
+    'assetType': LayerType.FEATURE_COLLECTION,
+    'displayName': 'asset1',
+    'displayOnLoad': false,
+    'colorFunction': colorProperties,
     'index': 1,
   },
   {
-    'ee-name': 'asset2',
-    'asset-type': LayerType.FEATURE_COLLECTION,
-    'display-name': 'asset2',
-    'display-on-load': false,
-    'color-function': colorProperties,
+    'eeName': 'asset2',
+    'assetType': LayerType.FEATURE_COLLECTION,
+    'displayName': 'asset2',
+    'displayOnLoad': false,
+    'colorFunction': colorProperties,
     'index': 2,
   },
   {
-    'ee-name': 'image_asset',
-    'asset-type': LayerType.IMAGE,
-    'display-name': 'image',
-    'display-on-load': true,
+    'eeName': 'image_asset',
+    'assetType': LayerType.IMAGE,
+    'displayName': 'image',
+    'displayOnLoad': true,
     'index': 3,
   },
   {
-    'ee-name': 'tile_asset',
-    'asset-type': LayerType.MAP_TILES,
+    'eeName': 'tile_asset',
+    'assetType': LayerType.MAP_TILES,
     'urls': ['tile-url1/{X}/{Y}/{Z}', 'tile-url2/{X}/{Y}/{Z}'],
-    'display-name': 'tiles',
-    'display-on-load': true,
+    'displayName': 'tiles',
+    'displayOnLoad': true,
     'index': 4,
   },
   {
-    'ee-name': 'kml_urls',
-    'asset-type': LayerType.KML,
+    'eeName': 'kml_urls',
+    'assetType': LayerType.KML,
     'urls': [
       'https://www.nhc.noaa.gov/storm_graphics/api/AL092017_043adv_CONE.kmz',
     ],
-    'display-name': 'tiles',
-    'display-on-load': false,
+    'displayName': 'tiles',
+    'displayOnLoad': false,
     'index': 5,
   },
 ];
@@ -184,11 +184,11 @@ describe('Unit test for toggleLayerOn', () => {
     setUpLayerFailure().then(
         () => addLayer(
             {
-              'ee-name': 'asset/does/not/exist',
-              'asset-type': LayerType.FEATURE_COLLECTION,
-              'display-name': 'asset1',
-              'display-on-load': false,
-              'color-function': colorProperties,
+              'eeName': 'asset/does/not/exist',
+              'assetType': LayerType.FEATURE_COLLECTION,
+              'displayName': 'asset1',
+              'displayOnLoad': false,
+              'colorFunction': colorProperties,
               'index': 3,
             },
             null));
@@ -197,22 +197,22 @@ describe('Unit test for toggleLayerOn', () => {
 
   it('fails to toggle on a layer', () => {
     const layer = {
-      'ee-name': 'asset/does/not/exist',
-      'asset-type': LayerType.FEATURE_COLLECTION,
-      'display-name': 'asset1',
-      'display-on-load': false,
-      'color-function': colorProperties,
+      'eeName': 'asset/does/not/exist',
+      'assetType': LayerType.FEATURE_COLLECTION,
+      'displayName': 'asset1',
+      'displayOnLoad': false,
+      'colorFunction': colorProperties,
       'index': failureLayerIndex,
     };
     addNullLayer(layer);
     setUpLayerFailure().then(
         () => toggleLayerOn(
             {
-              'ee-name': 'asset/does/not/exist',
-              'asset-type': LayerType.FEATURE_COLLECTION,
-              'display-name': 'asset1',
-              'display-on-load': false,
-              'color-function': colorProperties,
+              'eeName': 'asset/does/not/exist',
+              'assetType': LayerType.FEATURE_COLLECTION,
+              'displayName': 'asset1',
+              'displayOnLoad': false,
+              'colorFunction': colorProperties,
               'index': failureLayerIndex,
             },
             null));
@@ -223,11 +223,11 @@ describe('Unit test for toggleLayerOn', () => {
     setUpLayerFailure().then(
         () => addLayer(
             {
-              'ee-name': 'asset/does/not/exist',
-              'asset-type': LayerType.IMAGE,
-              'display-name': 'asset1',
-              'display-on-load': false,
-              'color-function': colorProperties,
+              'eeName': 'asset/does/not/exist',
+              'assetType': LayerType.IMAGE,
+              'displayName': 'asset1',
+              'displayOnLoad': false,
+              'colorFunction': colorProperties,
               'index': failureLayerIndex,
             },
             null));
@@ -579,13 +579,13 @@ describe('Unit test for toggleLayerOn', () => {
     expectNoBlobImages().then(
         () => addLayer(
             {
-              'ee-name': 'tile_asset',
-              'asset-type': LayerType.MAP_TILES,
+              'eeName': 'tile_asset',
+              'assetType': LayerType.MAP_TILES,
               'urls': [
                 'https://storms.ngs.noaa.gov/storms/tilesd/services/tileserver.php?/20170827-rgb.json',
               ],
-              'display-name': 'tiles',
-              'display-on-load': true,
+              'displayName': 'tiles',
+              'displayOnLoad': true,
               'index': 4,
             },
             map));
@@ -606,11 +606,11 @@ describe('Unit test for toggleLayerOn', () => {
     cy.stub($, 'getJSON').returns(promise);
     let addLayerPromise = null;
     const layer = {
-      'ee-name': 'tile_asset',
-      'asset-type': LayerType.MAP_TILES,
+      'eeName': 'tile_asset',
+      'assetType': LayerType.MAP_TILES,
       'urls': ['dummy_url'],
-      'display-name': 'tiles',
-      'display-on-load': true,
+      'displayName': 'tiles',
+      'displayOnLoad': true,
       'index': 4,
     };
     expectNoBlobImages().then(() => {

--- a/cypress/integration/unit_tests/color_function_util_test.js
+++ b/cypress/integration/unit_tests/color_function_util_test.js
@@ -93,8 +93,6 @@ describe('Unit tests for color function utility', () => {
         'color': 'yellow',
       },
     };
-    let currentStyle, color, field;
-
     const td = setUpWithLayer(layer);
     expect(colorFunctionEditor.is(':visible')).to.be.false;
 
@@ -114,6 +112,8 @@ describe('Unit tests for color function utility', () => {
     $('#CONTINUOUS-radio').trigger('change');
     expectOneFirebaseWrite();
     const continuousPropertyPicker = $('#continuous-property-picker');
+    let currentStyle;
+    let color;
     ({currentStyle, color} = getColorFunction());
     expect(currentStyle).to.equal(0);
     expect(color).to.equal('red');
@@ -129,6 +129,7 @@ describe('Unit tests for color function utility', () => {
     $('#DISCRETE-radio').trigger('change');
     expectOneFirebaseWrite();
     const discretePropertyPicker = $('#discrete-property-picker');
+    let field;
     ({currentStyle, field} = getColorFunction());
     expect(currentStyle).to.equal(1);
     expect(td.children().length).to.equal(0);

--- a/cypress/integration/unit_tests/color_function_util_test.js
+++ b/cypress/integration/unit_tests/color_function_util_test.js
@@ -112,9 +112,7 @@ describe('Unit tests for color function utility', () => {
     $('#CONTINUOUS-radio').trigger('change');
     expectOneFirebaseWrite();
     const continuousPropertyPicker = $('#continuous-property-picker');
-    let currentStyle;
-    let color;
-    ({currentStyle, color} = getColorFunction());
+    let {currentStyle, color} = getColorFunction();
     expect(currentStyle).to.equal(0);
     expect(color).to.equal('red');
     expect(continuousPropertyPicker.val()).to.be.null;

--- a/cypress/integration/unit_tests/color_function_util_test.js
+++ b/cypress/integration/unit_tests/color_function_util_test.js
@@ -4,7 +4,7 @@ import {getCurrentLayers} from '../../../docs/import/manage_layers_lib.js';
 import {createTrs, setDisasterAndLayers} from '../../support/import_test_util.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
 
-const property = 'color-function';
+const property = 'colorFunction';
 let writeToFirebaseStub;
 
 describe('Unit tests for color function utility', () => {
@@ -32,8 +32,8 @@ describe('Unit tests for color function utility', () => {
   it('updates min-max values', () => {
     // layer in pre-picking a property state
     const layer = {
-      'color-function': {
-        'current-style': 0,
+      'colorFunction': {
+        'currentStyle': 0,
         'columns': {
           'wings': {'min': 0, 'max': 100, 'values': [0, 1, 2, 100]},
         },
@@ -65,7 +65,7 @@ describe('Unit tests for color function utility', () => {
     expect(maxMin.is(':visible'));
     expect(maxInput.val()).to.equal('20');
     expect(minInput.val()).to.equal('1');
-    const wings = getCurrentLayers()[0]['color-function']['columns']['wings'];
+    const wings = getCurrentLayers()[0]['colorFunction']['columns']['wings'];
     expect(wings['min']).to.equal(1);
     expect(wings['max']).to.equal(20);
 
@@ -83,8 +83,8 @@ describe('Unit tests for color function utility', () => {
 
   it('switches schemas and writes data', () => {
     const layer = {
-      'color-function': {
-        'current-style': 2,
+      'colorFunction': {
+        'currentStyle': 2,
         'columns': {
           'wings': {'min': 0, 'max': 2, 'values': [0, 1, 2]},
           'legs': {'min': 0, 'max': 100, 'values': [0, 2, 4, 8, 100]},
@@ -112,7 +112,7 @@ describe('Unit tests for color function utility', () => {
     $('#CONTINUOUS-radio').trigger('change');
     expectOneFirebaseWrite();
     const continuousPropertyPicker = $('#continuous-property-picker');
-    expect(getColorFunction()['current-style']).to.equal(0);
+    expect(getColorFunction()['currentStyle']).to.equal(0);
     expect(getColorFunction()['color']).to.equal('red');
     expect(continuousPropertyPicker.val()).to.be.null;
 
@@ -126,7 +126,7 @@ describe('Unit tests for color function utility', () => {
     $('#DISCRETE-radio').trigger('change');
     expectOneFirebaseWrite();
     const discretePropertyPicker = $('#discrete-property-picker');
-    expect(getColorFunction()['current-style']).to.equal(1);
+    expect(getColorFunction()['currentStyle']).to.equal(1);
     expect(td.children().length).to.equal(0);
     expect(getColorFunction()['field']).to.equal('wings');
     expect(discretePropertyPicker.val()).to.equal('wings');

--- a/cypress/integration/unit_tests/color_function_util_test.js
+++ b/cypress/integration/unit_tests/color_function_util_test.js
@@ -27,8 +27,6 @@ describe('Unit tests for color function utility', () => {
     colorFunctionEditor.hide();
   });
 
-  afterEach(() => colorFunctionEditor.hide());
-
   it('updates min-max values', () => {
     // layer in pre-picking a property state
     const layer = {

--- a/cypress/integration/unit_tests/color_function_util_test.js
+++ b/cypress/integration/unit_tests/color_function_util_test.js
@@ -65,7 +65,7 @@ describe('Unit tests for color function utility', () => {
     expect(maxMin.is(':visible'));
     expect(maxInput.val()).to.equal('20');
     expect(minInput.val()).to.equal('1');
-    const wings = getCurrentLayers()[0]['colorFunction']['columns']['wings'];
+    const wings = getCurrentLayers()[0].colorFunction.columns.wings;
     expect(wings['min']).to.equal(1);
     expect(wings['max']).to.equal(20);
 
@@ -93,18 +93,20 @@ describe('Unit tests for color function utility', () => {
         'color': 'yellow',
       },
     };
+    let currentStyle, color, field;
+
     const td = setUpWithLayer(layer);
     expect(colorFunctionEditor.is(':visible')).to.be.false;
 
     td.trigger('click');
     expect(colorFunctionEditor.is(':visible')).to.be.true;
     expect(writeToFirebaseStub).to.not.be.called;
-    expect(getColorFunction()['color']).to.equal('yellow');
+    expect(getColorFunction().color).to.equal('yellow');
 
     // update color
     $('#single-color-picker').val('red').trigger('change');
     expectOneFirebaseWrite();
-    expect(getColorFunction()['color']).to.equal('red');
+    expect(getColorFunction().color).to.equal('red');
     expect(td.children().length).to.equal(1);
     expect(td.children().first().css('background-color')).to.equal('red');
 
@@ -112,23 +114,25 @@ describe('Unit tests for color function utility', () => {
     $('#CONTINUOUS-radio').trigger('change');
     expectOneFirebaseWrite();
     const continuousPropertyPicker = $('#continuous-property-picker');
-    expect(getColorFunction()['currentStyle']).to.equal(0);
-    expect(getColorFunction()['color']).to.equal('red');
+    ({currentStyle, color} = getColorFunction());
+    expect(currentStyle).to.equal(0);
+    expect(color).to.equal('red');
     expect(continuousPropertyPicker.val()).to.be.null;
 
     // update field
     continuousPropertyPicker.val('wings').trigger('change');
     expectOneFirebaseWrite();
-    expect(getColorFunction()['field']).to.equal('wings');
+    expect(getColorFunction().field).to.equal('wings');
     expect($('#continuous-color-picker').val()).to.equal('red');
 
     // switch to discrete
     $('#DISCRETE-radio').trigger('change');
     expectOneFirebaseWrite();
     const discretePropertyPicker = $('#discrete-property-picker');
-    expect(getColorFunction()['currentStyle']).to.equal(1);
+    ({currentStyle, field} = getColorFunction());
+    expect(currentStyle).to.equal(1);
     expect(td.children().length).to.equal(0);
-    expect(getColorFunction()['field']).to.equal('wings');
+    expect(field).to.equal('wings');
     expect(discretePropertyPicker.val()).to.equal('wings');
     const discreteColorPickerList = $('#discrete-color-pickers');
     expect(discreteColorPickerList.children('li').length).to.equal(3);
@@ -136,17 +140,17 @@ describe('Unit tests for color function utility', () => {
     // update field
     discretePropertyPicker.val('legs').trigger('change');
     expectOneFirebaseWrite();
-    expect(getColorFunction()['field']).to.equal('legs');
+    expect(getColorFunction().field).to.equal('legs');
 
     // update discrete color
-    expect(getColorFunction()['colors']).to.be.empty;
+    expect(getColorFunction().colors).to.be.empty;
     discreteColorPickerList.children('li')
         .first()
         .children('select')
         .val('orange')
         .trigger('change');
     expectOneFirebaseWrite();
-    expect(getColorFunction()['colors']).to.eql({'0': 'orange'});
+    expect(getColorFunction().colors).to.eql({'0': 'orange'});
     expect(td.children().length).to.equal(1);
     expect(td.children().first().css('background-color')).to.equal('orange');
 

--- a/cypress/integration/unit_tests/firebase_layers_test.js
+++ b/cypress/integration/unit_tests/firebase_layers_test.js
@@ -2,32 +2,32 @@ import {getLinearGradient} from '../../../docs/firebase_layers.js';
 
 it('creates the correct linear gradients', () => {
   const layer1 = {
-    'color-function': {
-      'current-style': 0,
+    'colorFunction': {
+      'currentStyle': 0,
       'color': 'yellow',
     },
   };
 
   const layer2 = {
-    'color-function': {
-      'current-style': 1,
+    'colorFunction': {
+      'currentStyle': 1,
       'colors': ['yellow', 'red'],
     },
   };
 
   const layer3 = {
-    'color-function': {
-      'current-style': 2,
+    'colorFunction': {
+      'currentStyle': 2,
       'color': 'blue',
     },
   };
   const layer1Gradient = 'linear-gradient(to right, white, yellow)';
-  expect(getLinearGradient(layer1['color-function'])).to.equal(layer1Gradient);
+  expect(getLinearGradient(layer1.colorFunction)).to.equal(layer1Gradient);
 
   const layer2Gradient =
       'linear-gradient(to right, yellow 0%, yellow 50%, red 50%, red 100%)';
-  expect(getLinearGradient(layer2['color-function'])).to.equal(layer2Gradient);
+  expect(getLinearGradient(layer2.colorFunction)).to.equal(layer2Gradient);
 
   const layer3Gradient = 'linear-gradient(to right, blue, blue)';
-  expect(getLinearGradient(layer3['color-function'])).to.equal(layer3Gradient);
+  expect(getLinearGradient(layer3.colorFunction)).to.equal(layer3Gradient);
 });

--- a/cypress/integration/unit_tests/manage_disaster_add_delete_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_add_delete_test.js
@@ -41,7 +41,7 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
           expect(createFolderStub).to.be.calledThrice;
           expect(setAclsStub).to.be.calledThrice;
           expect($('#status').is(':visible')).is.false;
-          expect(disasterData.get(id).layers).to.eql([]);
+          expect(disasterData.get(id).layerArray).to.eql([]);
           expect(disasterData.get(id).assetData.stateBasedData)
               .has.property('states', states);
           const disasterPicker = $('#disaster-dropdown');
@@ -78,7 +78,7 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
           const data = doc.data();
           const assetDataClone = deepCopy(stateAssetDataTemplate);
           assetDataClone.stateBasedData.states = states;
-          expect(disasterData.get(id).layers).to.eql([]);
+          expect(disasterData.get(id).layerArray).to.eql([]);
           const {assetData} = data;
           expect(assetData).to.eql(assetDataClone);
           // Sanity-check structure.
@@ -120,7 +120,7 @@ describe('Add/delete-related tests for manage_disaster.js', () => {
         .then((doc) => {
           expect(doc.exists).to.be.true;
           const data = doc.data();
-          expect(data.layers).to.eql([]);
+          expect(data.layerArray).to.eql([]);
           const {assetData} = data;
           expect(assetData).to.eql(flexibleAssetData);
           // Sanity-check structure.

--- a/cypress/integration/unit_tests/manage_layers_test.js
+++ b/cypress/integration/unit_tests/manage_layers_test.js
@@ -137,15 +137,13 @@ describe('Unit tests for manage_layers page', () => {
 
     const yellow = 'yellow';
     const singleColor = withColor(
-        createTd(), {color: {'currentStyle': 2, 'color': yellow}}, property,
-        0);
+        createTd(), {color: {'currentStyle': 2, 'color': yellow}}, property, 0);
     expect(singleColor.children('.box').length).to.equal(1);
     expect(singleColor.children().eq(0).css('background-color'))
         .to.equal(yellow);
 
     const baseColor = withColor(
-        createTd(), {color: {'currentStyle': 0, 'color': yellow}}, property,
-        0);
+        createTd(), {color: {'currentStyle': 0, 'color': yellow}}, property, 0);
     expect(baseColor.children('.box').length).to.equal(1);
     expect(baseColor.children().eq(0).css('background-color')).to.equal(yellow);
 

--- a/cypress/integration/unit_tests/manage_layers_test.js
+++ b/cypress/integration/unit_tests/manage_layers_test.js
@@ -137,14 +137,14 @@ describe('Unit tests for manage_layers page', () => {
 
     const yellow = 'yellow';
     const singleColor = withColor(
-        createTd(), {color: {'current-style': 2, 'color': yellow}}, property,
+        createTd(), {color: {'currentStyle': 2, 'color': yellow}}, property,
         0);
     expect(singleColor.children('.box').length).to.equal(1);
     expect(singleColor.children().eq(0).css('background-color'))
         .to.equal(yellow);
 
     const baseColor = withColor(
-        createTd(), {color: {'current-style': 0, 'color': yellow}}, property,
+        createTd(), {color: {'currentStyle': 0, 'color': yellow}}, property,
         0);
     expect(baseColor.children('.box').length).to.equal(1);
     expect(baseColor.children().eq(0).css('background-color')).to.equal(yellow);
@@ -153,7 +153,7 @@ describe('Unit tests for manage_layers page', () => {
     const discrete = withColor(
         createTd(), {
           color: {
-            'current-style': 1,
+            'currentStyle': 1,
             'colors': {'squash': yellow, 'tomato': red, 'pepper': red},
           },
         },

--- a/cypress/integration/unit_tests/process_joined_data_test.js
+++ b/cypress/integration/unit_tests/process_joined_data_test.js
@@ -85,6 +85,6 @@ describe('Unit test for processed_joined_data.js', () => {
    */
   function assertColorAndOpacity(resultProperties, opacity) {
     expect(resultProperties).to.have.property('color');
-    expect(resultProperties['color']).to.eqls([255, 0, 255, opacity]);
+    expect(resultProperties.color).to.eqls([255, 0, 255, opacity]);
   }
 });

--- a/cypress/integration/unit_tests/style_functions_test.js
+++ b/cypress/integration/unit_tests/style_functions_test.js
@@ -3,7 +3,7 @@ import {colorMap, createStyleFunction} from '../../../docs/firebase_layers.js';
 describe('Unit test for generating style functions', () => {
   it('calculates a discrete function', () => {
     const fxn = createStyleFunction({
-      'current-style': 1,
+      'currentStyle': 1,
       'field': 'flavor',
       'colors': {
         'cherry': 'red',
@@ -20,7 +20,7 @@ describe('Unit test for generating style functions', () => {
 
   it('calculates a continuous function', () => {
     const fxn = createStyleFunction({
-      'current-style': 0,
+      'currentStyle': 0,
       'field': 'oranges',
       'color': 'orange',
       'columns': {'oranges': {'min': 14, 'max': 10005}},
@@ -36,7 +36,7 @@ describe('Unit test for generating style functions', () => {
 
   it('calculates a single-color function', () => {
     const fxn = createStyleFunction({
-      'current-style': 2,
+      'currentStyle': 2,
       'color': 'blue',
     });
     const trueBlue = fxn({});

--- a/cypress/support/import_test_util.js
+++ b/cypress/support/import_test_util.js
@@ -33,7 +33,7 @@ function createTrs(num) {
  */
 function setDisasterAndLayers(layers) {
   const currentDisaster = '2005-fall';
-  disasterData.set(currentDisaster, {layers: layers});
+  disasterData.set(currentDisaster, {layerArray: layers});
   window.localStorage.setItem('disaster', currentDisaster);
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,10 +3,10 @@
 In `disaster-metadata` => `<year>` => `<disaster>` => `layers` we hold a map of \<asset path : `<data>`>
 
 all `<data>` instances contain the following fields:
-* asset-type `{int}`: corresponds to the LayerType enum
-* display-name `{string}`
-* display-on-load `{boolean}`
-* color-function `{Object}` 
+* assetType `{int}`: corresponds to the LayerType enum
+* displayName `{string}`
+* displayOnLoad `{boolean}`
+* colorFunction `{Object}` 
 
 ### LayerType Enum:
 
@@ -16,7 +16,7 @@ all `<data>` instances contain the following fields:
 * Image Collection: 3
 
 ### Color Functions
-We have three types of coloring schemes: continuous, discrete, and single color. Each has a different schema for the <code>color-function</code> object:
+We have three types of coloring schemes: continuous, discrete, and single color. Each has a different schema for the <code>colorFunction</code> object:
 
 #### ColorStyle Enum:
 
@@ -25,7 +25,7 @@ We have three types of coloring schemes: continuous, discrete, and single color.
 * Single Color: 2
 
 **continuous:**
-* current-style `{enum}`: set to 0
+* currentStyle `{enum}`: set to 0
 * color `{string}`: from set of known colors
 * field `{string}`: name of property we're using to calculate color
 * max `{number}`: max value of field
@@ -33,13 +33,13 @@ We have three types of coloring schemes: continuous, discrete, and single color.
 * opacity `{number}`: opacity level
 
 **discrete:**
-* current-style `{enum}`: set to 1
+* currentStyle `{enum}`: set to 1
 * field `{string}`: name of property we're using to calculate color
 * colors `{Map}`: map of field value `{string}` to color `{string}` (from known colors)
 * opacity `{number}`
 
 **single-color:**
-* current-style `{enum}`: set to 2
+* currentStyle `{enum}`: set to 2
 * color `{string}`: from set of known colors
 * opacity `{number}`
 

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -33,7 +33,7 @@ const opacity = 200;
  */
 function createStyleFunction(colorFunctionProperties) {
   const field = colorFunctionProperties['field'];
-  switch (colorFunctionProperties['current-style']) {
+  switch (colorFunctionProperties.currentStyle) {
     case ColorStyle.SINGLE:
       const color = colorMap.get(colorFunctionProperties['color']);
       return () => color;
@@ -121,9 +121,8 @@ function getLinearGradient(colorFunction) {
   if (!colorFunction) {
     return '';
   }
-  const currentStyle = colorFunction['current-style'];
   let gradientString = 'linear-gradient(to right';
-  switch (currentStyle) {
+  switch (colorFunction.currentStyle) {
     case 0:
       gradientString += ', white, ' + colorFunction['color'];
       break;

--- a/docs/import/add_layer.js
+++ b/docs/import/add_layer.js
@@ -24,10 +24,10 @@ function processNewEeLayer(asset, type) {
     case LayerType.IMAGE:
     case LayerType.IMAGE_COLLECTION:
       const layer = {
-        'asset-type': type,
-        'ee-name': asset,
-        'display-name': '',
-        'display-on-load': false,
+        'assetType': type,
+        'eeName': asset,
+        'displayName': '',
+        'displayOnLoad': false,
       };
       return prependToTable(layer);
     case LayerType.FEATURE_COLLECTION:
@@ -51,15 +51,15 @@ function processNewEeLayer(asset, type) {
                  ee.Dictionary.fromLists(properties, stats))
           .then((columns) => {
             const layer = {
-              'asset-type': type,
-              'ee-name': asset,
-              'color-function': {
+              'assetType': type,
+              'eeName': asset,
+              'colorFunction': {
                 'columns': columns,
-                'current-style': 2,
+                'currentStyle': 2,
                 'colors': {},
               },
-              'display-name': '',
-              'display-on-load': false,
+              'displayName': '',
+              'displayOnLoad': false,
             };
             return prependToTable(layer);
           });
@@ -89,10 +89,10 @@ function prependToTable(layer) {
  */
 function processNonEeLayer(type, urls) {
   const layer = {
-    'display-name': '',
-    'asset-type': type,
+    'displayName': '',
+    'assetType': type,
     'urls': urls,
-    'display-on-load': false,
+    'displayOnLoad': false,
   };
   return prependToTable(layer);
 }

--- a/docs/import/color_function_util.js
+++ b/docs/import/color_function_util.js
@@ -455,5 +455,5 @@ function createColorBox(color) {
  */
 function getColorFunction() {
   const index = getRowIndex(globalTd.parents('tr'));
-  return getCurrentLayers()[index]['colorFunction'];
+  return getCurrentLayers()[index].colorFunction;
 }

--- a/docs/import/color_function_util.js
+++ b/docs/import/color_function_util.js
@@ -86,9 +86,8 @@ function populateColorFunctions() {
  */
 function updateTdAndFirestore() {
   const colorFunction = getColorFunction();
-  const style = colorFunction['current-style'];
   globalTd.empty();
-  if (style === ColorStyle.DISCRETE) {
+  if (colorFunction.currentStyle === ColorStyle.DISCRETE) {
     createColorBoxesForDiscrete(colorFunction, globalTd);
   } else {
     globalTd.append(createColorBox(colorFunction['color']));
@@ -267,7 +266,8 @@ function withColor(td, layer, property) {
   if (!colorFunction) {
     return td.text('N/A').addClass('na');
   }
-  switch (colorFunction['current-style']) {
+  const {currentStyle} = colorFunction;
+  switch (currentStyle) {
     case ColorStyle.SINGLE:
       td.append(createColorBox(colorFunction['color']));
       break;
@@ -281,7 +281,7 @@ function withColor(td, layer, property) {
       setStatus(ILLEGAL_STATE_ERR + 'unrecognized color function: ' + layer);
   }
   td.addClass('editable color-td')
-      .on('click', () => onClick(td, colorFunction['current-style']));
+      .on('click', () => onClick(td, currentStyle));
   return td;
 }
 
@@ -333,7 +333,7 @@ function selectCurrentRow(selected) {
  */
 function switchSchema(type) {
   displaySchema(type);
-  getColorFunction()['current-style'] = type;
+  getColorFunction().currentStyle = type;
   return updateTdAndFirestore();
 }
 
@@ -456,5 +456,5 @@ function createColorBox(color) {
  */
 function getColorFunction() {
   const index = getRowIndex(globalTd.parents('tr'));
-  return getCurrentLayers()[index]['color-function'];
+  return getCurrentLayers()[index]['colorFunction'];
 }

--- a/docs/import/color_function_util.js
+++ b/docs/import/color_function_util.js
@@ -280,8 +280,7 @@ function withColor(td, layer, property) {
     default:
       setStatus(ILLEGAL_STATE_ERR + 'unrecognized color function: ' + layer);
   }
-  td.addClass('editable color-td')
-      .on('click', () => onClick(td, currentStyle));
+  td.addClass('editable color-td').on('click', () => onClick(td, currentStyle));
   return td;
 }
 

--- a/docs/import/create_disaster_lib.js
+++ b/docs/import/create_disaster_lib.js
@@ -155,7 +155,7 @@ const flexibleAssetData = Object.freeze(
  * @return {Object}
  */
 function createDisasterData(states) {
-  const result = {layers: []};
+  const result = {layerArray: []};
   if (states) {
     const assetData = deepCopy(stateAssetDataTemplate);
     assetData.stateBasedData.states = states;

--- a/docs/import/manage_layers.js
+++ b/docs/import/manage_layers.js
@@ -272,11 +272,11 @@ function createLayerRow(layer, index) {
   // index
   row.append(createTd().text(index).addClass('index-td'));
   // display name
-  row.append(withInput(createTd(), layer, 'display-name'));
+  row.append(withInput(createTd(), layer, 'displayName'));
   // asset path/url sample
   const assetOrUrl = createTd();
-  if (layer['ee-name']) {
-    withText(assetOrUrl, layer, 'ee-name');
+  if (layer['eeName']) {
+    withText(assetOrUrl, layer, 'eeName');
   } else if (layer['urls']) {
     withList(assetOrUrl, layer, 'urls');
   } else {
@@ -284,11 +284,11 @@ function createLayerRow(layer, index) {
   }
   row.append(assetOrUrl);
   // type
-  row.append(withType(createTd(), layer, 'asset-type'));
+  row.append(withType(createTd(), layer, 'assetType'));
   // display on load
-  row.append(withCheckbox(createTd(), layer, 'display-on-load'));
+  row.append(withCheckbox(createTd(), layer, 'displayOnLoad'));
   // color
-  row.append(withColor(createTd(), layer, 'color-function'));
+  row.append(withColor(createTd(), layer, 'colorFunction'));
   row.append(withDeleteButton(createTd()));
   return row;
 }

--- a/docs/import/manage_layers_lib.js
+++ b/docs/import/manage_layers_lib.js
@@ -42,7 +42,7 @@ function getCurrentData() {
  * @return {Array<Object>}
  */
 function getCurrentLayers() {
-  return getCurrentData()['layerArray'];
+  return getCurrentData().layerArray;
 }
 
 /**

--- a/docs/import/manage_layers_lib.js
+++ b/docs/import/manage_layers_lib.js
@@ -42,7 +42,7 @@ function getCurrentData() {
  * @return {Array<Object>}
  */
 function getCurrentLayers() {
-  return getCurrentData()['layers'];
+  return getCurrentData()['layerArray'];
 }
 
 /**

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -128,7 +128,7 @@ class DeckParams {
 }
 
 DeckParams.fromLayer = (layer) => {
-  return new DeckParams(layer['ee-name'], layer['color-function']);
+  return new DeckParams(layer.eeName, layer.colorFunction);
 };
 
 /**
@@ -165,7 +165,7 @@ function toggleLayerOn(layer, map) {
     // have completed.
     if (layerDisplayData.overlay instanceof CompositeImageMapType) {
       return createCompositeTilePromise(
-          layerDisplayData, index, map, layer['display-name']);
+          layerDisplayData, index, map, layer.displayName);
     }
     return createLoadingAwarePromise((resolve) => {
       resolveOnEeTilesFinished(layerDisplayData, resolve);
@@ -211,8 +211,8 @@ function toggleLayerOff(index, map) {
  * @return {Promise} Promise that completes when layer is processed
  */
 function addImageLayer(map, imageAsset, layer) {
-  const imgStyles = layer['vis-params'];
-  if (layer['use-terrain-style']) {
+  const imgStyles = layer.visParams;
+  if (layer.useTerrainStyle) {
     imageAsset = terrainStyle(imageAsset);
   }
   const index = layer['index'];
@@ -352,13 +352,13 @@ function addTileLayer(map, layer) {
     layerDisplayData.overlay = new CompositeImageMapType({
       // JSON urls each had an array of tile URLS, so flatten them.
       tileUrls: urls.flat(),
-      tileSize: layer['tile-size'],
+      tileSize: layer['tileSize'],
       maxZoom: layer['maxZoom'],
       opacity: layer['opacity'],
     });
     layerDisplayData.pendingPromise = null;
     return createCompositeTilePromise(
-        layerDisplayData, layer['index'], map, layer['display-name']);
+        layerDisplayData, layer['index'], map, layer.displayName);
   });
   return layerDisplayData.pendingPromise;
 }
@@ -399,7 +399,7 @@ function createCompositeTilePromise(
     layerDisplayData.overlay.setTileCallback(
         createTileCallback(layerDisplayData, resolve));
     showOverlayLayer(layerDisplayData.overlay, index, map);
-  }, {'display-name': displayNameForErrors, index});
+  }, {'displayName': displayNameForErrors, index});
 }
 
 /**
@@ -463,18 +463,18 @@ function showColor(color) {
  * @return {Promise} Promise that completes when layer is processed
  */
 function addLayer(layer, map) {
-  switch (layer['asset-type']) {
+  switch (layer.assetType) {
     case LayerType.IMAGE:
-      return addImageLayer(map, ee.Image(layer['ee-name']), layer);
+      return addImageLayer(map, ee.Image(layer.eeName), layer);
     case LayerType.IMAGE_COLLECTION:
       return addImageLayer(
-          map, processImageCollection(layer['ee-name']), layer);
+          map, processImageCollection(layer.eeName), layer);
     case LayerType.FEATURE:
     case LayerType.FEATURE_COLLECTION:
-      const layerName = layer['ee-name'];
+      const layerName = layer.eeName;
       return addLayerFromGeoJsonPromise(
           getEePromiseForFeatureCollection(layerName),
-          DeckParams.fromLayer(layer), layer['index'], layer['display-name']);
+          DeckParams.fromLayer(layer), layer['index'], layer.displayName);
     case LayerType.KML:
       return addKmlLayers(layer, map);
     case LayerType.MAP_TILES:
@@ -482,7 +482,7 @@ function addLayer(layer, map) {
     default:
       // No way this can actually happen, but be ready for it.
       handleErrorLoadingLayer(
-          'Error parsing layer type during add: ' + layer['asset-type'] +
+          'Error parsing layer type during add: ' + layer.assetType +
               ' not recognized layer type',
           layer);
   }
@@ -548,7 +548,7 @@ function addLayerFromGeoJsonPromise(
         addLayerFromFeatures(layerDisplayData, index);
         layerDisplayData.pendingPromise = null;
       }),
-      {'display-name': displayNameForErrors, index});
+      {'displayName': displayNameForErrors, index});
   return layerDisplayData.pendingPromise;
 }
 
@@ -559,7 +559,7 @@ function addLayerFromGeoJsonPromise(
  * @param {Object} layer Data for layer coming from Firestore
  */
 function addNullLayer(layer) {
-  const assetType = layer['asset-type'];
+  const assetType = layer.assetType;
   layerArray[layer['index']] = new LayerDisplayData(
       assetType === LayerType.FEATURE_COLLECTION ||
               assetType === LayerType.FEATURE ?
@@ -649,11 +649,11 @@ function wrapPromiseLoadingAware(promise, layerInfoForErrors) {
  * Shows error and disables layer if an error is encountered loading a layer.
  * @param {string|Error} err
  * @param {Object} layerInfoForErrors Data for layer in same format as coming
- *     from Firestore. Must have `display-name` and `index` properties. Only
+ *     from Firestore. Must have `displayName` and `index` properties. Only
  *     used in case of errors.
  */
 function handleErrorLoadingLayer(err, layerInfoForErrors) {
-  const {index, 'display-name': displayName} = layerInfoForErrors;
+  const {index, displayName} = layerInfoForErrors;
   const notFound = err instanceof AssetNotFoundError;
   const message = err.message ? err.message : err;
   showError(

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -467,8 +467,7 @@ function addLayer(layer, map) {
     case LayerType.IMAGE:
       return addImageLayer(map, ee.Image(layer.eeName), layer);
     case LayerType.IMAGE_COLLECTION:
-      return addImageLayer(
-          map, processImageCollection(layer.eeName), layer);
+      return addImageLayer(map, processImageCollection(layer.eeName), layer);
     case LayerType.FEATURE:
     case LayerType.FEATURE_COLLECTION:
       const layerName = layer.eeName;

--- a/docs/run.js
+++ b/docs/run.js
@@ -81,7 +81,7 @@ function run(map, firebaseAuthPromise, disasterMetadataPromise) {
       setUpToggles(disasterMetadataPromise, map);
   createAndDisplayJoinedData(map, initialTogglesValuesPromise);
   initializeAndProcessUserRegions(map, disasterMetadataPromise);
-  disasterMetadataPromise.then((doc) => addLayers(map, doc.data().layers));
+  disasterMetadataPromise.then((doc) => addLayers(map, doc.data().layerArray));
 }
 
 let mapSelectListener = null;
@@ -178,9 +178,9 @@ function createNewCheckbox(index, displayName, parentDiv) {
  */
 function createNewCheckboxForLayer(layer, parentDiv, map) {
   const index = layer['index'];
-  const newBox = createNewCheckbox(index, layer['display-name'], parentDiv);
-  const linearGradient = getLinearGradient(layer['color-function']);
-  newBox.checked = !!layer['display-on-load'];
+  const newBox = createNewCheckbox(index, layer.displayName, parentDiv);
+  const linearGradient = getLinearGradient(layer.colorFunction);
+  newBox.checked = !!layer.displayOnLoad;
   updateCheckboxBackground(newBox, linearGradient);
 
   newBox.onclick = () => {
@@ -220,7 +220,7 @@ function updateCheckboxBackground(checkbox, gradient) {
 function createCheckboxForUserFeatures(parentDiv) {
   const newBox = createNewCheckbox(
       'user-features', 'user features', parentDiv,
-      {'color': '#4CEF64', 'current-style': 2});
+      {'color': '#4CEF64', 'currentStyle': 2});
   newBox.checked = true;
   newBox.onclick = () => setUserFeatureVisibility(newBox.checked);
 }
@@ -239,7 +239,7 @@ function addLayers(map, firebaseLayers) {
   for (let i = 0; i < firebaseLayers.length; i++) {
     const properties = firebaseLayers[i];
     properties['index'] = i;
-    if (properties['display-on-load']) {
+    if (properties.displayOnLoad) {
       addLayer(properties, map);
     } else {
       addNullLayer(properties);
@@ -249,10 +249,10 @@ function addLayers(map, firebaseLayers) {
   createCheckboxForUserFeatures(sidebarDiv);
   createNewCheckboxForLayer(
       {
-        'display-name': scoreLayerName,
+        'displayName': scoreLayerName,
         'index': scoreLayerName,
-        'display-on-load': true,
-        'color-function': {'color': '#ff00ff', 'current-style': 0},
+        'displayOnLoad': true,
+        'colorFunction': {'color': '#ff00ff', 'currentStyle': 0},
       },
       sidebarDiv, map);
 }


### PR DESCRIPTION
specifically:

asset-type -> assetType
ee-name -> eeName
display-name -> displayName
display-on-load -> displayOnLoad
color-function -> colorFunction
current-style -> currentStyle

and

layers -> layerArray