### PR TITLE
Allow for flexible columns when computing score

### DIFF
--- a/admin_utils/process_firestore.js
+++ b/admin_utils/process_firestore.js
@@ -1,4 +1,6 @@
 import firebaseAdmin from 'firebase-admin';
+import {blockGroupTag, povertyPercentageTag} from '../docs/property_names.js';
+import {BUILDING_COUNT_KEY} from '../docs/import/create_disaster_lib.js';
 
 /**
  * General utility script for modifying Firestore database. Currently configured
@@ -50,18 +52,17 @@ async function getDisastersData(adminApp) {
 async function main() {
   const adminApp = await setUpFirebase();
   const disasters = await getDisastersData(adminApp);
-  // Track all modified keys, to notice errors and know what strings to change.
-  const allKeys = new Set();
   for (const [name, data] of disasters) {
-    const mangledKeys = new Set();
-    const camelData = camelCase(data, mangledKeys);
-    console.log('Keys to be modified for ' + name, mangledKeys);
-    adminApp.firestore().doc('disaster-metadata/' + name).set(camelData, {
+    let damageAssetPath = data.assetData ? data.assetData.damageAssetPath : null;
+    if (!damageAssetPath) {
+      damageAssetPath = null;
+    }
+    adminApp.firestore().doc('disaster-metadata/' + name).set({scoreAssetCreationParameters: {damageAssetPath, povertyRateKey: povertyPercentageTag, districtDescriptionKey: blockGroupTag, buildingKey: BUILDING_COUNT_KEY}}, {
       merge: true,
     });
-    mangledKeys.forEach((key) => allKeys.add(key));
+    // mangledKeys.forEach((key) => allKeys.add(key));
   }
-  console.log('All keys modified:', allKeys);
+  // console.log('All keys modified:', allKeys);
 }
 
 /**

--- a/admin_utils/process_firestore.js
+++ b/admin_utils/process_firestore.js
@@ -1,6 +1,4 @@
 import firebaseAdmin from 'firebase-admin';
-import {blockGroupTag, povertyPercentageTag} from '../docs/property_names.js';
-import {BUILDING_COUNT_KEY} from '../docs/import/create_disaster_lib.js';
 
 /**
  * General utility script for modifying Firestore database. Currently configured
@@ -52,17 +50,18 @@ async function getDisastersData(adminApp) {
 async function main() {
   const adminApp = await setUpFirebase();
   const disasters = await getDisastersData(adminApp);
+  // Track all modified keys, to notice errors and know what strings to change.
+  const allKeys = new Set();
   for (const [name, data] of disasters) {
-    let damageAssetPath = data.assetData ? data.assetData.damageAssetPath : null;
-    if (!damageAssetPath) {
-      damageAssetPath = null;
-    }
-    adminApp.firestore().doc('disaster-metadata/' + name).set({scoreAssetCreationParameters: {damageAssetPath, povertyRateKey: povertyPercentageTag, districtDescriptionKey: blockGroupTag, buildingKey: BUILDING_COUNT_KEY}}, {
+    const mangledKeys = new Set();
+    const camelData = camelCase(data, mangledKeys);
+    console.log('Keys to be modified for ' + name, mangledKeys);
+    adminApp.firestore().doc('disaster-metadata/' + name).set(camelData, {
       merge: true,
     });
-    // mangledKeys.forEach((key) => allKeys.add(key));
+    mangledKeys.forEach((key) => allKeys.add(key));
   }
-  // console.log('All keys modified:', allKeys);
+  console.log('All keys modified:', allKeys);
 }
 
 /**

--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -94,8 +94,7 @@ describe('Unit tests for click_feature.js with map and table', () => {
                                                             'OTHER PERCENTAGE',
                                                           ],
                                                         })),
-          Promise.resolve({districtDescriptionKey: blockGroupTag}),
-          map);
+          Promise.resolve({districtDescriptionKey: blockGroupTag}), map);
     });
     cy.wrap(loadingFinishedPromise);
     return assertNoSelection();
@@ -147,7 +146,8 @@ describe('Unit tests for click_feature.js with map and table', () => {
     assertFeatureShownOnMap(missingPropertiesCorners);
     cy.get('#test-map-div').should('contain', 'SCORE: 4');
     cy.get('#test-map-div').should('contain', 'missing properties group');
-    cy.get('#test-map-div').should('contain', 'OTHER PERCENTAGE: (data unavailable)');
+    cy.get('#test-map-div')
+        .should('contain', 'OTHER PERCENTAGE: (data unavailable)');
   });
 
   /**

--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -2,8 +2,7 @@ import {tableContainerId} from '../../../docs/dom_constants.js';
 import {convertEeObjectToPromise} from '../../../docs/ee_promise_cache.js';
 import {currentFeatures} from '../../../docs/highlight_features';
 import * as loading from '../../../docs/loading.js';
-import {blockGroupTag, geoidTag} from '../../../docs/property_names';
-import {scoreTag} from '../../../docs/property_names.js';
+import {geoidTag, scoreTag} from '../../../docs/property_names.js';
 import * as Resources from '../../../docs/resources.js';
 import {drawTableAndSetUpHandlers, resolveScoreAsset} from '../../../docs/run.js';
 import {cyQueue} from '../../support/commands.js';
@@ -16,6 +15,8 @@ const feature1Corners = [0.25, 0.25, 0.75, 1];
 const feature2Corners = [0.75, 0.25, 1.5, 0.75];
 const zeroScoreCorners = [0, 0, 0.25, 0.25];
 const missingPropertiesCorners = [-0.25, -0.25, 0, 0];
+
+const blockGroupTag = 'district descript';
 
 describe('Unit tests for click_feature.js with map and table', () => {
   loadScriptsBeforeForUnitTests('ee', 'charts', 'maps');
@@ -89,10 +90,11 @@ describe('Unit tests for click_feature.js with map and table', () => {
                                                             geoidTag,
                                                             blockGroupTag,
                                                             scoreTag,
-                                                            'OTHER PERCENTAGE',
                                                             'SOME PROPERTY',
+                                                            'OTHER PERCENTAGE',
                                                           ],
                                                         })),
+          Promise.resolve({districtDescriptionKey: blockGroupTag}),
           map);
     });
     cy.wrap(loadingFinishedPromise);
@@ -145,6 +147,7 @@ describe('Unit tests for click_feature.js with map and table', () => {
     assertFeatureShownOnMap(missingPropertiesCorners);
     cy.get('#test-map-div').should('contain', 'SCORE: 4');
     cy.get('#test-map-div').should('contain', 'missing properties group');
+    cy.get('#test-map-div').should('contain', 'OTHER PERCENTAGE: (data unavailable)');
   });
 
   /**
@@ -181,9 +184,13 @@ describe('Unit tests for click_feature.js with map and table', () => {
     // Rounded because property name ends with 'PERCENTAGE'.
     cy.get('#test-map-div').should('contain', 'OTHER PERCENTAGE: 4.233');
     cy.get('#test-map-div').should('contain', 'SOME PROPERTY: 100');
+    cy.get('#test-map-div').should('not.contain', blockGroupTag);
     cy.get('.google-visualization-table-tr-sel')
         .find('[class="google-visualization-table-td"]')
         .should('have.text', 'my block group');
+    cy.get('.table-header > th').eq(0).should('have.text', blockGroupTag);
+    cy.get('.table-header > th').eq(1).should('have.text', scoreTag);
+    cy.get('.table-header > th').eq(2).should('have.text', 'SOME PROPERTY');
     return assertFeatureShownOnMap(feature1Corners);
   }
 

--- a/cypress/integration/unit_tests/color_function_util_test.js
+++ b/cypress/integration/unit_tests/color_function_util_test.js
@@ -207,8 +207,7 @@ describe('Unit tests for color function utility', () => {
 
   it('tests against real harvey layer', () => {
     setDisaster('2017-harvey');
-    readDisasterDocument().then((doc) => {
-      const {layerArray} = doc.data();
+    readDisasterDocument().then(({layerArray}) => {
       let featureCollectionLayer;
       for (const layer of layerArray) {
         if (layer.assetType === LayerType.FEATURE_COLLECTION) {

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -59,8 +59,8 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     cy.get('#damage-asset-select').select('asset2').blur();
     cy.get('#map-bounds-div').should('not.be.visible');
     readFirestoreAfterWritesFinish().then(
-        ({assetData}) => expect(assetData)
-            .has.property('damageAssetPath', 'asset2'));
+        ({assetData}) =>
+            expect(assetData).has.property('damageAssetPath', 'asset2'));
   });
 
   it('no map coordinates to start', () => {
@@ -94,8 +94,8 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     cy.get('#damage-asset-select').select('asset2').blur();
     cy.get('#map-bounds-div').should('not.be.visible');
     readFirestoreAfterWritesFinish().then(
-        ({assetData}) => expect(assetData)
-            .has.property('damageAssetPath', 'asset2'));
+        ({assetData}) =>
+            expect(assetData).has.property('damageAssetPath', 'asset2'));
   });
 
   const allMandatoryMissingText =
@@ -362,7 +362,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     // written on a different change shows we're not silently overwriting it.
     readFirestoreAfterWritesFinish().then(
         ({assetData}) => expect(assetData.stateBasedData.snapData.paths.NY)
-                     .to.eql(missingSnapPath));
+                             .to.eql(missingSnapPath));
   });
 
   it('does column verification', () => {

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -59,8 +59,8 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     cy.get('#damage-asset-select').select('asset2').blur();
     cy.get('#map-bounds-div').should('not.be.visible');
     readFirestoreAfterWritesFinish().then(
-        (doc) => expect(doc.data().assetData)
-                     .has.property('damageAssetPath', 'asset2'));
+        ({assetData}) => expect(assetData)
+            .has.property('damageAssetPath', 'asset2'));
   });
 
   it('no map coordinates to start', () => {
@@ -94,8 +94,8 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     cy.get('#damage-asset-select').select('asset2').blur();
     cy.get('#map-bounds-div').should('not.be.visible');
     readFirestoreAfterWritesFinish().then(
-        (doc) => expect(doc.data().assetData)
-                     .has.property('damageAssetPath', 'asset2'));
+        ({assetData}) => expect(assetData)
+            .has.property('damageAssetPath', 'asset2'));
   });
 
   const allMandatoryMissingText =
@@ -293,8 +293,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
                 'or map bounds');
     cy.get('#process-button').should('be.disabled');
     // Validate that score data was correctly written
-    readFirestoreAfterWritesFinish().then((doc) => {
-      const {assetData} = doc.data();
+    readFirestoreAfterWritesFinish().then(({assetData}) => {
       expect(assetData.damageAssetPath).to.be.null;
       expect(assetData.stateBasedData.sviAssetPaths).to.eql({'NY': 'state2'});
       expect(assetData.stateBasedData.snapData.paths).to.eql({'NY': null});
@@ -362,7 +361,7 @@ describe('Score parameters-related tests for manage_disaster.js', () => {
     // Data wasn't actually in Firestore before, but checking that it was
     // written on a different change shows we're not silently overwriting it.
     readFirestoreAfterWritesFinish().then(
-        (doc) => expect(doc.data().assetData.stateBasedData.snapData.paths.NY)
+        ({assetData}) => expect(assetData.stateBasedData.snapData.paths.NY)
                      .to.eql(missingSnapPath));
   });
 

--- a/cypress/integration/unit_tests/polygon_draw_firebase_issues_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_firebase_issues_test.js
@@ -34,7 +34,7 @@ describe('Tests for polygon_draw.js with Firebase issues', () => {
     cy.wrap(firebase.auth().signOut());
     setUpDocumentAndReturnMap().then(
         (map) => initializeAndProcessUserRegions(
-            map, Promise.resolve({data: () => ({assetData: {}})})));
+            map, Promise.resolve({scoreAssetCreationParameters: {}})));
     cy.get('[title="Draw a shape"]').should('not.exist');
     cy.get('#' + getCheckBoxRowId('user-features'))
         .should('have.css', 'text-decoration')
@@ -74,7 +74,7 @@ describe('Tests for polygon_draw.js with Firebase issues', () => {
     setUpDocumentAndReturnMap()
         .then(
             (map) => initializeAndProcessUserRegions(
-                map, Promise.resolve({data: () => ({assetData: {}})})))
+                map, Promise.resolve({scoreAssetCreationParameters: {}})))
         .then(() => {
           expect(getFirestoreStub).to.be.calledOnce;
           expect(collectionStub).to.be.calledOnce;

--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -91,11 +91,15 @@ describe('Unit test for ShapeData', () => {
         .then((mapResult) => map = mapResult)
         .then(() => {
           userRegionData.clear();
-          return initializeAndProcessUserRegions(map, Promise.resolve({
-            // Normally damageAssetPath is a string, but code tolerates just
-            // putting an ee.FeatureCollection in.
-            data: () => ({assetData: {damageAssetPath: damageCollection}}),
-          }));
+          return initializeAndProcessUserRegions(
+              map,
+              Promise.resolve(
+                  // Normally damageAssetPath is a string, but code tolerates
+                  // just putting an ee.FeatureCollection in.
+                  {
+                    scoreAssetCreationParameters:
+                        {damageAssetPath: damageCollection},
+                  }));
         })
         .then((drawingManagerResult) => drawingManager = drawingManagerResult);
     // Confirm that drawing controls are visible.
@@ -536,7 +540,7 @@ describe('Unit test for ShapeData', () => {
 
   it('Absence of damage asset tolerated', () => {
     cy.wrap(initializeAndProcessUserRegions(map, Promise.resolve({
-      data: () => ({assetData: {damageAssetPath: null}}),
+      scoreAssetCreationParameters: {damageAssetPath: null},
     })));
     drawPolygon();
     const expectedData = Object.assign({}, defaultData);

--- a/cypress/integration/unit_tests/process_joined_data_test.js
+++ b/cypress/integration/unit_tests/process_joined_data_test.js
@@ -1,5 +1,4 @@
 import {processJoinedData} from '../../../docs/process_joined_data.js';
-import {scoreTag} from '../../../docs/property_names.js';
 
 const featureProperties = {
   'GEOID': '45',
@@ -20,20 +19,38 @@ feature.geometry = geometryObject;
 const joinedDataPromise = {};
 joinedDataPromise.then = (lambda) => lambda([feature]);
 
-const scoreAssetCreationParameters = {povertyRateKey: 'poverty rate', districtDescriptionKey: 'district descript',
-  buildingKey: 'building count key', damageAssetPath: 'damage asset'};
+const scoreAssetCreationParameters = {
+  povertyRateKey: 'poverty rate',
+  districtDescriptionKey: 'district descript',
+  buildingKey: 'building count key',
+  damageAssetPath: 'damage asset',
+};
 const SCORE_COMPUTATION_PARAMETERS = {
-  povertyThreshold: 0.3, damageThreshold: 0.5, povertyWeight: 0.5,
-  scoreAssetCreationParameters};
+  povertyThreshold: 0.3,
+  damageThreshold: 0.5,
+  povertyWeight: 0.5,
+  scoreAssetCreationParameters,
+};
 
 describe('Unit test for processed_joined_data.js', () => {
   it('Processes an above threshold block group', () => {
     cy.wrap(processJoinedData(
-        joinedDataPromise, 100 /* scalingFactor */,
-        Promise.resolve(SCORE_COMPUTATION_PARAMETERS)))
+                joinedDataPromise, 100 /* scalingFactor */,
+                Promise.resolve(SCORE_COMPUTATION_PARAMETERS)))
         .then(({featuresList, columnsFound}) => {
-          expect(columnsFound).to.eql(['GEOID', 'district descript',
-            'SCORE', 'poverty rate', 'DAMAGE PERCENTAGE', 'building count key', 'SNAP HOUSEHOLDS', 'TOTAL HOUSEHOLDS', 'no-damage', 'minor-damage', 'major-damage']);
+          expect(columnsFound).to.eql([
+            'GEOID',
+            'district descript',
+            'SCORE',
+            'poverty rate',
+            'DAMAGE PERCENTAGE',
+            'building count key',
+            'SNAP HOUSEHOLDS',
+            'TOTAL HOUSEHOLDS',
+            'no-damage',
+            'minor-damage',
+            'major-damage',
+          ]);
           expect(featuresList).to.be.an('array');
           expect(featuresList.length).to.equal(1);
           const [returnedFeature] = featuresList;
@@ -54,9 +71,12 @@ describe('Unit test for processed_joined_data.js', () => {
 
   it('Processes uneven weights', () => {
     cy.wrap(processJoinedData(
-        joinedDataPromise, 100 /* scalingFactor */,
-        Promise.resolve(
-            {povertyThreshold: 0.3, damageThreshold: 0.5, povertyWeight: 0.9, scoreAssetCreationParameters})))
+                joinedDataPromise, 100 /* scalingFactor */, Promise.resolve({
+                  povertyThreshold: 0.3,
+                  damageThreshold: 0.5,
+                  povertyWeight: 0.9,
+                  scoreAssetCreationParameters,
+                })))
         .then(({featuresList}) => {
           expect(featuresList).to.be.an('array');
           expect(featuresList.length).to.equal(1);
@@ -76,9 +96,12 @@ describe('Unit test for processed_joined_data.js', () => {
 
   it('Processes a below threshold block group', () => {
     cy.wrap(processJoinedData(
-        joinedDataPromise, 100 /* scalingFactor */,
-        Promise.resolve(
-            {povertyThreshold: 0.9, damageThreshold: 0.5, povertyWeight: 0.5, scoreAssetCreationParameters})))
+                joinedDataPromise, 100 /* scalingFactor */, Promise.resolve({
+                  povertyThreshold: 0.9,
+                  damageThreshold: 0.5,
+                  povertyWeight: 0.5,
+                  scoreAssetCreationParameters,
+                })))
         .then(({featuresList}) => {
           const resultProperties = featuresList[0].properties;
           expect(resultProperties).to.have.property('SCORE', 0);
@@ -87,16 +110,34 @@ describe('Unit test for processed_joined_data.js', () => {
   });
 
   it('Handles no damage', () => {
-    const noDamageScoreAssetCreationParameters = Object.assign({}, scoreAssetCreationParameters);
+    const noDamageScoreAssetCreationParameters =
+        Object.assign({}, scoreAssetCreationParameters);
     noDamageScoreAssetCreationParameters.damageAssetPath = null;
-    cy.wrap(processJoinedData(joinedDataPromise, 100 /* scalingFactor */,
-        Promise.resolve({povertyThreshold: 0.4, damageThreshold: 0.0, povertyWeight: 1.0, scoreAssetCreationParameters: noDamageScoreAssetCreationParameters}))).then(({featuresList, columnsFound}) => {
-          expect(columnsFound).to.eql(['GEOID', 'district descript',
-            'SCORE', 'poverty rate', 'SNAP HOUSEHOLDS', 'TOTAL HOUSEHOLDS', 'no-damage', 'minor-damage',
-            'DAMAGE PERCENTAGE', 'major-damage', 'building count key']);
+    cy.wrap(processJoinedData(
+                joinedDataPromise, 100 /* scalingFactor */, Promise.resolve({
+                  povertyThreshold: 0.4,
+                  damageThreshold: 0.0,
+                  povertyWeight: 1.0,
+                  scoreAssetCreationParameters:
+                      noDamageScoreAssetCreationParameters,
+                })))
+        .then(({featuresList, columnsFound}) => {
+          expect(columnsFound).to.eql([
+            'GEOID',
+            'district descript',
+            'SCORE',
+            'poverty rate',
+            'SNAP HOUSEHOLDS',
+            'TOTAL HOUSEHOLDS',
+            'no-damage',
+            'minor-damage',
+            'DAMAGE PERCENTAGE',
+            'major-damage',
+            'building count key',
+          ]);
           const [returnedFeature] = featuresList;
           expect(returnedFeature.properties).to.have.property('SCORE', 50);
-    });
+        });
   });
 
   /**

--- a/cypress/integration/unit_tests/process_joined_data_test.js
+++ b/cypress/integration/unit_tests/process_joined_data_test.js
@@ -1,15 +1,17 @@
 import {processJoinedData} from '../../../docs/process_joined_data.js';
+import {scoreTag} from '../../../docs/property_names.js';
 
 const featureProperties = {
+  'GEOID': '45',
   'SNAP HOUSEHOLDS': 2,
   'TOTAL HOUSEHOLDS': 4,
-  'SNAP PERCENTAGE': 0.5,
-  'BUILDING COUNT': 27,
-  'BLOCK GROUP': 'block group',
+  'poverty rate': 0.5,
+  'building count key': 27,
+  'district descript': 'block group',
   'no-damage': 12,
   'minor-damage': 10,
-  'major-damage': 5,
   'DAMAGE PERCENTAGE': 15 / 27,
+  'major-damage': 5,
 };
 const feature = {};
 feature.properties = featureProperties;
@@ -18,23 +20,30 @@ feature.geometry = geometryObject;
 const joinedDataPromise = {};
 joinedDataPromise.then = (lambda) => lambda([feature]);
 
+const scoreAssetCreationParameters = {povertyRateKey: 'poverty rate', districtDescriptionKey: 'district descript',
+  buildingKey: 'building count key', damageAssetPath: 'damage asset'};
+const SCORE_COMPUTATION_PARAMETERS = {
+  povertyThreshold: 0.3, damageThreshold: 0.5, povertyWeight: 0.5,
+  scoreAssetCreationParameters};
+
 describe('Unit test for processed_joined_data.js', () => {
   it('Processes an above threshold block group', () => {
-    processJoinedData(
+    cy.wrap(processJoinedData(
         joinedDataPromise, 100 /* scalingFactor */,
-        Promise.resolve(
-            {povertyThreshold: 0.3, damageThreshold: 0.5, povertyWeight: 0.5}))
-        .then((result) => {
-          expect(result).to.be.an('array');
-          expect(result.length).to.equal(1);
-          const returnedFeature = result[0];
+        Promise.resolve(SCORE_COMPUTATION_PARAMETERS)))
+        .then(({featuresList, columnsFound}) => {
+          expect(columnsFound).to.eql(['GEOID', 'district descript',
+            'SCORE', 'poverty rate', 'DAMAGE PERCENTAGE', 'building count key', 'SNAP HOUSEHOLDS', 'TOTAL HOUSEHOLDS', 'no-damage', 'minor-damage', 'major-damage']);
+          expect(featuresList).to.be.an('array');
+          expect(featuresList.length).to.equal(1);
+          const [returnedFeature] = featuresList;
           expect(returnedFeature).to.have.property('geometry', geometryObject);
           expect(returnedFeature).to.haveOwnProperty('properties');
           const resultProperties = returnedFeature.properties;
           // We modify the properties in place.
           expect(resultProperties).to.equal(featureProperties);
           expect(resultProperties)
-              .to.have.property('BLOCK GROUP', 'block group');
+              .to.have.property('district descript', 'block group');
           expect(resultProperties)
               .to.have.property(
                   'SCORE',
@@ -44,19 +53,19 @@ describe('Unit test for processed_joined_data.js', () => {
   });
 
   it('Processes uneven weights', () => {
-    processJoinedData(
+    cy.wrap(processJoinedData(
         joinedDataPromise, 100 /* scalingFactor */,
         Promise.resolve(
-            {povertyThreshold: 0.3, damageThreshold: 0.5, povertyWeight: 0.9}))
-        .then((result) => {
-          expect(result).to.be.an('array');
-          expect(result.length).to.equal(1);
-          const returnedFeature = result[0];
+            {povertyThreshold: 0.3, damageThreshold: 0.5, povertyWeight: 0.9, scoreAssetCreationParameters})))
+        .then(({featuresList}) => {
+          expect(featuresList).to.be.an('array');
+          expect(featuresList.length).to.equal(1);
+          const [returnedFeature] = featuresList;
           expect(returnedFeature).to.have.property('geometry', geometryObject);
           expect(returnedFeature).to.haveOwnProperty('properties');
           const resultProperties = returnedFeature.properties;
           expect(resultProperties)
-              .to.have.property('BLOCK GROUP', 'block group');
+              .to.have.property('district descript', 'block group');
           expect(resultProperties)
               .to.have.property(
                   'SCORE',
@@ -66,15 +75,28 @@ describe('Unit test for processed_joined_data.js', () => {
   });
 
   it('Processes a below threshold block group', () => {
-    processJoinedData(
+    cy.wrap(processJoinedData(
         joinedDataPromise, 100 /* scalingFactor */,
         Promise.resolve(
-            {povertyThreshold: 0.9, damageThreshold: 0.5, povertyWeight: 0.5}))
-        .then((result) => {
-          const resultProperties = result[0].properties;
+            {povertyThreshold: 0.9, damageThreshold: 0.5, povertyWeight: 0.5, scoreAssetCreationParameters})))
+        .then(({featuresList}) => {
+          const resultProperties = featuresList[0].properties;
           expect(resultProperties).to.have.property('SCORE', 0);
           assertColorAndOpacity(resultProperties, 0);
         });
+  });
+
+  it('Handles no damage', () => {
+    const noDamageScoreAssetCreationParameters = Object.assign({}, scoreAssetCreationParameters);
+    noDamageScoreAssetCreationParameters.damageAssetPath = null;
+    cy.wrap(processJoinedData(joinedDataPromise, 100 /* scalingFactor */,
+        Promise.resolve({povertyThreshold: 0.4, damageThreshold: 0.0, povertyWeight: 1.0, scoreAssetCreationParameters: noDamageScoreAssetCreationParameters}))).then(({featuresList, columnsFound}) => {
+          expect(columnsFound).to.eql(['GEOID', 'district descript',
+            'SCORE', 'poverty rate', 'SNAP HOUSEHOLDS', 'TOTAL HOUSEHOLDS', 'no-damage', 'minor-damage',
+            'DAMAGE PERCENTAGE', 'major-damage', 'building count key']);
+          const [returnedFeature] = featuresList;
+          expect(returnedFeature.properties).to.have.property('SCORE', 50);
+    });
   });
 
   /**

--- a/cypress/integration/unit_tests/update_test.js
+++ b/cypress/integration/unit_tests/update_test.js
@@ -1,5 +1,4 @@
 import * as ErrorLib from '../../../docs/error.js';
-import {disasterData, getCurrentData} from '../../../docs/import/manage_layers_lib.js';
 import * as LayerUtil from '../../../docs/layer_util.js';
 import * as Run from '../../../docs/run.js';
 import {setUpScoreComputationParameters} from '../../../docs/update.js';
@@ -27,9 +26,8 @@ describe('Unit test for updates.js', () => {
   });
 
   it('does not have a damage asset', () => {
-    const nullData = {assetData: {damageAssetPath: null}};
-    cy.wrap(setUpScoreComputationParameters(
-        Promise.resolve({data: () => nullData}), {}));
+    const nullData = {scoreAssetCreationParameters: {damageAssetPath: null}};
+    cy.wrap(setUpScoreComputationParameters(Promise.resolve(nullData), {}));
     cy.get('input').should('have.length', 2);
     cy.get('[id="poverty threshold"]').clear().type('0.05');
     cy.get('#update').click().then(() => assertDisplayCalledWith(1, 0.3, 0));
@@ -112,9 +110,7 @@ describe('Unit test for updates.js', () => {
  * @return {Cypress.Chainable<Array<number>>}
  */
 function setUpDamageAsset() {
-  const currentDisaster = '2005-fall';
-  disasterData.set(currentDisaster, {assetData: {damageAssetPath: 'foo'}});
-  window.localStorage.setItem('disaster', currentDisaster);
-  return cy.wrap(setUpScoreComputationParameters(
-      Promise.resolve({data: getCurrentData}), {}));
+  const currentData = {scoreAssetCreationParameters: {damageAssetPath: 'foo'}};
+  return cy.wrap(
+      setUpScoreComputationParameters(Promise.resolve(currentData), {}));
 }

--- a/cypress/integration/unit_tests/update_test.js
+++ b/cypress/integration/unit_tests/update_test.js
@@ -2,7 +2,7 @@ import * as ErrorLib from '../../../docs/error.js';
 import {disasterData, getCurrentData} from '../../../docs/import/manage_layers_lib.js';
 import * as LayerUtil from '../../../docs/layer_util.js';
 import * as Run from '../../../docs/run.js';
-import {setUpScoreParameters} from '../../../docs/update.js';
+import {setUpScoreComputationParameters} from '../../../docs/update.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
 
 describe('Unit test for updates.js', () => {
@@ -28,7 +28,8 @@ describe('Unit test for updates.js', () => {
 
   it('does not have a damage asset', () => {
     const nullData = {assetData: {damageAssetPath: null}};
-    cy.wrap(setUpScoreParameters(Promise.resolve({data: () => nullData}), {}));
+    cy.wrap(setUpScoreComputationParameters(
+        Promise.resolve({data: () => nullData}), {}));
     cy.get('input').should('have.length', 2);
     cy.get('[id="poverty threshold"]').clear().type('0.05');
     cy.get('#update').click().then(() => assertDisplayCalledWith(1, 0.3, 0));
@@ -114,6 +115,6 @@ function setUpDamageAsset() {
   const currentDisaster = '2005-fall';
   disasterData.set(currentDisaster, {assetData: {damageAssetPath: 'foo'}});
   window.localStorage.setItem('disaster', currentDisaster);
-  return cy.wrap(
-      setUpScoreParameters(Promise.resolve({data: getCurrentData}), {}));
+  return cy.wrap(setUpScoreComputationParameters(
+      Promise.resolve({data: getCurrentData}), {}));
 }

--- a/cypress/integration/unit_tests/update_test.js
+++ b/cypress/integration/unit_tests/update_test.js
@@ -2,7 +2,7 @@ import * as ErrorLib from '../../../docs/error.js';
 import {disasterData, getCurrentData} from '../../../docs/import/manage_layers_lib.js';
 import * as LayerUtil from '../../../docs/layer_util.js';
 import * as Run from '../../../docs/run.js';
-import {setUpToggles} from '../../../docs/update.js';
+import {setUpScoreParameters} from '../../../docs/update.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
 
 describe('Unit test for updates.js', () => {
@@ -28,7 +28,7 @@ describe('Unit test for updates.js', () => {
 
   it('does not have a damage asset', () => {
     const nullData = {assetData: {damageAssetPath: null}};
-    cy.wrap(setUpToggles(Promise.resolve({data: () => nullData}), {}));
+    cy.wrap(setUpScoreParameters(Promise.resolve({data: () => nullData}), {}));
     cy.get('input').should('have.length', 2);
     cy.get('[id="poverty threshold"]').clear().type('0.05');
     cy.get('#update').click().then(() => assertDisplayCalledWith(1, 0.3, 0));
@@ -114,5 +114,5 @@ function setUpDamageAsset() {
   const currentDisaster = '2005-fall';
   disasterData.set(currentDisaster, {assetData: {damageAssetPath: 'foo'}});
   window.localStorage.setItem('disaster', currentDisaster);
-  return cy.wrap(setUpToggles(Promise.resolve({data: getCurrentData}), {}));
+  return cy.wrap(setUpScoreParameters(Promise.resolve({data: getCurrentData}), {}));
 }

--- a/cypress/integration/unit_tests/update_test.js
+++ b/cypress/integration/unit_tests/update_test.js
@@ -114,5 +114,6 @@ function setUpDamageAsset() {
   const currentDisaster = '2005-fall';
   disasterData.set(currentDisaster, {assetData: {damageAssetPath: 'foo'}});
   window.localStorage.setItem('disaster', currentDisaster);
-  return cy.wrap(setUpScoreParameters(Promise.resolve({data: getCurrentData}), {}));
+  return cy.wrap(
+      setUpScoreParameters(Promise.resolve({data: getCurrentData}), {}));
 }

--- a/cypress/support/firestore_map_bounds.js
+++ b/cypress/support/firestore_map_bounds.js
@@ -11,9 +11,8 @@ export {assertFirestoreMapBounds, expectLatLngBoundsWithin};
  */
 function assertFirestoreMapBounds(expectedLatLngBounds) {
   // Make sure we don't call readDisasterDocument until Cypress is ready.
-  cyQueue(readDisasterDocument).then((doc) => {
+  cyQueue(readDisasterDocument).then(({mapBounds}) => {
     // Expect that result retrieved from Firestore is correct.
-    const {mapBounds} = doc.data();
     expectLatLngBoundsWithin(
         {
           sw: makeLatLngFromGeoPoint(mapBounds.sw),

--- a/docs/click_feature.js
+++ b/docs/click_feature.js
@@ -91,8 +91,10 @@ function createHtmlForPopup(feature, rowData, scoreParameters, columns) {
     if (value && column.endsWith(' PERCENTAGE')) {
       value = parseFloat(value).toFixed(3);
     }
-    property.innerText = column + ': ' +
-        (value !== null && value !== undefined ? value : '(data unavailable)');
+    property.innerHTML = column + ': ' +
+        (value !== null && value !== undefined ?
+             value :
+             '<span class="data-unavailable-span">(data unavailable)</span>');
     properties.appendChild(property);
   }
   div.appendChild(heading);

--- a/docs/click_feature.js
+++ b/docs/click_feature.js
@@ -1,6 +1,6 @@
 import {showError} from './error.js';
 import {currentFeatures, highlightFeatures} from './highlight_features.js';
-import {blockGroupTag, geoidTag, scoreTag} from './property_names.js';
+import {geoidTag, scoreTag} from './property_names.js';
 
 export {clickFeature, selectHighlightedFeatures};
 
@@ -14,8 +14,11 @@ export {clickFeature, selectHighlightedFeatures};
  * @param {string|ee.FeatureCollection} featuresAsset asset (path) of features
  *     which could be clicked
  * @param {Function} tableSelector See drawTable
+ * @param {ScoreParameters} scoreParameters Needed for `districtDescriptionKey`
+ * @param {Array<EeColumn>} columns Properties to show on click
  */
-function clickFeature(lng, lat, map, featuresAsset, tableSelector, scoreParameters, columns) {
+function clickFeature(
+    lng, lat, map, featuresAsset, tableSelector, scoreParameters, columns) {
   const point = ee.Geometry.Point(lng, lat);
   const blockGroups = ee.FeatureCollection(featuresAsset).filterBounds(point);
   const selected = blockGroups.first();
@@ -37,7 +40,8 @@ function clickFeature(lng, lat, map, featuresAsset, tableSelector, scoreParamete
       highlightFeatures([feature], map);
       const rowData = tableSelector([geoid]);
       const infoWindow = new google.maps.InfoWindow();
-      infoWindow.setContent(createHtmlForPopup(feature, rowData, scoreParameters, columns));
+      infoWindow.setContent(
+          createHtmlForPopup(feature, rowData, scoreParameters, columns));
       const borderPoint = feature.geometry.coordinates[0][0];
       infoWindow.setPosition(
           new google.maps.LatLng({lat: borderPoint[1], lng: borderPoint[0]}));
@@ -57,6 +61,8 @@ const HIDDEN_PROPERTIES = Object.freeze(new Set([
  * @param {Feature} feature post-evaluate JSON feature
  * @param {?Array<string>} rowData Data from selected row in table for this
  *     feature, if found
+ * @param {ScoreParameters} scoreParameters
+ * @param {Array<EeColumn>} columns
  * @return {HTMLDivElement} Div with information
  */
 function createHtmlForPopup(feature, rowData, scoreParameters, columns) {
@@ -85,7 +91,8 @@ function createHtmlForPopup(feature, rowData, scoreParameters, columns) {
     if (value && column.endsWith(' PERCENTAGE')) {
       value = parseFloat(value).toFixed(3);
     }
-    property.innerText = column + ': ' + (value !== null && value !== undefined ? value : '(data unavailable)');
+    property.innerText = column + ': ' +
+        (value !== null && value !== undefined ? value : '(data unavailable)');
     properties.appendChild(property);
   }
   div.appendChild(heading);

--- a/docs/create_map.js
+++ b/docs/create_map.js
@@ -13,15 +13,13 @@ const placeIconParams = {
 /**
  * Creates, initializes and returns a map with search box and drawing tools.
  *
- * @param {Promise<firebase.firestore.DocumentSnapshot>} firebasePromise Promise
- *     with disaster metadata
+ * @param {Promise<DisasterDocument>} firebasePromise
  * @return {google.maps.Map}
  */
 function createMap(firebasePromise) {
   const {map, searchBox} = createBasicMap(document.getElementById('map'));
 
-  firebasePromise.then((doc) => {
-    const {mapBounds} = doc.data();
+  firebasePromise.then(({mapBounds}) => {
     map.fitBounds(new google.maps.LatLngBounds(
         new google.maps.LatLng(geoPointToLatLng(mapBounds.sw)),
         new google.maps.LatLng(geoPointToLatLng(mapBounds.ne))));

--- a/docs/disaster_picker.js
+++ b/docs/disaster_picker.js
@@ -4,8 +4,8 @@ export {initializeDisasterPicker};
 
 /**
  * Initializes the disaster picker.
- * @param {Promise<Map<string, Object>>} firebaseDataPromise Promise with data
- *     for all disasters
+ * @param {Promise<Map<string, DisasterDocument>>} firebaseDataPromise Promise
+ *     with data for all disasters
  * @param {?Function} changeDisasterHandler Function invoked when current
  *     disaster is changed. location.reload is called if null
  */

--- a/docs/draw_table.js
+++ b/docs/draw_table.js
@@ -8,7 +8,8 @@ export {drawTable};
  * Displays a ranked table of the given features that have non-zero score. Sets
  * up handlers for clicking on the table and highlighting features on the map.
  *
- * @param {Promise} scoredFeaturesAndColumns
+ * @param {Promise<{featuresList: Array<GeoJsonFeature>, columnsFound:
+ *     Array<EeColumn>}>} scoredFeaturesAndColumns
  * @param {google.maps.Map} map
  * @return {Promise<Function>} Promise for a function that takes an iterable of
  *     strings and selects rows in the table whose geoids are those strings. The

--- a/docs/firestore_document.js
+++ b/docs/firestore_document.js
@@ -30,12 +30,18 @@ function disasterDocumentReference() {
 }
 
 /**
+ * Object with all Firestore metadata for the current disaster (everything under
+ * `disaster-metadata/2017-harvey`, for instance).
+ * @typedef {Object} DisasterDocument
+ */
+
+/**
  * Fetches the document with all metadata for the current disaster. Should only
  * be called once to avoid excessive fetches.
- * @return {Promise<firebase.firestore.DocumentSnapshot>}
+ * @return {Promise<DisasterDocument>}
  */
 function readDisasterDocument() {
-  return disasterDocumentReference().get();
+  return disasterDocumentReference().get().then((doc) => doc.data());
 }
 
 /** @return {firebase.firestore.CollectionReference} all disasters collection */
@@ -48,7 +54,7 @@ function getDisasters() {
   return disasterCollectionReference().get();
 }
 
-/** @return {Promise<Map<string, Object>>} data for all disasters */
+/** @return {Promise<Map<string, DisasterDocument>>} data for all disasters */
 function getDisastersData() {
   const disasterData = new Map();
   return getDisasters()

--- a/docs/import/create_disaster_lib.js
+++ b/docs/import/create_disaster_lib.js
@@ -123,7 +123,8 @@ const stateAssetDataTemplate = Object.freeze(
  *     Asset can contain geometries (in which case each geometry corresponds to
  *     a building), or just have rows, in which case each row has a building
  *     count that will be joined to the poverty asset. `buildingGeoid` will
- *     be the joining column and `buildingKey` the column with the count.
+ *     be the joining column to the poverty asset's `povertyGeoid` and
+ *     `buildingKey` the column with the count.
  * @param {number} POVERTY Indicates that poverty asset already has a building
  *     count per district. `buildingKey` will identify the column.
  * @param {number} DAMAGE Indicates that damage asset contains geometries for

--- a/docs/import/create_disaster_lib.js
+++ b/docs/import/create_disaster_lib.js
@@ -145,7 +145,7 @@ const BuildingSource = {
  * @property {EeFC} povertyPath Contains poverty data. May have geometries, in
  *     which case `geographyPath` is not used. May have building counts, in
  *     which case `buildingPath` is not used. All columns from this asset end up
- *     in final score asset. Must have {@link povertyPercentageTag} column.
+ *     in final score asset.
  * @property {EeColumn} povertyGeoid Column of `povertyPath` that contains
  *     district-identifying string ("district identifier").
  * @property {EeColumn} povertyRateKey Column of `povertyPath` that

--- a/docs/import/create_disaster_lib.js
+++ b/docs/import/create_disaster_lib.js
@@ -122,15 +122,16 @@ const stateAssetDataTemplate = Object.freeze(
  * @param {number} BUILDING Indicates that there is a separate buildings asset.
  *     Asset can contain geometries (in which case each geometry corresponds to
  *     a building), or just have rows, in which case each row has a building
- *     count that will be joined to the poverty asset.
- * @param {number} POVERTY Indicates that poverty asset already has building
- *     count.
+ *     count that will be joined to the poverty asset. `buildingGeoid` will
+ *     be the joining column and `buildingKey` the column with the count.
+ * @param {number} POVERTY Indicates that poverty asset already has a building
+ *     count per district. `buildingKey` will identify the column.
  * @param {number} DAMAGE Indicates that damage asset contains geometries for
  *     all buildings, not just damaged ones, so the building count can be taken
  *     from it. If specified, `flexibleData` fields `noDamageKey` and
- *     `noDamageValue` must be set if `assetData.damageAssetPath` is. (If the
- *     damage asset is not specified, the score asset can be created, without
- *     damage or buildings.)
+ *     `noDamageValue` must be set if `assetData.damageAssetPath` is. (If this
+ *     is set but the damage asset is not specified, the score asset can be
+ *     created, without damage or buildings.)
  */
 const BuildingSource = {
   BUILDING: 1,

--- a/docs/import/create_disaster_lib.js
+++ b/docs/import/create_disaster_lib.js
@@ -5,7 +5,7 @@ export {
   incomeKey,
   snapKey,
   sviKey,
-  totalKey
+  totalKey,
 };
 // For testing
 export {deepCopy, flexibleAssetData, stateAssetDataTemplate};

--- a/docs/import/create_disaster_lib.js
+++ b/docs/import/create_disaster_lib.js
@@ -1,5 +1,12 @@
 export {createDisasterData};
-export {BUILDING_COUNT_KEY, incomeKey, snapKey, sviKey, totalKey};
+export {
+  BUILDING_COUNT_KEY,
+  BuildingSource,
+  incomeKey,
+  snapKey,
+  sviKey,
+  totalKey
+};
 // For testing
 export {deepCopy, flexibleAssetData, stateAssetDataTemplate};
 
@@ -33,10 +40,6 @@ const BUILDING_COUNT_KEY = 'BUILDING COUNT';
  *     contains undamaged buildings, this must be specified.
  * @property {string} [noDamageValue] The value of `noDamageKey` that indicates
  *     that a building is undamaged.
- * @property {boolean} useDamageForBuildings Whether the damage asset should be
- *     used to compute the total number of buildings. Ignored for state-based
- *     disasters. If specified, `damageAssetPath`, `noDamageKey`,
- *     `noDamageValue` must all be set.
  * @property {Array<firebase.firestore.GeoPoint>} [scoreBoundsCoordinates]
  *     Coordinates of polygon that score asset should be restricted to. Only
  *     used if `damageAssetPath` not specified: if `damageAssetPath` is
@@ -47,7 +50,6 @@ const commonAssetDataTemplate = Object.freeze({
   damageAssetPath: null,
   noDamageKey: null,
   noDamageValue: null,
-  useDamageForBuildings: false,
   scoreBoundsCoordinates: null,
 });
 
@@ -115,6 +117,28 @@ const stateAssetDataTemplate = Object.freeze(
     {...commonAssetDataTemplate, stateBasedData: stateBasedDataTemplate});
 
 /**
+ * Where building count comes from.
+ * @type {Object}
+ * @param {number} BUILDING Indicates that there is a separate buildings asset.
+ *     Asset can contain geometries (in which case each geometry corresponds to
+ *     a building), or just have rows, in which case each row has a building
+ *     count that will be joined to the poverty asset.
+ * @param {number} POVERTY Indicates that poverty asset already has building
+ *     count.
+ * @param {number} DAMAGE Indicates that damage asset contains geometries for
+ *     all buildings, not just damaged ones, so the building count can be taken
+ *     from it. If specified, `flexibleData` fields `noDamageKey` and
+ *     `noDamageValue` must be set if `assetData.damageAssetPath` is. (If the
+ *     damage asset is not specified, the score asset can be created, without
+ *     damage or buildings.)
+ */
+const BuildingSource = {
+  BUILDING: 1,
+  POVERTY: 2,
+  DAMAGE: 3,
+};
+
+/**
  * Has data for a "flexible" (non-Census-based) disaster.
  * @type {Readonly<Object>}
  * @property {EeFC} povertyPath Contains poverty data. May have geometries, in
@@ -123,25 +147,40 @@ const stateAssetDataTemplate = Object.freeze(
  *     in final score asset. Must have {@link povertyPercentageTag} column.
  * @property {EeColumn} povertyGeoid Column of `povertyPath` that contains
  *     district-identifying string ("district identifier").
+ * @property {EeColumn} povertyRateKey Column of `povertyPath` that
+ *     contains poverty rate, as a number between 0 and 1, for use in score.
+ * @property {EeColumn} districtDescriptionKey Column of `povertyPath` that
+ *     contains human-readable description of each district, for display on map.
+ * @property {EeColumn} povertyGeoid Column of `povertyPath` that contains
+ *     district-identifying string ("district identifier").
+ * @property {boolean} povertyHasGeometry Whether the poverty asset has
+ *     geometries for its districts. If not, `geographyPath` must be specified.
  * @property {EeFC} [geographyPath] Contains geometries of districts.
  * @property {EeColumn} [geographyGeoid] Column of `geographyPath` that contains
  *     district identifier.
+ * @property {BuildingSource} buildingSource Where the building count comes
+ *     from.
  * @property {EeFC} [buildingPath] Contains building data. If buildings
  *     have geometries, building counts per district will be computed by
  *     geographic intersection. If there are no geometries, each row is a
  *     per-district count of buildings.
  * @property {EeColumn} [buildingGeoid] If `buildingPath` contains per-district
  *     counts of buildings, indicates the column that has district identifier.
- * @property {EeColumn} [buildingKey] If `buildingPath` contains per-district
- *     counts of buildings, indicates the column that has counts. If
- *     `buildingPath` is not specified and `useDamageForBuildings` is false,
- *     indicates the column of `povertyPath` that has counts.
+ * @property {EeColumn} [buildingKey] If `buildingSource` is {@link
+ * BuildingSource.BUILDING}, indicates the column of `buildingPath` that has
+ * counts. If `buildingSource` is {@link BuildingSource.POVERTY}, indicates the
+ * column of `povertyPath` that has counts.
  */
 const flexibleDataTemplate = Object.freeze({
   povertyPath: null,
+  povertyRateKey: null,
+  districtDescriptionKey: null,
   povertyGeoid: null,
+  povertyHasGeometry: false,
   geographyPath: null,
   buildingPath: null,
+  buildingSource: null,
+  buildingKey: null,
 });
 
 const flexibleAssetData = Object.freeze(

--- a/docs/import/create_disaster_lib.js
+++ b/docs/import/create_disaster_lib.js
@@ -134,11 +134,11 @@ const stateAssetDataTemplate = Object.freeze(
  *     is set but the damage asset is not specified, the score asset can be
  *     created, without damage or buildings.)
  */
-const BuildingSource = {
+const BuildingSource = Object.freeze({
   BUILDING: 1,
   POVERTY: 2,
   DAMAGE: 3,
-};
+});
 
 /**
  * Has data for a "flexible" (non-Census-based) disaster.
@@ -149,17 +149,18 @@ const BuildingSource = {
  *     in final score asset.
  * @property {EeColumn} povertyGeoid Column of `povertyPath` that contains
  *     district-identifying string ("district identifier").
+ *     {@link censusGeoidKey} for Census data.
  * @property {EeColumn} povertyRateKey Column of `povertyPath` that
  *     contains poverty rate, as a number between 0 and 1, for use in score.
+ *     {@link POVERTY_PERCENTAGE_TAG} for Census data.
  * @property {EeColumn} districtDescriptionKey Column of `povertyPath` that
  *     contains human-readable description of each district, for display on map.
- * @property {EeColumn} povertyGeoid Column of `povertyPath` that contains
- *     district-identifying string ("district identifier").
+ *     {@link censusBlockGroupKey} for Census data.
  * @property {boolean} povertyHasGeometry Whether the poverty asset has
  *     geometries for its districts. If not, `geographyPath` must be specified.
  * @property {EeFC} [geographyPath] Contains geometries of districts.
  * @property {EeColumn} [geographyGeoid] Column of `geographyPath` that contains
- *     district identifier.
+ *     district identifier. {@link tigerGeoidKey} for Census data.
  * @property {BuildingSource} buildingSource Where the building count comes
  *     from.
  * @property {EeFC} [buildingPath] Contains building data. If buildings

--- a/docs/import/create_score_asset.js
+++ b/docs/import/create_score_asset.js
@@ -407,6 +407,7 @@ function createScoreAssetForFlexibleDisaster(
   const {povertyGeoid, povertyHasGeometry, buildingSource} = flexibleData;
   let {buildingKey} = flexibleData;
   if (!buildingKey) {
+    // If buildings have geometries, buildingKey will be null.
     buildingKey = BUILDING_COUNT_KEY;
   }
   // First thing we do is add geographies if necessary and restrict to the
@@ -505,7 +506,7 @@ async function backUpAssetAndStartTask(
     // These checks aren't perfect detection, but best we can do.
     if (renameErr.includes('does not exist')) {
     } else if (renameErr.includes('Cannot overwrite asset')) {
-      // Delete and try again.
+      // Delete existing backup asset and try again.
       await new Promise(
           (deleteResolve, deleteReject) =>
               ee.data.deleteAsset(oldScoreAssetPath, (_, deleteErr) => {

--- a/docs/import/create_score_asset.js
+++ b/docs/import/create_score_asset.js
@@ -13,6 +13,7 @@ export {
   createScoreAssetForStateBasedDisaster,
   setStatus,
 };
+
 // For testing.
 export {backUpAssetAndStartTask};
 

--- a/docs/import/create_score_asset.js
+++ b/docs/import/create_score_asset.js
@@ -1,7 +1,7 @@
 import {transformEarthEngineFailureMessage} from '../ee_promise_cache.js';
 import {disasterDocumentReference} from '../firestore_document.js';
 import {inProduction} from '../in_test_util.js';
-import {blockGroupTag, damageTag, geoidTag, povertyHouseholdsTag, povertyPercentageTag, totalHouseholdsTag} from '../property_names.js';
+import {damageTag, geoidTag, povertyHouseholdsTag, totalHouseholdsTag} from '../property_names.js';
 import {getBackupScoreAssetPath, getScoreAssetPath} from '../resources.js';
 
 import {computeAndSaveBounds} from './center.js';
@@ -16,10 +16,14 @@ export {
 // For testing.
 export {backUpAssetAndStartTask};
 
+// State-based tags.
+
 const TRACT_TAG = 'TRACT';
 const SVI_TAG = 'SVI';
 // Median household income in the past 12 months.
 const INCOME_TAG = 'MEDIAN INCOME';
+const BLOCK_GROUP_TAG = 'BLOCK GROUP';
+const POVERTY_PERCENTAGE_TAG = 'SNAP PERCENTAGE';
 
 /**
  * Given a dictionary of building counts per district, attach the count to each
@@ -169,13 +173,13 @@ function combineWithSnap(feature, snapKey, totalKey) {
       ee.Feature(feature.get('secondary')).geometry(), ee.Dictionary([
         geoidTag,
         snapFeature.get(censusGeoidKey),
-        blockGroupTag,
+        BLOCK_GROUP_TAG,
         snapFeature.get(censusBlockGroupKey),
         povertyHouseholdsTag,
         snapPop,
         totalHouseholdsTag,
         totalPop,
-        povertyPercentageTag,
+        POVERTY_PERCENTAGE_TAG,
         snapPercentage,
       ]));
 }
@@ -355,8 +359,8 @@ function createScoreAssetForStateBasedDisaster(
   return backUpAssetAndStartTask(
       allStatesProcessing, {
         buildingKey: BUILDING_COUNT_KEY,
-        districtDescriptionKey: blockGroupTag,
-        povertyRateKey: povertyPercentageTag,
+        districtDescriptionKey: BLOCK_GROUP_TAG,
+        povertyRateKey: POVERTY_PERCENTAGE_TAG,
         damageAssetPath: getDamageAssetPath(assetData),
       },
       disasterData.scoreAssetCreationParameters);

--- a/docs/navbar.js
+++ b/docs/navbar.js
@@ -28,12 +28,12 @@ function loadNavbar(callback) {
 
 /**
  * Loads the navbar with a disaster picker.
- * @param {Promise} firebaseAuthPromise Promise that completes when Firebase
+ * @param {Promise<any>} firebaseAuthPromise Promise that completes when Firebase
  *     login is done
  * @param {string} title Title of page
  * @param {?Function} changeDisasterHandler Function invoked when disaster is
  *     changed. If not specified, reloads page
- * @param {?Promise<Map<string, Object>>} firebaseDataPromise If caller has
+ * @param {?Promise<Map<string, DisasterDocument>>} firebaseDataPromise If caller has
  *     already kicked off a fetch of all disasters, pass that Promise in here to
  *     avoid a duplicate fetch
  */

--- a/docs/navbar.js
+++ b/docs/navbar.js
@@ -28,14 +28,14 @@ function loadNavbar(callback) {
 
 /**
  * Loads the navbar with a disaster picker.
- * @param {Promise<any>} firebaseAuthPromise Promise that completes when Firebase
- *     login is done
+ * @param {Promise<any>} firebaseAuthPromise Promise that completes when
+ *     Firebase login is done
  * @param {string} title Title of page
  * @param {?Function} changeDisasterHandler Function invoked when disaster is
  *     changed. If not specified, reloads page
- * @param {?Promise<Map<string, DisasterDocument>>} firebaseDataPromise If caller has
- *     already kicked off a fetch of all disasters, pass that Promise in here to
- *     avoid a duplicate fetch
+ * @param {?Promise<Map<string, DisasterDocument>>} firebaseDataPromise If
+ *     caller has already kicked off a fetch of all disasters, pass that Promise
+ *     in here to avoid a duplicate fetch
  */
 function loadNavbarWithPicker(
     firebaseAuthPromise, title, changeDisasterHandler = null,

--- a/docs/polygon_draw.js
+++ b/docs/polygon_draw.js
@@ -446,8 +446,8 @@ function createHelpIcon(url) {
  * Adds a listener to display notes on pop-up. Stores EE path for damage asset.
  *
  * @param {google.maps.Map} map Map to display regions on
- * @param {Promise<DisasterDocument>} firebasePromise Promise with Firebase damage data (also
- *     implies that authentication is complete)
+ * @param {Promise<DisasterDocument>} firebasePromise Promise with Firebase
+ *     damage data (also implies that authentication is complete)
  * @return {Promise<?google.maps.drawing.DrawingManager>} Promise with drawing
  *     manager added to map (only used by tests). Null if there was an error
  */

--- a/docs/polygon_draw.js
+++ b/docs/polygon_draw.js
@@ -379,7 +379,7 @@ const appearance = {
  * Create a Google Maps Drawing Manager for drawing polygons and markers.
  *
  * @param {google.maps.Map} map
- * @return {google.maps.DrawingManager}
+ * @return {google.maps.drawing.DrawingManager}
  */
 function setUpPolygonDrawing(map) {
   const drawingManager = new google.maps.drawing.DrawingManager({
@@ -446,7 +446,7 @@ function createHelpIcon(url) {
  * Adds a listener to display notes on pop-up. Stores EE path for damage asset.
  *
  * @param {google.maps.Map} map Map to display regions on
- * @param {Promise<any>} firebasePromise Promise with Firebase damage data (also
+ * @param {Promise<DisasterDocument>} firebasePromise Promise with Firebase damage data (also
  *     implies that authentication is complete)
  * @return {Promise<?google.maps.drawing.DrawingManager>} Promise with drawing
  *     manager added to map (only used by tests). Null if there was an error
@@ -456,10 +456,9 @@ async function initializeAndProcessUserRegions(map, firebasePromise) {
   addLoadingElement(mapContainerId);
   try {
     // Firebase retrieval error handled elsewhere. Let this throw if it throws.
-    const doc = await firebasePromise;
+    ({scoreAssetCreationParameters: damageAssetPath} = await firebasePromise);
     // Damage asset may not exist yet, so this is undefined. We tolerate
     // gracefully.
-    ({damageAssetPath} = doc.data().assetData);
     userShapes = getFirestoreRoot().collection(collectionName);
     let querySnapshot;
     try {

--- a/docs/polygon_draw.js
+++ b/docs/polygon_draw.js
@@ -456,7 +456,7 @@ async function initializeAndProcessUserRegions(map, firebasePromise) {
   addLoadingElement(mapContainerId);
   try {
     // Firebase retrieval error handled elsewhere. Let this throw if it throws.
-    ({scoreAssetCreationParameters: damageAssetPath} = await firebasePromise);
+    ({scoreAssetCreationParameters: {damageAssetPath}} = await firebasePromise);
     // Damage asset may not exist yet, so this is undefined. We tolerate
     // gracefully.
     userShapes = getFirestoreRoot().collection(collectionName);

--- a/docs/process_joined_data.js
+++ b/docs/process_joined_data.js
@@ -62,8 +62,8 @@ function colorAndRate(
  * @param {number} scalingFactor multiplies the raw score, it can be
  *     adjusted to make sure that the values span the desired range of ~0 to
  *     ~100.
- * @param {Promise<ScoreComputationParameters>} scoreComputationParameters
- *     promise
+ * @param {Promise<ScoreComputationParameters>}
+ *     scoreComputationParametersPromise
  * that returns the poverty and damage thresholds and the poverty weight (from
  * which the damage weight is derived).
  * @return {Promise<{featuresList: Array<GeoJsonFeature>, columnsFound:
@@ -79,8 +79,8 @@ function colorAndRate(
  *     generally means alphabetically, since EarthEngine always sorts them.
  */
 function processJoinedData(
-    dataPromise, scalingFactor, scoreComputationParameters) {
-  return Promise.all([dataPromise, scoreComputationParameters])
+    dataPromise, scalingFactor, scoreComputationParametersPromise) {
+  return Promise.all([dataPromise, scoreComputationParametersPromise])
       .then(([
               featuresList,
               {
@@ -96,10 +96,8 @@ function processJoinedData(
               },
             ]) => {
         const hasDamage = !!damageAssetPath;
-        const columnsFound = new Set([geoidTag]);
-        columnsFound.add(districtDescriptionKey);
-        columnsFound.add(scoreTag);
-        columnsFound.add(povertyRateKey);
+        const columnsFound = new Set(
+            [geoidTag, districtDescriptionKey, scoreTag, povertyRateKey]);
         if (hasDamage) {
           columnsFound.add(damageTag);
           columnsFound.add(buildingKey);

--- a/docs/process_joined_data.js
+++ b/docs/process_joined_data.js
@@ -47,21 +47,25 @@ function colorAndRate(
 }
 
 /**
+ * @typedef {Object} GeoJsonFeature See
+ *     https://macwright.org/2015/03/23/geojson-second-bite.html#features
+ */
+
+/**
  * Processes the provided Promise. The returned Promise has the same underlying
  * data as the original Promise. In other words, this method will mutate the
  * underlying data of the original Promise. This is acceptable, because it only
  * adds/overwrites the computed attributes of score and color. We avoid doing a
  * full copy because it would unnecessarily copy a lot of data.
  *
- * @param {Promise} dataPromise
+ * @param {Promise<Array<GeoJsonFeature>>} dataPromise
  * @param {number} scalingFactor multiplies the raw score, it can be
  *     adjusted to make sure that the values span the desired range of ~0 to
  *     ~100.
- * @param {Promise<Object>} scoreComputationParameters promise
+ * @param {Promise<ScoreComputationParameters>} scoreComputationParameters
+ *     promise
  * that returns the poverty and damage thresholds and the poverty weight (from
  * which the damage weight is derived).
- * @typedef {Object} GeoJsonFeature See
- *     https://macwright.org/2015/03/23/geojson-second-bite.html#features
  * @return {Promise<{featuresList: Array<GeoJsonFeature>, columnsFound:
  *     Array<EeColumn>}>} Resolved scored features, together with all columns
  *     found in features (and the additional {@link scoreTag} and

--- a/docs/property_names.js
+++ b/docs/property_names.js
@@ -1,26 +1,14 @@
 export {
-  blockGroupTag,
   damageTag,
   geoidTag,
   povertyHouseholdsTag,
-  povertyPercentageTag,
   scoreTag,
   totalHouseholdsTag,
 };
 
-const blockGroupTag = 'BLOCK GROUP';
 const damageTag = 'DAMAGE PERCENTAGE';
 const geoidTag = 'GEOID';
 const scoreTag = 'SCORE';
-// TODO(janakr): Allow user to set the column names for the score ingredient
-//  (currently always 'SNAP PERCENTAGE') and population properties (for use with
-//  drawing polygons, currently always 'SNAP HOUSEHOLDS' and
-//  'TOTAL HOUSEHOLDS'). Then can read these in from Firestore.
-//  Alternately, change these names to be a bit more generic:
-//  'POVERTY PERCENTAGE' and similar. Then GD can just transform their asset to
-//  have these properties. That does make table a bit generic, though: helpful
-//  to have some indication where percentage comes from.
-const povertyPercentageTag = 'SNAP PERCENTAGE';
 // TODO(ruthtalbot): Does GD actually want these totals surfaced?
 const povertyHouseholdsTag = 'SNAP HOUSEHOLDS';
 const totalHouseholdsTag = 'TOTAL HOUSEHOLDS';

--- a/docs/property_names.js
+++ b/docs/property_names.js
@@ -9,6 +9,7 @@ export {
 const damageTag = 'DAMAGE PERCENTAGE';
 const geoidTag = 'GEOID';
 const scoreTag = 'SCORE';
-// TODO(ruthtalbot): Does GD actually want these totals surfaced?
+// TODO(janakr): We need some kind of "totals" tags to enable polygon selection
+//  in the flexible disaster case, but they should probably be optional.
 const povertyHouseholdsTag = 'SNAP HOUSEHOLDS';
 const totalHouseholdsTag = 'TOTAL HOUSEHOLDS';

--- a/docs/run.js
+++ b/docs/run.js
@@ -11,7 +11,7 @@ import {initializeAndProcessUserRegions} from './polygon_draw.js';
 import {setUserFeatureVisibility} from './popup.js';
 import {processJoinedData} from './process_joined_data.js';
 import {getBackupScoreAssetPath, getScoreAssetPath} from './resources.js';
-import {setUpScoreParameters} from './update.js';
+import {setUpScoreComputationParameters} from './update.js';
 
 export {createAndDisplayJoinedData, run};
 // For testing.
@@ -80,7 +80,7 @@ function run(map, firebaseAuthPromise, disasterMetadataPromise) {
   disasterMetadataPromise = massageDisasterMetadataPromiseWhenUsingBackupAsset(
       disasterMetadataPromise);
   const initialTogglesValuesPromise =
-      setUpScoreParameters(disasterMetadataPromise, map);
+      setUpScoreComputationParameters(disasterMetadataPromise, map);
   createAndDisplayJoinedData(map, initialTogglesValuesPromise);
   initializeAndProcessUserRegions(map, disasterMetadataPromise);
   disasterMetadataPromise.then(({layerArray}) => addLayers(map, layerArray));

--- a/docs/run.js
+++ b/docs/run.js
@@ -79,9 +79,9 @@ function run(map, firebaseAuthPromise, disasterMetadataPromise) {
   resolveScoreAsset();
   disasterMetadataPromise = massageDisasterMetadataPromiseWhenUsingBackupAsset(
       disasterMetadataPromise);
-  const initialTogglesValuesPromise =
+  const scoreComputationParametersPromise =
       setUpScoreComputationParameters(disasterMetadataPromise, map);
-  createAndDisplayJoinedData(map, initialTogglesValuesPromise);
+  createAndDisplayJoinedData(map, scoreComputationParametersPromise);
   initializeAndProcessUserRegions(map, disasterMetadataPromise);
   disasterMetadataPromise.then(({layerArray}) => addLayers(map, layerArray));
 }
@@ -114,7 +114,8 @@ let featureSelectListener = null;
  * @param {google.maps.Map} map main map
  * @param {Promise<ScoreComputationParameters>} scoreParametersPromise Will
  *     resolve once score asset name is known and Firestore fetch done
- * @return {Promise<void>} Promise that is done when score layer all done
+ * @return {Promise<void>} Promise that is done when score layer rendered on map
+ *     and shown in list
  */
 function createAndDisplayJoinedData(map, scoreParametersPromise) {
   addLoadingElement(tableContainerId);

--- a/docs/style.css
+++ b/docs/style.css
@@ -429,6 +429,10 @@ input[type=checkbox]:checked {
   transition: background-image 0.2s ease-in-out;
 }
 
+.data-unavailable-span{
+  color: grey;
+}
+
 /* Loading indicator css */
 
 .loader {

--- a/docs/update.js
+++ b/docs/update.js
@@ -15,6 +15,7 @@ const povertyThresholdKey = 'poverty threshold';
 const damageThresholdKey = 'damage threshold';
 const povertyWeightKey = 'poverty weight';
 
+/** @type {Map<string, number>} */
 const toggles = new Map([
   [povertyThresholdKey, 0.3],
   [damageThresholdKey, 0.0],
@@ -41,7 +42,8 @@ function update(map) {
   }
 
   removeScoreLayer();
-  createAndDisplayJoinedData(map, Promise.resolve(getScoreComputationParameters()));
+  createAndDisplayJoinedData(
+      map, Promise.resolve(getScoreComputationParameters()));
   // clear old listeners
   google.maps.event.clearListeners(map, 'click');
   google.maps.event.clearListeners(map.data, 'click');
@@ -63,7 +65,7 @@ function getUpdatedValue(toggle) {
 
 /**
  * Set in setUpInitialToggleValues.
- * @type {boolean}
+ * @type {ScoreParameters}
  */
 let scoreAssetCreationParameters;
 
@@ -85,15 +87,27 @@ async function setUpScoreParameters(disasterMetadataPromise, map) {
 }
 
 /**
+ * Contains a {@link ScoreParameters} together with toggles values. These are
+ * the values needed to compute a score for a {@link GeoJsonFeature}.
+ * @typedef {Object} ScoreComputationParameters
+ * @property {number} povertyThreshold
+ * @property {number} damageThreshold 0 if
+ *     `scoreAssetCreationParameters.damageAssetPath` is missing
+ * @property {number} povertyWeight 1 if
+ *     `scoreAssetCreationParameters.damageAssetPath` is missing
+ * @property {ScoreParameters} scoreAssetCreationParameters
+ */
+
+/**
  * Gets all the parameters needed for score computation, as an object.
- * @return {Object}
+ * @return {ScoreComputationParameters}
  */
 function getScoreComputationParameters() {
   return {
     povertyThreshold: toggles.get(povertyThresholdKey),
     damageThreshold: toggles.get(damageThresholdKey),
     povertyWeight: toggles.get(povertyWeightKey),
-    scoreAssetCreationParameters
+    scoreAssetCreationParameters,
   };
 }
 

--- a/docs/update.js
+++ b/docs/update.js
@@ -7,7 +7,7 @@ export {
   damageThresholdKey,
   povertyThresholdKey,
   povertyWeightKey,
-  setUpScoreParameters,
+  setUpScoreComputationParameters,
   toggles,
 };
 
@@ -76,7 +76,7 @@ let scoreAssetCreationParameters;
  * @param {google.maps.Map} map
  * @return {Promise<Object>} returns all the toggle initial values.
  */
-async function setUpScoreParameters(disasterMetadataPromise, map) {
+async function setUpScoreComputationParameters(disasterMetadataPromise, map) {
   ({scoreAssetCreationParameters} = await disasterMetadataPromise);
   if (!!scoreAssetCreationParameters.damageAssetPath) {
     toggles.set(damageThresholdKey, 0.5);


### PR DESCRIPTION
* Write important parameters used to create score asset to Firestore. Move the old parameters if we're moving the asset, so it all stays in sync.
* Make score computation use parameters set when computing score asset, instead of hard-coded ones.
* We now know whether damage was actually used when creating score asset, versus just whether it exists now.
* Order columns according to some criteria (score -> poverty -> damage), and display in pop-up in that order as well. Also show "(data unavailable)" if a feature is missing data that other features have.
* Add a bunch of parameters to `assetData.flexibleData`, in preparation for follow-up PR. This allows user to customize the columns that are used for various things, and doesn't rename the columns, so that the user can see the original column names on the map, rather than something generic. `GEOID` is the only one renamed, since it's never shown to the user.
* Support filtering out no-damage buildings from damage asset even in state-based score asset creation. Currently there's no way for user to specify no-damage buildings, so doesn't matter.
* Change `firestore_document#readDisasterDocument` to return the actual data, since it's supposed to be read-only anyway.
* async/await a few functions I came across.
* Add test coverage for failure to start an EE task, which I ran across in real life.

#305 #17 Closes #322