### PR TITLE
Don't block layer loading on score asset retrieval

### DIFF
--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -96,8 +96,8 @@ describe('Unit test for ShapeData', () => {
               map,
               // Normally damageAssetPath is a string, but code tolerates
               // just putting an ee.FeatureCollection in.
-              Promise.resolve(
-                  {damageAssetPath: damageCollection}, getUserFeatures()));
+              Promise.resolve({damageAssetPath: damageCollection}),
+              getUserFeatures());
         })
         .then((drawingManagerResult) => drawingManager = drawingManagerResult);
     // Confirm that drawing controls are visible.

--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -95,9 +95,7 @@ describe('Unit test for ShapeData', () => {
               map,
               // Normally damageAssetPath is a string, but code tolerates
               // just putting an ee.FeatureCollection in.
-              Promise.resolve(
-                  {damageAssetPath: damageCollection},
-                  ));
+              Promise.resolve({damageAssetPath: damageCollection}));
         })
         .then((drawingManagerResult) => drawingManager = drawingManagerResult);
     // Confirm that drawing controls are visible.

--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -93,9 +93,9 @@ describe('Unit test for ShapeData', () => {
           userRegionData.clear();
           return initializeAndProcessUserRegions(
               map,
+              // Normally damageAssetPath is a string, but code tolerates
+              // just putting an ee.FeatureCollection in.
               Promise.resolve(
-                  // Normally damageAssetPath is a string, but code tolerates
-                  // just putting an ee.FeatureCollection in.
                   {damageAssetPath: damageCollection},
                   ));
         })

--- a/cypress/integration/unit_tests/polygon_draw_test.js
+++ b/cypress/integration/unit_tests/polygon_draw_test.js
@@ -96,10 +96,8 @@ describe('Unit test for ShapeData', () => {
               Promise.resolve(
                   // Normally damageAssetPath is a string, but code tolerates
                   // just putting an ee.FeatureCollection in.
-                  {
-                    scoreAssetCreationParameters:
-                        {damageAssetPath: damageCollection},
-                  }));
+                  {damageAssetPath: damageCollection},
+                  ));
         })
         .then((drawingManagerResult) => drawingManager = drawingManagerResult);
     // Confirm that drawing controls are visible.
@@ -539,9 +537,8 @@ describe('Unit test for ShapeData', () => {
   }
 
   it('Absence of damage asset tolerated', () => {
-    cy.wrap(initializeAndProcessUserRegions(map, Promise.resolve({
-      scoreAssetCreationParameters: {damageAssetPath: null},
-    })));
+    cy.wrap(initializeAndProcessUserRegions(
+        map, Promise.resolve({damageAssetPath: null})));
     drawPolygon();
     const expectedData = Object.assign({}, defaultData);
     expectedData.damage = 'unknown';

--- a/cypress/integration/unit_tests/update_test.js
+++ b/cypress/integration/unit_tests/update_test.js
@@ -26,8 +26,8 @@ describe('Unit test for updates.js', () => {
   });
 
   it('does not have a damage asset', () => {
-    const nullData = {scoreAssetCreationParameters: {damageAssetPath: null}};
-    cy.wrap(setUpScoreComputationParameters(Promise.resolve(nullData), {}));
+    cy.wrap(setUpScoreComputationParameters(
+        Promise.resolve({damageAssetPath: null}), {}));
     cy.get('input').should('have.length', 2);
     cy.get('[id="poverty threshold"]').clear().type('0.05');
     cy.get('#update').click().then(() => assertDisplayCalledWith(1, 0.3, 0));
@@ -110,7 +110,6 @@ describe('Unit test for updates.js', () => {
  * @return {Cypress.Chainable<Array<number>>}
  */
 function setUpDamageAsset() {
-  const currentData = {scoreAssetCreationParameters: {damageAssetPath: 'foo'}};
-  return cy.wrap(
-      setUpScoreComputationParameters(Promise.resolve(currentData), {}));
+  return cy.wrap(setUpScoreComputationParameters(
+      Promise.resolve({damageAssetPath: 'foo'}), {}));
 }

--- a/docs/polygon_draw.js
+++ b/docs/polygon_draw.js
@@ -446,7 +446,7 @@ function createHelpIcon(url) {
  * Adds a listener to display notes on pop-up. Stores EE path for damage asset.
  *
  * @param {google.maps.Map} map Map to display regions on
- * @param {Promise<DisasterDocument>} firebasePromise Promise with Firebase
+ * @param {Promise<ScoreParameters>} firebasePromise Promise with Firebase
  *     damage data (also implies that authentication is complete)
  * @return {Promise<?google.maps.drawing.DrawingManager>} Promise with drawing
  *     manager added to map (only used by tests). Null if there was an error
@@ -456,7 +456,7 @@ async function initializeAndProcessUserRegions(map, firebasePromise) {
   addLoadingElement(mapContainerId);
   try {
     // Firebase retrieval error handled elsewhere. Let this throw if it throws.
-    ({scoreAssetCreationParameters: {damageAssetPath}} = await firebasePromise);
+    ({damageAssetPath} = await firebasePromise);
     // Damage asset may not exist yet, so this is undefined. We tolerate
     // gracefully.
     userShapes = getFirestoreRoot().collection(collectionName);

--- a/docs/run.js
+++ b/docs/run.js
@@ -99,10 +99,10 @@ async function getScoreAssetComputationParametersPromise(
     disasterMetadataPromise) {
   const disasterMetadata = await disasterMetadataPromise;
   const scoreAsset = await resolvedScoreAsset;
-  if (scoreAsset !== getScoreAssetPath()) {
-    return disasterMetadata.lastScoreAssetCreationParameters;
+  if (scoreAsset === getScoreAssetPath()) {
+    return disasterMetadata.scoreAssetCreationParameters;
   }
-  return disasterMetadata.scoreAssetCreationParameters;
+  return disasterMetadata.lastScoreAssetCreationParameters;
 }
 
 let mapSelectListener = null;

--- a/docs/run.js
+++ b/docs/run.js
@@ -77,32 +77,32 @@ function resolveScoreAsset() {
 function run(map, firebaseAuthPromise, disasterMetadataPromise) {
   setMapToDrawLayersOn(map);
   resolveScoreAsset();
-  disasterMetadataPromise = massageDisasterMetadataPromiseWhenUsingBackupAsset(
-      disasterMetadataPromise);
-  const scoreComputationParametersPromise =
-      setUpScoreComputationParameters(disasterMetadataPromise, map);
+  const scoreAssetComputationParametersPromise =
+      getScoreAssetComputationParametersPromise(disasterMetadataPromise);
+  const scoreComputationParametersPromise = setUpScoreComputationParameters(
+      scoreAssetComputationParametersPromise, map);
   createAndDisplayJoinedData(map, scoreComputationParametersPromise);
-  initializeAndProcessUserRegions(map, disasterMetadataPromise);
+  initializeAndProcessUserRegions(map, scoreAssetComputationParametersPromise);
   disasterMetadataPromise.then(({layerArray}) => addLayers(map, layerArray));
 }
 
 /**
- * Modifies the result of `disasterMetadataPromise` in case we are using the
- * backup score asset, so that the `scoreAssetCreationParameters` are set to
+ *
+ * Returns `scoreAssetCreationParameters` unless we are using the backup score
+ * asset, so that the `scoreAssetCreationParameters` are set to
  * `lastScoreAssetCreationParameters`. This allows downstream consumers to
  * remain ignorant of which score asset is being used.
- * @param {Promise<DisasterDocument>}disasterMetadataPromise
- * @return {Promise<DisasterDocument>}
+ * @param {Promise<DisasterDocument>} disasterMetadataPromise
+ * @return {Promise<ScoreParameters>}
  */
-async function massageDisasterMetadataPromiseWhenUsingBackupAsset(
+async function getScoreAssetComputationParametersPromise(
     disasterMetadataPromise) {
   const disasterMetadata = await disasterMetadataPromise;
   const scoreAsset = await resolvedScoreAsset;
   if (scoreAsset !== getScoreAssetPath()) {
-    disasterMetadata.scoreAssetCreationParameters =
-        disasterMetadata.lastScoreAssetCreationParameters;
+    return disasterMetadata.lastScoreAssetCreationParameters;
   }
-  return disasterMetadata;
+  return disasterMetadata.scoreAssetCreationParameters;
 }
 
 let mapSelectListener = null;

--- a/docs/update.js
+++ b/docs/update.js
@@ -72,12 +72,12 @@ let scoreAssetCreationParameters;
 /**
  * Initializes damage-related toggle values based on whether or not we have
  * a damage asset.
- * @param {Promise<DisasterDocument>} disasterMetadataPromise
+ * @param {Promise<ScoreParameters>} scoreParametersPromise
  * @param {google.maps.Map} map
  * @return {Promise<Object>} returns all the toggle initial values.
  */
-async function setUpScoreComputationParameters(disasterMetadataPromise, map) {
-  ({scoreAssetCreationParameters} = await disasterMetadataPromise);
+async function setUpScoreComputationParameters(scoreParametersPromise, map) {
+  scoreAssetCreationParameters = await scoreParametersPromise;
   if (!!scoreAssetCreationParameters.damageAssetPath) {
     toggles.set(damageThresholdKey, 0.5);
     toggles.set(povertyWeightKey, 0.5);


### PR DESCRIPTION
Sequentializes things too much. User regions are still blocked, but there's a better reason for that.