### PR TITLE
Speed up checking existence of score asset

### DIFF
--- a/cypress/integration/unit_tests/run_test.js
+++ b/cypress/integration/unit_tests/run_test.js
@@ -4,7 +4,7 @@ import * as Resources from '../../../docs/resources.js';
 import {resolveScoreAsset} from '../../../docs/run.js';
 import {loadScriptsBeforeForUnitTests} from '../../support/script_loader.js';
 
-const waitForPromiseToResolve = 6000;
+const waitForPromiseToResolve = 3000;
 
 describe('Unit test for run.js', () => {
   loadScriptsBeforeForUnitTests('ee');


### PR DESCRIPTION
Now that we wait for score asset existence before doing other operations, downloading the entire asset is an unnecessary block (even though we need to do it eventually). Race the download against a simpler EE query that should still succeed if the asset exists. This is both a performance optimization and a prerequisite for #437, which seems to slow down feature collection downloading in tests.