### PR TITLE
Fix color rendering

### DIFF
--- a/cypress/integration/unit_tests/style_functions_test.js
+++ b/cypress/integration/unit_tests/style_functions_test.js
@@ -42,7 +42,7 @@ describe('Unit test for generating style functions', () => {
       'color': 'blue',
     });
     const trueBlue = fxn({});
-    const blue = [0, 0, 255];
+    const blue = [0, 0, 255, 200];
     expect(trueBlue).to.eql(blue);
   });
 });

--- a/cypress/integration/unit_tests/style_functions_test.js
+++ b/cypress/integration/unit_tests/style_functions_test.js
@@ -1,4 +1,4 @@
-import {colorMap, createStyleFunction} from '../../../docs/firebase_layers.js';
+import {createStyleFunction} from '../../../docs/firebase_layers.js';
 
 describe('Unit test for generating style functions', () => {
   it('calculates a discrete function', () => {
@@ -11,11 +11,13 @@ describe('Unit test for generating style functions', () => {
       },
     });
     const cherry = fxn({'properties': {'flavor': 'cherry'}});
-    const expectedCherry = colorMap.get('red');
+    const expectedCherry = [255, 0, 0, 200];
     expect(cherry).to.eql(expectedCherry);
     const banana = fxn({'properties': {'flavor': 'banana'}});
-    const expectedBanana = colorMap.get('yellow');
+    const expectedBanana = [255, 255, 0, 200];
     expect(banana).to.eql(expectedBanana);
+    const secondBanana = fxn({'properties': {'flavor': 'banana'}});
+    expect(secondBanana).to.eql(expectedBanana);
   });
 
   it('calculates a continuous function', () => {
@@ -40,7 +42,7 @@ describe('Unit test for generating style functions', () => {
       'color': 'blue',
     });
     const trueBlue = fxn({});
-    const blue = colorMap.get('blue');
+    const blue = [0, 0, 255];
     expect(trueBlue).to.eql(blue);
   });
 });

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -39,8 +39,7 @@ function createStyleFunction(colorFunctionProperties) {
   const field = colorFunctionProperties['field'];
   switch (colorFunctionProperties.currentStyle) {
     case ColorStyle.SINGLE:
-      // Drop opacity for single-color.
-      const color = colorMap.get(colorFunctionProperties.color).slice(0, 3);
+      const color = colorMap.get(colorFunctionProperties.color);
       return () => color;
     case ColorStyle.CONTINUOUS:
       return createContinuousFunction(

--- a/docs/firebase_layers.js
+++ b/docs/firebase_layers.js
@@ -5,6 +5,7 @@ export {
   createStyleFunction,
   getLinearGradient,
   LayerType,
+  SOLID_BLACK,
 };
 
 const LayerType = {
@@ -24,7 +25,9 @@ const ColorStyle = {
 };
 Object.freeze(ColorStyle);
 
-const opacity = 200;
+const OPACITY = 200;
+
+const SOLID_BLACK = [0, 0, 0];
 
 /**
  * Creates the style function for the given properties. Caller should cache to
@@ -36,7 +39,8 @@ function createStyleFunction(colorFunctionProperties) {
   const field = colorFunctionProperties['field'];
   switch (colorFunctionProperties.currentStyle) {
     case ColorStyle.SINGLE:
-      const color = colorMap.get(colorFunctionProperties.color);
+      // Drop opacity for single-color.
+      const color = colorMap.get(colorFunctionProperties.color).slice(0, 3);
       return () => color;
     case ColorStyle.CONTINUOUS:
       return createContinuousFunction(
@@ -77,7 +81,7 @@ function createContinuousFunction(field, minVal, maxVal, color) {
       rgba.push(
           white[i] + (colorRgb[i] - white[i]) * ((value - minVal) / range));
     }
-    rgba.push(opacity);
+    rgba.push(OPACITY);
     return rgba;
   };
 }
@@ -93,24 +97,22 @@ function createDiscreteFunction(field, colors) {
   return (feature) => {
     const value = feature['properties'][field];
     if (value === null) return transparent;
-    const rgba = colorMap.get(colors[value]);
-    rgba.push(opacity);
-    return rgba;
+    return colorMap.get(colors[value]);
   };
 }
 
-const transparent = [0, 0, 0, 0];
+const transparent = Object.freeze([0, 0, 0, 0]);
 
-const colorMap = new Map([
-  ['red', [255, 0, 0]],
-  ['orange', [255, 140, 0]],
-  ['yellow', [255, 255, 0]],
-  ['green', [0, 255, 0]],
-  ['blue', [0, 0, 255]],
-  ['purple', [128, 0, 128]],
-  ['black', [0, 0, 0]],
-  ['white', [255, 255, 255]],
-]);
+const colorMap = Object.freeze(new Map([
+  ['red', Object.freeze([255, 0, 0, OPACITY])],
+  ['orange', Object.freeze([255, 140, 0, OPACITY])],
+  ['yellow', Object.freeze([255, 255, 0, OPACITY])],
+  ['green', Object.freeze([0, 255, 0, OPACITY])],
+  ['blue', Object.freeze([0, 0, 255, OPACITY])],
+  ['purple', Object.freeze([128, 0, 128, OPACITY])],
+  ['black', Object.freeze([0, 0, 0, OPACITY])],
+  ['white', Object.freeze([255, 255, 255, OPACITY])],
+]));
 
 /**
  * Gets the linear gradient of the colors for the legend.

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -4,7 +4,8 @@ import {mapContainerId} from './dom_constants.js';
 import {terrainStyle} from './earth_engine_asset.js';
 import {AssetNotFoundError, getEePromiseForFeatureCollection, transformEarthEngineFailureMessage} from './ee_promise_cache.js';
 import {showError} from './error.js';
-import {colorMap, createStyleFunction, LayerType} from './firebase_layers.js';
+import {SOLID_BLACK} from './firebase_layers';
+import {createStyleFunction, LayerType} from './firebase_layers.js';
 import {addLoadingElement, loadingElementFinished} from './loading.js';
 
 export {
@@ -453,7 +454,7 @@ function addLayerFromFeatures(layerDisplayData, index) {
  * @return {Array} RGBA color specification as an array
  */
 function showColor(color) {
-  return color ? color : colorMap.get('black');
+  return color ? color : SOLID_BLACK;
 }
 
 /**

--- a/docs/layer_util.js
+++ b/docs/layer_util.js
@@ -4,8 +4,7 @@ import {mapContainerId} from './dom_constants.js';
 import {terrainStyle} from './earth_engine_asset.js';
 import {AssetNotFoundError, getEePromiseForFeatureCollection, transformEarthEngineFailureMessage} from './ee_promise_cache.js';
 import {showError} from './error.js';
-import {SOLID_BLACK} from './firebase_layers';
-import {createStyleFunction, LayerType} from './firebase_layers.js';
+import {createStyleFunction, LayerType, SOLID_BLACK} from './firebase_layers.js';
 import {addLoadingElement, loadingElementFinished} from './loading.js';
 
 export {


### PR DESCRIPTION
Don't accidentally modify the color arrays.

I wonder if the latest deck.gl that we started using a few weeks before fellowship ended got stricter? It looks like this bug has been here since this code was introduced in #186.