### PR TITLE
Properly wait for response.json() promise

### DIFF
--- a/docs/authenticate.js
+++ b/docs/authenticate.js
@@ -39,9 +39,9 @@ const firebaseConfigTest = {
   appId: '1:340543030947:web:0cf3235904250687592116',
 };
 
-// const TOKEN_SERVER_URL = 'https://mapping-crisis.appspot.com';
+const TOKEN_SERVER_URL = 'https://mapping-crisis.appspot.com';
 // For local testing.
-const TOKEN_SERVER_URL = 'http://localhost:9080';
+// const TOKEN_SERVER_URL = 'http://localhost:9080';
 
 // Request a new token with 5 minutes of validity remaining on our current token
 // to leave time for any slowness.

--- a/docs/authenticate.js
+++ b/docs/authenticate.js
@@ -39,9 +39,9 @@ const firebaseConfigTest = {
   appId: '1:340543030947:web:0cf3235904250687592116',
 };
 
-const TOKEN_SERVER_URL = 'https://mapping-crisis.appspot.com';
+// const TOKEN_SERVER_URL = 'https://mapping-crisis.appspot.com';
 // For local testing.
-// const TOKEN_SERVER_URL = 'http://localhost:9080';
+const TOKEN_SERVER_URL = 'http://localhost:9080';
 
 // Request a new token with 5 minutes of validity remaining on our current token
 // to leave time for any slowness.
@@ -217,7 +217,7 @@ class Authenticator {
       showError('Error contacting server for anonymous EarthEngine access');
       throw new Error(message);
     }
-    const {accessToken, expireTime} = response.json();
+    const {accessToken, expireTime} = await response.json();
     await new Promise(
         (resolve) => ee.data.setAuthToken(
             CLIENT_ID, 'Bearer', accessToken,

--- a/token_server/token_server.js
+++ b/token_server/token_server.js
@@ -104,7 +104,7 @@ function generateTokenPeriodically() {
   createServer(async (req, res) => {
     const origin = req.headers['origin'];
     if (!allowedOrigins.has(origin)) {
-      console.warn("Bad origin", origin);
+      console.warn('Bad origin', origin);
       fail(res);
       return;
     }
@@ -113,7 +113,7 @@ function generateTokenPeriodically() {
       const {idToken} = await parseBody(req);
       await client.verifyIdToken({idToken: idToken, audience: CLIENT_ID});
     } catch (err) {
-      console.warn("Error verifying id token", err, idToken);
+      console.warn('Error verifying id token', err, idToken);
       fail(res);
       return;
     }

--- a/token_server/token_server.js
+++ b/token_server/token_server.js
@@ -104,6 +104,7 @@ function generateTokenPeriodically() {
   createServer(async (req, res) => {
     const origin = req.headers['origin'];
     if (!allowedOrigins.has(origin)) {
+      console.warn("Bad origin", origin);
       fail(res);
       return;
     }
@@ -112,6 +113,7 @@ function generateTokenPeriodically() {
       const {idToken} = await parseBody(req);
       await client.verifyIdToken({idToken: idToken, audience: CLIENT_ID});
     } catch (err) {
+      console.warn("Error verifying id token", err, idToken);
       fail(res);
       return;
     }


### PR DESCRIPTION
Broken by https://github.com/givedirectly/Google-Partnership/commit/72dd1775cf549bec616f39a6467d73d3aaa2f42d#diff-10d6fe37a932cbb977d8ff39d67db610L203: we used to chain promises. When I switched to async style as part of EE upgrade, forgot to add "await" here.