### PR TITLE
Augment error message when there are non-matching columns.

### DIFF
--- a/cypress/integration/integration_tests/checkbox_test.js
+++ b/cypress/integration/integration_tests/checkbox_test.js
@@ -4,8 +4,7 @@
  */
 describe('Integration test', () => {
   it('Checks threshold update checks score box', () => {
-    cy.visit('');
-    cy.awaitLoad();
+    cy.visit('').then(() => cy.awaitLoad());
 
     cy.get('#sidebar-toggle-datasets').click();
 

--- a/cypress/integration/integration_tests/checkbox_test.js
+++ b/cypress/integration/integration_tests/checkbox_test.js
@@ -4,7 +4,8 @@
  */
 describe('Integration test', () => {
   it('Checks threshold update checks score box', () => {
-    cy.visit('').then(() => cy.awaitLoad());
+    cy.visit('');
+    cy.awaitLoad();
 
     cy.get('#sidebar-toggle-datasets').click();
 

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -414,7 +414,8 @@ it('does column verification', () => {
       null, {'GEO_ID': 0, 'NAME': 0, 'B22010_001E': 0, 'B22010_002E': 0})]);
   // U+200C: zero-width character, doesn't print as anything.
   const nonAsciiColumnFeature = ee.FeatureCollection([ee.Feature(
-      null, {'\u200CGEO_ID': 0, 'NAME': 0, 'B22010_001E': 0, 'B22010_002E': 0})]);
+      null,
+      {'\u200CGEO_ID': 0, 'NAME': 0, 'B22010_001E': 0, 'B22010_002E': 0})]);
 
   const featureCollectionStub = cy.stub(ee, 'FeatureCollection');
   featureCollectionStub.withArgs('state0').returns(goodIncomeBadSnapFeature);
@@ -457,13 +458,13 @@ it('does column verification', () => {
   checkSelectBorder(SNAP_INDEX, 'rgb(255, 0, 0)');
   checkHoverText(
       SNAP_INDEX,
-     'Error! asset is missing columns for all 2 possibilities ' +
-     'for valid columns:\n' +
-     '* [GEO_ID,NAME,B22010_002E,B22010_001E] ' +
-     '(missing GEO_ID)\n' +
-     '* [GEOid,GEOdisplay-label,HD01_VD02,HD01_VD01] ' +
-     '(missing GEOid,GEOdisplay-label,HD01_VD02,HD01_VD01)\n' +
-     'Columns with non-ascii characters: \u200CGEO_ID');
+      'Error! asset is missing columns for all 2 possibilities ' +
+          'for valid columns:\n' +
+          '* [GEO_ID,NAME,B22010_002E,B22010_001E] ' +
+          '(missing GEO_ID)\n' +
+          '* [GEOid,GEOdisplay-label,HD01_VD02,HD01_VD01] ' +
+          '(missing GEOid,GEOdisplay-label,HD01_VD02,HD01_VD01)\n' +
+          'Columns with non-ascii characters: \u200CGEO_ID');
 
   // new good
   setSelectWithDelayedEvaluate(0, 'state3', 'NY');
@@ -537,11 +538,11 @@ it('has two racing sets on same selector', () => {
   checkHoverText(
       SNAP_INDEX,
       'Error! asset is missing columns for all 2 possibilities ' +
-      'for valid columns:\n' +
-      '* [GEOid,GEOdisplay-label,HD01_VD02,HD01_VD01] ' +
-      '(missing GEOdisplay-label,HD01_VD02)\n' +
-      '* [GEO_ID,NAME,B22010_002E,B22010_001E] ' +
-      '(missing GEO_ID,NAME,B22010_002E,B22010_001E)\n');
+          'for valid columns:\n' +
+          '* [GEOid,GEOdisplay-label,HD01_VD02,HD01_VD01] ' +
+          '(missing GEOdisplay-label,HD01_VD02)\n' +
+          '* [GEO_ID,NAME,B22010_002E,B22010_001E] ' +
+          '(missing GEO_ID,NAME,B22010_002E,B22010_001E)\n');
 
   // now do opposite order
   cyQueue(() => {
@@ -558,7 +559,7 @@ it('has two racing sets on same selector', () => {
   checkSelectBorder(SNAP_INDEX, 'rgb(255, 0, 0)');
   checkHoverText(
       SNAP_INDEX,
-          'Error! asset is missing columns for all 2 possibilities ' +
+      'Error! asset is missing columns for all 2 possibilities ' +
           'for valid columns:\n' +
           '* [GEOid,GEOdisplay-label,HD01_VD02,HD01_VD01] ' +
           '(missing GEOdisplay-label,HD01_VD02)\n' +
@@ -568,7 +569,7 @@ it('has two racing sets on same selector', () => {
   checkSelectBorder(SNAP_INDEX, 'rgb(255, 0, 0)');
   checkHoverText(
       SNAP_INDEX,
-          'Error! asset is missing columns for all 2 possibilities ' +
+      'Error! asset is missing columns for all 2 possibilities ' +
           'for valid columns:\n' +
           '* [GEOid,GEOdisplay-label,HD01_VD02,HD01_VD01] ' +
           '(missing GEOdisplay-label,HD01_VD02)\n' +

--- a/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
+++ b/cypress/integration/unit_tests/manage_disaster_set_score_parameters_test.js
@@ -419,7 +419,6 @@ it('does column verification', () => {
   const featureCollectionStub = cy.stub(ee, 'FeatureCollection');
   featureCollectionStub.withArgs('state0').returns(goodIncomeBadSnapFeature);
   featureCollectionStub.withArgs('state1').returns(goodNewIncomeBadSnapFeature);
-  // featureCollectionStub.withArgs('state2').returns(goodIncomeBadSnapFeature);
   featureCollectionStub.withArgs('state2').returns(goodSnapFeature);
   featureCollectionStub.withArgs('state3').returns(goodNewSnapFeature);
   featureCollectionStub.withArgs('state4').returns(nonAsciiColumnFeature);

--- a/docs/import/manage_disaster_base.js
+++ b/docs/import/manage_disaster_base.js
@@ -69,6 +69,8 @@ const DAMAGE_PROPERTY_PATH = Object.freeze(['damageAssetPath']);
 
 const damageAssetChecker = new PendingChecker();
 
+const asciiRegex = /^[ -~]+$/;
+
 /**
  * Does all initialization for damage asset and related fields. Creates damage
  * select, no-damage column and value, puts everything in a pending state but
@@ -419,34 +421,61 @@ async function verifyAsset(propertyPath, expectedColumns) {
           select, 'green', expectedColumns ? 'No expected columns' : '');
       return result;
     }
+    const badColumns = [];
+    for (const column of result) {
+      if (!asciiRegex.test(column)) {
+        badColumns.push(column);
+      }
+    }
+    console.log(asset, result);
     const presentColumns = new Set(result);
     if (Array.isArray(expectedColumns[0])) {
-      outerLoop: for (const columns of expectedColumns) {
+      const missingColumns = [];
+      let curMissingColumns = [];
+      let i = 0;
+      for (const columns of expectedColumns) {
         for (const column of columns) {
           if (!presentColumns.has(column)) {
-            continue outerLoop;
+            curMissingColumns.push(column);
           }
         }
+        if (curMissingColumns.length == 0) {
+          updateColorAndHover(
+              select, 'green', 'Success! asset has all expected columns');
+          return result;
+        } else {
+          missingColumns.push([curMissingColumns, i++]);
+          curMissingColumns = [];
+        }
+      }
+      missingColumns.sort(function(left, right) {
+        return left[0].length < right[0].length ? -1 : 1;
+      });
+      let errStr = 'Error! asset is missing columns for all ' + expectedColumns.length + ' possibilities for valid columns:\n';
+      for (const [missing, ind] of missingColumns) {
+        errStr += '* [' + expectedColumns[ind] + '] (missing ' + missing + ')\n';
+      }
+      if (badColumns.length > 0) {
+        errStr += 'Columns with non-ascii characters: ' + badColumns;
+      }
+      updateColorAndHover(select, 'red', errStr);
+    } else {
+      const missingColumns = [];
+      for (const column of expectedColumns) {
+        if (!presentColumns.has(column)) {
+          missingColumns.push(column);
+        }
+      }
+      if (missingColumns.length == 0) {
         updateColorAndHover(
             select, 'green', 'Success! asset has all expected columns');
         return result;
       }
-      updateColorAndHover(
-          select, 'red',
-          'Error! asset does not have all expected columns: ' +
-              '[' + expectedColumns.join('] or [') + ']');
-    } else {
-      for (const column of expectedColumns) {
-        if (!presentColumns.has(column)) {
-          updateColorAndHover(
-              select, 'red',
-              'Error! asset does not have all expected columns: ' +
-                  expectedColumns);
-          return result;
-        }
+      let errStr = 'Error! asset does not have all expected columns: ' + expectedColumns + ' (missing ' + missingColumns + ')';
+      if (badColumns.length > 0) {
+        errStr += 'Columns with non-ascii characters: ' + badColumns;
       }
-      updateColorAndHover(
-          select, 'green', 'Success! asset has all expected columns');
+      updateColorAndHover(select, 'red', errStr);
       return result;
     }
   }

--- a/docs/import/manage_disaster_base.js
+++ b/docs/import/manage_disaster_base.js
@@ -18,6 +18,7 @@ export {
   createSelect,
   createSelectListItemFromColumnInfo,
   createSelectWithSimpleWriteOnChange,
+  DAMAGE_PROPERTY_PATH,
   damageAssetPresent,
   disasterData,
   getAssetsAndSetOptionsForSelect,
@@ -34,6 +35,7 @@ export {
   NODAMAGE_VALUE_INFO,
   noteNewDisaster,
   onAssetSelect,
+  scoreBoundsMap,
   setExplanationSpanTextForColumn,
   setOptionsForSelect,
   setUpScoreBoundsMap,
@@ -46,8 +48,6 @@ export {
   writeAssetDataLocally,
   writeSelectAndGetPropertyNames,
 };
-// For testing.
-export {DAMAGE_PROPERTY_PATH, scoreBoundsMap};
 
 /**
  * @type {Map<string, Object>} Disaster id to disaster data, corresponding to
@@ -453,7 +453,8 @@ async function verifyAsset(propertyPath, expectedColumns) {
       let errStr = 'Error! asset is missing columns for all ' +
           expectedColumns.length + ' possibilities for valid columns:\n';
       for (const [missing, ind] of missingColumns) {
-        errStr += '* [' + expectedColumns[ind] + '] (missing ' + missing + ')\n';
+        errStr +=
+            '* [' + expectedColumns[ind] + '] (missing ' + missing + ')\n';
       }
       if (badColumns.length > 0) {
         errStr += 'Columns with non-ascii characters: ' + badColumns;

--- a/docs/import/manage_disaster_base.js
+++ b/docs/import/manage_disaster_base.js
@@ -427,7 +427,6 @@ async function verifyAsset(propertyPath, expectedColumns) {
         badColumns.push(column);
       }
     }
-    console.log(asset, result);
     const presentColumns = new Set(result);
     if (Array.isArray(expectedColumns[0])) {
       const missingColumns = [];
@@ -451,7 +450,8 @@ async function verifyAsset(propertyPath, expectedColumns) {
       missingColumns.sort(function(left, right) {
         return left[0].length < right[0].length ? -1 : 1;
       });
-      let errStr = 'Error! asset is missing columns for all ' + expectedColumns.length + ' possibilities for valid columns:\n';
+      let errStr = 'Error! asset is missing columns for all ' +
+          expectedColumns.length + ' possibilities for valid columns:\n';
       for (const [missing, ind] of missingColumns) {
         errStr += '* [' + expectedColumns[ind] + '] (missing ' + missing + ')\n';
       }
@@ -471,7 +471,8 @@ async function verifyAsset(propertyPath, expectedColumns) {
             select, 'green', 'Success! asset has all expected columns');
         return result;
       }
-      let errStr = 'Error! asset does not have all expected columns: ' + expectedColumns + ' (missing ' + missingColumns + ')';
+      let errStr = 'Error! asset does not have all expected columns: ' +
+          expectedColumns + ' (missing ' + missingColumns + ')';
       if (badColumns.length > 0) {
         errStr += 'Columns with non-ascii characters: ' + badColumns;
       }

--- a/docs/import/manage_disaster_base.js
+++ b/docs/import/manage_disaster_base.js
@@ -46,9 +46,8 @@ export {
   writeAssetDataLocally,
   writeSelectAndGetPropertyNames,
 };
-
 // clang-format off
-// For testing.
+// @VisibleForTesting
 export {DAMAGE_PROPERTY_PATH, scoreBoundsMap};
 // clang-format on
 

--- a/docs/import/manage_disaster_base.js
+++ b/docs/import/manage_disaster_base.js
@@ -47,8 +47,10 @@ export {
   writeSelectAndGetPropertyNames,
 };
 
+// clang-format off
 // For testing.
 export {DAMAGE_PROPERTY_PATH, scoreBoundsMap};
+// clang-format on
 
 /**
  * @type {Map<string, Object>} Disaster id to disaster data, corresponding to

--- a/docs/import/manage_disaster_base.js
+++ b/docs/import/manage_disaster_base.js
@@ -18,7 +18,6 @@ export {
   createSelect,
   createSelectListItemFromColumnInfo,
   createSelectWithSimpleWriteOnChange,
-  DAMAGE_PROPERTY_PATH,
   damageAssetPresent,
   disasterData,
   getAssetsAndSetOptionsForSelect,
@@ -35,7 +34,6 @@ export {
   NODAMAGE_VALUE_INFO,
   noteNewDisaster,
   onAssetSelect,
-  scoreBoundsMap,
   setExplanationSpanTextForColumn,
   setOptionsForSelect,
   setUpScoreBoundsMap,
@@ -48,6 +46,9 @@ export {
   writeAssetDataLocally,
   writeSelectAndGetPropertyNames,
 };
+
+// For testing.
+export {DAMAGE_PROPERTY_PATH, scoreBoundsMap};
 
 /**
  * @type {Map<string, Object>} Disaster id to disaster data, corresponding to

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "babel-eslint": "10.0.3",
-    "cypress": "<=11.2.0",
+    "cypress": "11.2.0",
     "eslint": "<=7.32.0",
     "eslint-config-google": "0.14.0",
     "firebase": "<=8.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1389,7 +1389,7 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@<=11.2.0:
+cypress@11.2.0:
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.2.0.tgz#63edef8c387b687066c5493f6f0ad7b9ced4b2b7"
   integrity sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==


### PR DESCRIPTION
This makes it easier to understand why an asset has an error. In real life, an asset had non-ascii characters in the column name, so add a specific check for that, because when the character is non-printable, it's impossible to tell with the naked eye why the name is wrong.