### PR TITLE
Allow zero-score tracts to be displayed in the table

### DIFF
--- a/cypress/integration/unit_tests/click_feature_test.js
+++ b/cypress/integration/unit_tests/click_feature_test.js
@@ -2,7 +2,7 @@ import {tableContainerId} from '../../../docs/dom_constants.js';
 import {convertEeObjectToPromise} from '../../../docs/ee_promise_cache.js';
 import {currentFeatures} from '../../../docs/highlight_features';
 import * as loading from '../../../docs/loading.js';
-import {geoidTag, scoreTag} from '../../../docs/property_names.js';
+import {displayedTag, geoidTag, scoreTag} from '../../../docs/property_names.js';
 import * as Resources from '../../../docs/resources.js';
 import {drawTableAndSetUpHandlers, resolveScoreAsset} from '../../../docs/run.js';
 import {cyQueue} from '../../support/commands.js';
@@ -45,11 +45,11 @@ describe('Unit tests for click_feature.js with map and table', () => {
       missingPropertiesFeature,
     ]);
     scoredFeatures = ee.FeatureCollection([
-      feature1.set(scoreTag, 1),
-      feature2.set(scoreTag, 3),
-      offMapFeature.set(scoreTag, 2),
-      zeroFeature.set(scoreTag, 0),
-      missingPropertiesFeature.set(scoreTag, 4),
+      feature1.set(scoreTag, 1).set(displayedTag, true),
+      feature2.set(scoreTag, 3).set(displayedTag, true),
+      offMapFeature.set(scoreTag, 2).set(displayedTag, true),
+      zeroFeature.set(scoreTag, 0).set(displayedTag, false),
+      missingPropertiesFeature.set(scoreTag, 4).set(displayedTag, true),
     ]);
     // We fake out element access below using cy.document(), but cy.document()
     // doesn't return an HTMLDocument (and its elements aren't HTMLElements)
@@ -106,6 +106,7 @@ describe('Unit tests for click_feature.js with map and table', () => {
                                                               fc.features,
                                                           columnsFound: [
                                                             geoidTag,
+                                                            displayedTag,
                                                             blockGroupTag,
                                                             scoreTag,
                                                             'SOME PROPERTY',

--- a/cypress/integration/unit_tests/process_joined_data_test.js
+++ b/cypress/integration/unit_tests/process_joined_data_test.js
@@ -40,6 +40,7 @@ describe('Unit test for processed_joined_data.js', () => {
         .then(({featuresList, columnsFound}) => {
           expect(columnsFound).to.eql([
             '___GD_GOOGLE_DELPHI_GEOID',
+            '___DISPLAYED',
             'district descript',
             'SCORE',
             'poverty rate',
@@ -65,6 +66,7 @@ describe('Unit test for processed_joined_data.js', () => {
               .to.have.property(
                   'SCORE',
                   Math.round(100 * (0.5 * ((10 + 5) / 27) + 0.5 * (2 / 4))));
+          expect(resultProperties).to.have.property('___DISPLAYED', true)
           assertColorAndOpacity(resultProperties, 135);
         });
   });
@@ -105,6 +107,7 @@ describe('Unit test for processed_joined_data.js', () => {
         .then(({featuresList}) => {
           const resultProperties = featuresList[0].properties;
           expect(resultProperties).to.have.property('SCORE', 0);
+          expect(resultProperties).to.have.property('___DISPLAYED', false);
           assertColorAndOpacity(resultProperties, 0);
         });
   });
@@ -124,6 +127,7 @@ describe('Unit test for processed_joined_data.js', () => {
         .then(({featuresList, columnsFound}) => {
           expect(columnsFound).to.eql([
             '___GD_GOOGLE_DELPHI_GEOID',
+            '___DISPLAYED',
             'district descript',
             'SCORE',
             'poverty rate',
@@ -159,6 +163,7 @@ describe('Unit test for processed_joined_data.js', () => {
         .then(({featuresList, columnsFound}) => {
           expect(columnsFound).to.eql([
             '___GD_GOOGLE_DELPHI_GEOID',
+            '___DISPLAYED',
             'district descript',
             'SCORE',
             'poverty rate',

--- a/cypress/integration/unit_tests/process_joined_data_test.js
+++ b/cypress/integration/unit_tests/process_joined_data_test.js
@@ -66,7 +66,7 @@ describe('Unit test for processed_joined_data.js', () => {
               .to.have.property(
                   'SCORE',
                   Math.round(100 * (0.5 * ((10 + 5) / 27) + 0.5 * (2 / 4))));
-          expect(resultProperties).to.have.property('___DISPLAYED', true)
+          expect(resultProperties).to.have.property('___DISPLAYED', true);
           assertColorAndOpacity(resultProperties, 135);
         });
   });

--- a/cypress/integration/unit_tests/process_joined_data_test.js
+++ b/cypress/integration/unit_tests/process_joined_data_test.js
@@ -53,7 +53,7 @@ describe('Unit test for processed_joined_data.js', () => {
             'major-damage',
           ]);
           expect(featuresList).to.be.an('array');
-          expect(featuresList.length).to.equal(1);
+          expect(featuresList).to.have.length(1);
           const [returnedFeature] = featuresList;
           expect(returnedFeature).to.have.property('geometry', geometryObject);
           expect(returnedFeature).to.haveOwnProperty('properties');
@@ -66,7 +66,7 @@ describe('Unit test for processed_joined_data.js', () => {
               .to.have.property(
                   'SCORE',
                   Math.round(100 * (0.5 * ((10 + 5) / 27) + 0.5 * (2 / 4))));
-          expect(resultProperties).to.have.property('___DISPLAYED', true);
+          expect(resultProperties).to.have.property('___DISPLAYED', true)
           assertColorAndOpacity(resultProperties, 135);
         });
   });
@@ -81,7 +81,7 @@ describe('Unit test for processed_joined_data.js', () => {
                 })))
         .then(({featuresList}) => {
           expect(featuresList).to.be.an('array');
-          expect(featuresList.length).to.equal(1);
+          expect(featuresList).to.have.length(1);
           const [returnedFeature] = featuresList;
           expect(returnedFeature).to.have.property('geometry', geometryObject);
           expect(returnedFeature).to.haveOwnProperty('properties');

--- a/cypress/integration/unit_tests/score_bounds_map_test.js
+++ b/cypress/integration/unit_tests/score_bounds_map_test.js
@@ -138,7 +138,7 @@ describe('Unit tests for ScoreBoundsMap class', () => {
         () => expect(underTest.map.getBounds().contains({lng: -100, lat: 41}))
                   .to.be.true);
     let zoomedBounds;
-    cy.get('[title="Zoom in"]').click().then(() => {
+    cy.get('#score-bounds-map').type('+').then(() => {
       zoomedBounds = underTest.map.getBounds();
       expect(zoomedBounds.contains({lng: -100, lat: 41})).to.be.false;
       releasePromise();

--- a/docs/click_feature.js
+++ b/docs/click_feature.js
@@ -80,7 +80,7 @@ function createHtmlForPopup(feature, rowData, scoreParameters, columns) {
     properties.appendChild(property);
   } else {
     const property = document.createElement('li');
-    property.innerText = 'SCORE: ' + rowData[2];
+    property.innerText = 'SCORE: ' + rowData[3];
     properties.appendChild(property);
   }
   for (const column of columns) {

--- a/docs/click_feature.js
+++ b/docs/click_feature.js
@@ -1,6 +1,6 @@
 import {showError} from './error.js';
 import {currentFeatures, highlightFeatures} from './highlight_features.js';
-import {geoidTag, scoreTag} from './property_names.js';
+import {displayedTag, geoidTag, scoreTag} from './property_names.js';
 
 export {clickFeature, selectHighlightedFeatures};
 
@@ -52,6 +52,7 @@ function clickFeature(
 }
 
 const HIDDEN_PROPERTIES = Object.freeze(new Set([
+  displayedTag,
   geoidTag,
   scoreTag,
 ]));

--- a/docs/draw_table.js
+++ b/docs/draw_table.js
@@ -1,8 +1,10 @@
 import {showError} from './error.js';
 import {highlightFeatures} from './highlight_features.js';
-import {displayedTag} from './property_names.js';
+import {displayedTag, geoidTag} from './property_names.js';
 
 export {drawTable};
+
+const hiddenColumns = new Set(geoidTag, displayedTag);
 
 /**
  * Displays a ranked table of the given features that have non-zero score. Sets
@@ -34,6 +36,15 @@ async function drawTable(scoredFeaturesAndColumns, map) {
       featuresList.filter((feature) => feature.properties[displayedTag]);
   // Clone headings.
   const list = [columnsFound];
+  const indicesToHide = [];
+  for (const [ind, col] of columnsFound.entries()) {
+    if (hiddenColumns.has(col)) {
+      indicesToHide.push(ind);
+      if (indicesToHide.length == hiddenColumns.length) {
+        break;
+      }
+    }
+  }
   for (const feature of features) {
     list.push(columnsFound.map((col) => feature.properties[col]));
   }
@@ -41,7 +52,7 @@ async function drawTable(scoredFeaturesAndColumns, map) {
   // https://developers.google.com/chart/interactive/docs/basic_load_libs#Callback
   return new Promise(
       (resolve) => google.charts.setOnLoadCallback(
-          () => renderTable(list, features, map, resolve)));
+          () => renderTable(list, indicesToHide, features, map, resolve)));
 }
 
 /**
@@ -49,16 +60,16 @@ async function drawTable(scoredFeaturesAndColumns, map) {
  * highlight features in the map if their rows are clicked on in the table.
  *
  * @param {Array} list The data to display in the chart, with headings
+ * @param {Array} indicesToHide The column indices not to show in the table
  * @param {Array} features The list of features corresponding to that data
  * @param {google.maps.Map} map
  * @param {Function} selectorReceiver receiver for the function inside the
  *     Promise returned by {@link drawTable}
  */
-function renderTable(list, features, map, selectorReceiver) {
+function renderTable(list, indicesToHide, features, map, selectorReceiver) {
   const data = google.visualization.arrayToDataTable(list, false);
   const dataView = new google.visualization.DataView(data);
-  // don't display geoid or displayedTag.
-  dataView.hideColumns([0, 1]);
+  dataView.hideColumns(indicesToHide);
   const table =
       new google.visualization.Table(document.getElementById('table'));
   table.draw(dataView, {

--- a/docs/draw_table.js
+++ b/docs/draw_table.js
@@ -4,7 +4,7 @@ import {displayedTag, geoidTag} from './property_names.js';
 
 export {drawTable};
 
-const hiddenColumns = new Set(geoidTag, displayedTag);
+const hiddenColumns = new Set([geoidTag, displayedTag]);
 
 /**
  * Displays a ranked table of the given features that have non-zero score. Sets
@@ -44,6 +44,10 @@ async function drawTable(scoredFeaturesAndColumns, map) {
         break;
       }
     }
+  }
+  if (indicesToHide.length != hiddenColumns.size) {
+    console.log('Not all hidden columns found: ',
+      hiddenColumns, indicesToHide, columnsFound);
   }
   for (const feature of features) {
     list.push(columnsFound.map((col) => feature.properties[col]));

--- a/docs/draw_table.js
+++ b/docs/draw_table.js
@@ -46,8 +46,9 @@ async function drawTable(scoredFeaturesAndColumns, map) {
     }
   }
   if (indicesToHide.length != hiddenColumns.size) {
-    console.log('Not all hidden columns found: ',
-      hiddenColumns, indicesToHide, columnsFound);
+    console.log(
+        'Not all hidden columns found: ', hiddenColumns, indicesToHide,
+        columnsFound);
   }
   for (const feature of features) {
     list.push(columnsFound.map((col) => feature.properties[col]));

--- a/docs/draw_table.js
+++ b/docs/draw_table.js
@@ -1,6 +1,6 @@
 import {showError} from './error.js';
 import {highlightFeatures} from './highlight_features.js';
-import {scoreTag} from './property_names.js';
+import {displayedTag} from './property_names.js';
 
 export {drawTable};
 
@@ -31,7 +31,7 @@ async function drawTable(scoredFeaturesAndColumns, map) {
   // This may throw an exception, but error reporting handled elsewhere.
   const {featuresList, columnsFound} = await scoredFeaturesAndColumns;
   const features =
-      featuresList.filter((feature) => feature.properties[scoreTag]);
+      featuresList.filter((feature) => feature.properties[displayedTag]);
   // Clone headings.
   const list = [columnsFound];
   for (const feature of features) {
@@ -57,8 +57,8 @@ async function drawTable(scoredFeaturesAndColumns, map) {
 function renderTable(list, features, map, selectorReceiver) {
   const data = google.visualization.arrayToDataTable(list, false);
   const dataView = new google.visualization.DataView(data);
-  // don't display geoid
-  dataView.hideColumns([0]);
+  // don't display geoid or displayedTag.
+  dataView.hideColumns([0, 1]);
   const table =
       new google.visualization.Table(document.getElementById('table'));
   table.draw(dataView, {

--- a/docs/process_joined_data.js
+++ b/docs/process_joined_data.js
@@ -30,7 +30,8 @@ function colorAndRate(
   const povertyRatio = feature.properties[povertyRateKey];
   const ratioBuildingsDamaged = hasDamage ? feature.properties[damageTag] : 0;
   let score = 0;
-  const displayed = povertyRatio >= povertyThreshold && ratioBuildingsDamaged >= damageThreshold;
+  const displayed = povertyRatio >= povertyThreshold &&
+      ratioBuildingsDamaged >= damageThreshold;
   feature.properties[displayedTag] = displayed;
   if (displayed) {
     score = Math.round(
@@ -97,8 +98,10 @@ function processJoinedData(
               },
             ]) => {
         const hasDamage = !!damageAssetPath;
-        const columnsFound = new Set(
-            [geoidTag, displayedTag, districtDescriptionKey, scoreTag, povertyRateKey]);
+        const columnsFound = new Set([
+          geoidTag, displayedTag, districtDescriptionKey, scoreTag,
+          povertyRateKey
+        ]);
         if (hasDamage) {
           columnsFound.add(damageTag);
           columnsFound.add(buildingKey);

--- a/docs/process_joined_data.js
+++ b/docs/process_joined_data.js
@@ -100,7 +100,7 @@ function processJoinedData(
         const hasDamage = !!damageAssetPath;
         const columnsFound = new Set([
           geoidTag, displayedTag, districtDescriptionKey, scoreTag,
-          povertyRateKey
+          povertyRateKey,
         ]);
         if (hasDamage) {
           columnsFound.add(damageTag);

--- a/docs/process_joined_data.js
+++ b/docs/process_joined_data.js
@@ -1,4 +1,4 @@
-import {damageTag, geoidTag, isUserProperty, scoreTag} from './property_names.js';
+import {damageTag, displayedTag, geoidTag, isUserProperty, scoreTag} from './property_names.js';
 
 export {processJoinedData};
 
@@ -30,8 +30,9 @@ function colorAndRate(
   const povertyRatio = feature.properties[povertyRateKey];
   const ratioBuildingsDamaged = hasDamage ? feature.properties[damageTag] : 0;
   let score = 0;
-  if (povertyRatio >= povertyThreshold &&
-      ratioBuildingsDamaged >= damageThreshold) {
+  const displayed = povertyRatio >= povertyThreshold && ratioBuildingsDamaged >= damageThreshold;
+  feature.properties[displayedTag] = displayed;
+  if (displayed) {
     score = Math.round(
         scalingFactor *
         (ratioBuildingsDamaged * (1 - povertyWeight) +
@@ -55,8 +56,8 @@ function colorAndRate(
  * Processes the provided Promise. The returned Promise has the same underlying
  * data as the original Promise. In other words, this method will mutate the
  * underlying data of the original Promise. This is acceptable, because it only
- * adds/overwrites the computed attributes of score and color. We avoid doing a
- * full copy because it would unnecessarily copy a lot of data.
+ * adds/overwrites the computed attributes of score, displayed, and color. We
+ * avoid doing a full copy because it would unnecessarily copy a lot of data.
  *
  * @param {Promise<Array<GeoJsonFeature>>} dataPromise
  * @param {number} scalingFactor multiplies the raw score, it can be
@@ -70,11 +71,11 @@ function colorAndRate(
  *     Array<EeColumn>}>} Resolved scored features, together with all columns
  *     found in features (and the additional {@link scoreTag} and
  *     {@link COLOR_TAG} columns). The first four columns are: {@link geoidTag},
- *     `districtDescriptionKey` from {@link ScoreParameters},
- *     {@link scoreTag}, and then `povertyRateKey` from
- *     {@link ScoreParameters}. If damage is present in the features,
- *     {@link damageTag} is next, followed by `buildingKey` from
- *     {@link ScoreParameters}. If damage is absent, `buildingKey` is last.
+ *     `displayedTag`, `districtDescriptionKey` from {@link ScoreParameters},
+ *     {@link scoreTag}, and then `povertyRateKey` from {@link ScoreParameters}.
+ *     If damage is present in the features, {@link damageTag} is next, followed
+ *     by `buildingKey` from {@link ScoreParameters}. If damage is absent,
+ *     `buildingKey` is last.
  *     Remaining columns are sorted by order encountered in the feature, which
  *     generally means alphabetically, since EarthEngine always sorts them.
  */
@@ -97,7 +98,7 @@ function processJoinedData(
             ]) => {
         const hasDamage = !!damageAssetPath;
         const columnsFound = new Set(
-            [geoidTag, districtDescriptionKey, scoreTag, povertyRateKey]);
+            [geoidTag, displayedTag, districtDescriptionKey, scoreTag, povertyRateKey]);
         if (hasDamage) {
           columnsFound.add(damageTag);
           columnsFound.add(buildingKey);

--- a/docs/process_joined_data.js
+++ b/docs/process_joined_data.js
@@ -99,7 +99,10 @@ function processJoinedData(
             ]) => {
         const hasDamage = !!damageAssetPath;
         const columnsFound = new Set([
-          geoidTag, displayedTag, districtDescriptionKey, scoreTag,
+          geoidTag,
+          displayedTag,
+          districtDescriptionKey,
+          scoreTag,
           povertyRateKey,
         ]);
         if (hasDamage) {

--- a/docs/property_names.js
+++ b/docs/property_names.js
@@ -12,7 +12,8 @@ const damageTag = 'DAMAGE PERCENTAGE';
 // Unique name to avoid clashing with user-given columns, never shown to user.
 const geoidTag = '___GD_GOOGLE_DELPHI_GEOID';
 const scoreTag = 'SCORE';
-// Internal-only column to determine if feature satisfies threshold requirements.
+// Internal-only column to determine if feature satisfies threshold
+// requirements.
 const displayedTag = '___DISPLAYED';
 // TODO(janakr): We need some kind of "totals" tags to enable polygon selection
 //  in the flexible disaster case, but they should probably be optional.

--- a/docs/property_names.js
+++ b/docs/property_names.js
@@ -1,5 +1,6 @@
 export {
   damageTag,
+  displayedTag,
   geoidTag,
   isUserProperty,
   povertyHouseholdsTag,
@@ -11,6 +12,8 @@ const damageTag = 'DAMAGE PERCENTAGE';
 // Unique name to avoid clashing with user-given columns, never shown to user.
 const geoidTag = '___GD_GOOGLE_DELPHI_GEOID';
 const scoreTag = 'SCORE';
+// Internal-only column to determine if feature satisfies threshold requirements.
+const displayedTag = '___DISPLAYED';
 // TODO(janakr): We need some kind of "totals" tags to enable polygon selection
 //  in the flexible disaster case, but they should probably be optional.
 const povertyHouseholdsTag = 'SNAP HOUSEHOLDS';


### PR DESCRIPTION
The table was using zero score to indicate that a block group was filtered out. That's normally true (we set the score to 0 for any filtered-out block group), but if the filtering options are set to include everything, some block groups that have a genuine zero score won't be included.

Also sneak in a fix to score_bounds_map_test since Google Maps changed the "Zoom in" button to not be visible by default.

Fixes #472